### PR TITLE
Explicitly set read permissions for products and orders

### DIFF
--- a/lib/generators/shopify_app/templates/config/initializers/omniauth.rb
+++ b/lib/generators/shopify_app/templates/config/initializers/omniauth.rb
@@ -5,7 +5,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
            # Example permission scopes - see http://api.shopify.com/authentication.html for full listing
            # :scope => 'read_orders, write_products',
-
+           :scope => 'read_orders, read_products',
            :setup => lambda {|env| 
                        params = Rack::Utils.parse_query(env['QUERY_STRING'])
                        site_url = "https://#{params['shop']}"


### PR DESCRIPTION
I tried using the shopify_app gem today and found that by default, we only have read permissions for products, however the Home controller index action tries to grab both orders and products.

This caused a 403 error.

This PR sets the api permissions to be able to read both orders and products, so the basic experience doesn't cause an error.

@edward @jnormore can you pull and update gem?
