### PR TITLE
Tab Helper Controller Name Checking

### DIFF
--- a/lib/generators/shopify_app/templates/app/helpers/tabs_helper.rb
+++ b/lib/generators/shopify_app/templates/app/helpers/tabs_helper.rb
@@ -1,7 +1,7 @@
 module TabsHelper
   # Create a tab as <li> and give it the id "current" if the current action matches that tab
   def tab(name, url, options = {})
-    if controller.action_name =~ (options[:highlight] = /#{name}/i)
+    if controller.action_name =~ (options[:highlight] = /#{name}/i)  && controller.controller_name == url[:controller]
       content_tag :li, link_to(options[:label] || name.to_s.capitalize, url, {:id => "current"})
     else
       content_tag :li, link_to(options[:label] || name.to_s.capitalize, url)


### PR DESCRIPTION
Added controller name checking for ensuring controllers containing the same action that are added as tabs do not get highlighted all at once.

For example

tab ( :index, { :controller => 'home', :action => 'index' }, :label => 'Home' )

and 

tab ( :index, { :controller => 'test', :action => 'index' }, :label => 'Home' )

used to highlight both when on either page. Now it will check the controller name and only highlight the actual current tab.
