### PR TITLE
Use http on development env

### DIFF
--- a/lib/generators/shopify_app/templates/config/initializers/omniauth.rb
+++ b/lib/generators/shopify_app/templates/config/initializers/omniauth.rb
@@ -8,7 +8,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
            :setup => lambda {|env| 
                        params = Rack::Utils.parse_query(env['QUERY_STRING'])
-                       site_url = "https://#{params['shop']}"
+                       site_url = "#{ Rails.env.development? ? 'http' : 'https' }://#{params['shop']}"
                        env['omniauth.strategy'].options[:client_options][:site] = site_url
                      }
 end


### PR DESCRIPTION
@jeromecornet @alexcoco 

When developing embedded apps we need to get shopify running locally. This means that auth will be looking at localhost and we are not using `https`. 
