### PR TITLE
refactored the login_controller and a route

### DIFF
--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -43,7 +43,6 @@ class ShopifyAppGenerator < Rails::Generators::Base
       route "root :to                   => 'home#index'"
       route "match 'login/logout'       => 'login#logout',       :as => :logout"
       route "match 'login/finalize'     => 'login#finalize',     :as => :finalize"
-      route "match 'login/authenticate' => 'login#authenticate', :as => :authenticate"
       route "match 'login'              => 'login#index',        :as => :login"
       route "match 'design'             => 'home#design'"
       route "match 'welcome'            => 'home#welcome'"

--- a/lib/generators/shopify_app/templates/app/controllers/login_controller.rb
+++ b/lib/generators/shopify_app/templates/app/controllers/login_controller.rb
@@ -4,15 +4,7 @@ class LoginController < ApplicationController
     
     # If the #{shop}.myshopify.com address is already provided in the URL, just skip to #authenticate
     if params[:shop].present?
-      redirect_to authenticate_path(:shop => params[:shop])
-    end
-  end
-
-  def authenticate
-    if params[:shop].present?
       redirect_to "/auth/shopify?shop=#{params[:shop].to_s.strip}"
-    else
-      redirect_to return_address
     end
   end
   

--- a/lib/generators/shopify_app/templates/app/views/login/index.html.erb
+++ b/lib/generators/shopify_app/templates/app/views/login/index.html.erb
@@ -4,7 +4,7 @@
 </div>
 
 <div style="width:340px; margin:0 auto;">
-  <%= form_tag '/login/authenticate', :class => 'form-search' do %>
+  <%= form_tag '/login', :class => 'form-search' do %>
     <%= text_field_tag 'shop', nil, :placeholder => 'Shop URL', :class => 'btn-large' %>
     <%= submit_tag 'Install', :class => 'btn btn-primary btn-large' %>
   <% end %>


### PR DESCRIPTION
LoginController#authenticate is repetitive and has been refactored into index.

Something that is still troubling: If the user mistypes their store name then LoginController#index will redirect them to a bad domain. A potential solution is to send an http request and check for a response before redirecting the user there, but this adds complexity that is probably not worth it, ie. require net/http and some control in LoginController#index, so I will not be pursuing it further.

@rziehl, @davefp 
