### PR TITLE
shopify_app_buttons.css.less

### DIFF
--- a/lib/generators/shopify_app/templates/app/assets/stylesheets/shopify_app_buttons.css.less
+++ b/lib/generators/shopify_app/templates/app/assets/stylesheets/shopify_app_buttons.css.less
@@ -57,7 +57,7 @@
 // Set the backgrounds
 // -------------------------
 .btn-primary {
-  .buttonBackground(@primaryButtonBackground, spin(@primaryButtonBackground, 20));
+  .buttonBackground(@shopifyBtnBackground, spin(@shopifyBtnBackground, 20));
 }
 // Warning appears are orange
 .btn-warning {


### PR DESCRIPTION
Running shopify_app on a fresh Rails 3.2.2 application and starting it raises a Less::ParseError exception in Login#index related to `@primaryButtonBackground` being undefined

Error is on Line 60, replaced both instances of primaryButtonBackground with shopifyBtnBackground

http://dl.dropbox.com/u/65594897/Screen%20Shot%202012-03-26%20at%2011.25.33%20AM.png

@redronin @warrendunlop
