### PR TITLE
Named routes

### DIFF
--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -34,13 +34,13 @@ class ShopifyAppGenerator < Rails::Generators::Base
   
   def add_routes
     unless options[:skip_routes]
-      route "match 'login/logout'       => 'login#logout'"
-      route "match 'login/finalize'     => 'login#finalize'"
-      route "match 'login/authenticate' => 'login#authenticate'"
-      route "match 'login'              => 'login#index'"
+      route "root :to                   => 'home#index'"
+      route "match 'login/logout'       => 'login#logout',       :as => :logout"
+      route "match 'login/finalize'     => 'login#finalize',     :as => :finalize"
+      route "match 'login/authenticate' => 'login#authenticate', :as => :authenticate"
+      route "match 'login'              => 'login#index',        :as => :login"
       route "match 'design'             => 'home#design'"
       route "match 'welcome'            => 'home#welcome'"
-      route "root :to                   => 'home#index'"
     end
   end
   

--- a/lib/generators/shopify_app/templates/app/controllers/login_controller.rb
+++ b/lib/generators/shopify_app/templates/app/controllers/login_controller.rb
@@ -4,7 +4,7 @@ class LoginController < ApplicationController
     
     # If the #{shop}.myshopify.com address is already provided in the URL, just skip to #authenticate
     if params[:shop].present?
-      redirect_to :controller => 'login', :action => "authenticate", :shop => params[:shop]
+      redirect_to authenticate_path(:shop => params[:shop])
     end
   end
 

--- a/lib/generators/shopify_app/templates/app/views/layouts/application.html.erb
+++ b/lib/generators/shopify_app/templates/app/views/layouts/application.html.erb
@@ -14,15 +14,15 @@
     <p id="login-link">
       <% if current_shop %>
           <span class="note">current shop</span> <%= link_to current_shop.url, "https://#{current_shop.url}", :class => 'shop_name' %> <span class="note">|</span>
-          <%= link_to 'logout', :controller => "login", :action => 'logout' %>
+          <%= link_to 'logout', logout_path %>
       <% end %>
     </p>
   </div>
 
   <div id="container" class="clearfix">
     <ul id="tabs">
-      <%= tab :index, {:controller => 'home'}, :label => 'Home' %>
-      <%= tab :design, {:controller => 'home', :action => 'design'}, :label => 'Design Help' %>
+      <%= tab :index, {:controller => '/home'}, :label => 'Home' %>
+      <%= tab :design, {:controller => '/home', :action => 'design'}, :label => 'Design Help' %>
     </ul>
     
     <!-- Flash error & notice-->

--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -10,7 +10,7 @@ module ShopifyApp::LoginProtection
       end
     else
       session[:return_to] = request.fullpath
-      redirect_to :controller => 'login'
+      redirect_to login_path
     end
   end
   


### PR DESCRIPTION
shopify_app should generate and use named routes: it's nicer and makes namespaced controllers in your shopify app work (otherwise ShopifyApp::LoginProtection.shopify_session tries to redirect to namespace::login_controller if it's called from a namespaced controller).
