### PR TITLE
Generate application controller with commented-out method for re-requesting authorization

### DIFF
--- a/lib/generators/shopify_app/templates/app/controllers/application_controller.rb
+++ b/lib/generators/shopify_app/templates/app/controllers/application_controller.rb
@@ -1,0 +1,10 @@
+class ApplicationController < ActionController::Base
+  protect_from_forgery
+  
+  # Ask shop to authorize app again if additional permissions are required
+  # rescue_from ActiveResource::ForbiddenAccess do
+  #   session[:shopify] = nil
+  #   flash[:notice] = "This app requires additional permissions, please log in and authorize it."
+  #   redirect_to controller: :sessions, action: :create
+  # end
+end


### PR DESCRIPTION
@jeromecornet for review

Added a commented-out call to rescue_from that avoids an exception if the app requires additional permissions. Nulls session and sends to login page.
