### PR TITLE
Handle UnauthorizedAccess if app is uninstalled

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -1,4 +1,10 @@
 module ShopifyApp::LoginProtection
+  extend ActiveSupport::Concern
+  
+  included do
+    rescue_from ActiveResource::UnauthorizedAccess, with: :close_session
+  end
+  
   def shopify_session
     if session[:shopify]
       begin
@@ -16,5 +22,12 @@ module ShopifyApp::LoginProtection
   
   def shop_session
     session[:shopify]
+  end
+  
+  protected
+  
+  def close_session
+    session[:shopify] = nil
+    redirect_to login_path
   end
 end

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end


### PR DESCRIPTION
If a shop owner uninstalls the app and later visits the app home page again (to reinstall it for example), it throws a 401. It's because the shop is still in the session with its old token. It leaves the shop owner with no option other than resetting browser cookies or manually visiting `/login/logout` path for the app.

This just handles the `ActiveResource::UnauthorizedAccess` and takes the user to the app's `root_path` as expected. Already tested it on my app.

@edward this seems fine?
