### PR TITLE
Updates auth response credential lookup to string key

### DIFF
--- a/lib/generators/shopify_app/templates/app/controllers/sessions_controller.rb
+++ b/lib/generators/shopify_app/templates/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
   
   def show
     if response = request.env['omniauth.auth']
-      sess = ShopifyAPI::Session.new(params[:shop], response[:credentials][:token])
+      sess = ShopifyAPI::Session.new(params[:shop], response['credentials']['token'])
       session[:shopify] = sess        
       flash[:notice] = "Logged in"
       redirect_to return_address


### PR DESCRIPTION
Auth response should use string key for credentials lookup. request.env['omniauth.auth'] does not return an indifferent access hash, it returns a hash with string keys. Test confirms this.

@gauravmc @edward Please review, thanks!
