### PR TITLE
Added less-rails-bootstrap dependency

### DIFF
--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rails', '~> 3.1')
   s.add_runtime_dependency('shopify_api', '~> 3.0.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '1.1.0')
+  s.add_runtime_dependency('less-rails-bootstrap', '>0')
   
   s.add_development_dependency('rake')
 


### PR DESCRIPTION
I just tried installing shopify_app on a clean Rails app & RVM gemset. When I ran the generator I got this error:

```
/Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/resolver.rb:287:in `resolve': Could not find gem 'less-rails-bootstrap (>= 0) ruby' in the gems available on this machine. (Bundler::GemNotFound)
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/resolver.rb:161:in `start'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/resolver.rb:128:in `block in resolve'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/resolver.rb:127:in `catch'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/resolver.rb:127:in `resolve'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/definition.rb:178:in `resolve'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/definition.rb:113:in `specs'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/definition.rb:158:in `specs_for'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/definition.rb:147:in `requested_specs'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/environment.rb:23:in `requested_specs'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/runtime.rb:11:in `setup'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler.rb:116:in `setup'
    from /Users/craig/.rvm/gems/ruby-1.9.2-p0@global/gems/bundler-1.2.2/lib/bundler/setup.rb:17:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
```

This PR adds `less-rails-bootstrap` as a gemspec dependency.
