### PR TITLE
Updated readme with correct auth example for default app set-up

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,7 +65,7 @@ Make this change to request write access to products and read access to orders:
 
 (Note that you can change your API permission scopes on the fly, but the merchant will have to approve each change and your computed API password will change.)
 
-You may need to create this file if it doesn't exist, and add a reference to the omniauth-shopify-oauth2 gem to you Gemfile.
+You may need to create this file if it doesn't exist, and add a reference to the omniauth-shopify-oauth2 gem to you <tt>Gemfile</tt>.
 
 == After running the generator
 


### PR DESCRIPTION
Updates to readme to correct pull #19 example to work with default app set up. Also, added clarification about including oauth2 gem.

@edward @rziehl 
