### PR TITLE
Revert "Bump omniauth-shopify-oauth2"

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "4.1.1"
+  VERSION = "4.1.0"
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('rails', '~> 3.1')
   s.add_runtime_dependency('shopify_api', '~> 3.0.0')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '1.1.0')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '1.0.0')
   
   s.add_development_dependency('rake')
 


### PR DESCRIPTION
While trying to install shopify_app to get my changes for [my pull request #40](https://github.com/Shopify/shopify_app/pull/40) working, I got bundler errors saying that omniauth-shopify-oauth2 v1.1.0 wasn't available. I didn't see any v1.1 branch in https://github.com/Shopify/omniauth-shopify-oauth2, nor did I see a "stable" branch in shopify_app, so I created this rollback branch/commit.

Then I merged this branch and my [add-less-rails-bootstrap branch](https://github.com/softcraft-development/shopify_app/tree/add-less-rails-bootstrap) into [no-omniauth-bump-plus-less-rails-bootstrap](https://github.com/softcraft-development/shopify_app/tree/no-omniauth-bump-plus-less-rails-bootstrap). When I used _this_ repo/branch, I was able to run the shopify_app generator on a clean Rails 3.2 install without error.

I'm guessing that you're rolling omniauth-shopify-oauth2 forward internally and just haven't pushed the changes yet. If that's the case, then you probably would _not_ want to actually merge this PR... and instead make v1.1 available. But as it stands right now, the master branch of shopify_app is broken.
