### PR TITLE
Multiple config sources

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,13 @@
-require 'bundler'
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
 Bundler::GemHelper.install_tasks
+
+Rake::TestTask.new do |t|
+  t.libs << 'lib/shopify_app'
+  t.libs << 'test'
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+end
+
+task :default => :test

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -3,7 +3,7 @@ class ShopifyApp::Configuration
   attr_writer *VALID_KEYS
   
   def initialize
-    @config_file = YAML.load_file(File.join(Rails.root, 'config', 'shopify_app.yml')) || {}
+    @config_file = load_config 
   end
   
   VALID_KEYS.each do |meth|
@@ -15,6 +15,10 @@ class ShopifyApp::Configuration
   
   private
   
+  def self.load_config
+    YAML.load_file(File.join(Rails.root, 'config', 'shopify_app.yml')) || {}
+  end
+  
   def config_from_env(meth)
     ENV["SHOPIFY_APP_#{meth.upcase}"]
   end
@@ -24,6 +28,6 @@ class ShopifyApp::Configuration
   end
   
   def config_from_file(meth)
-    @config_file[Rails.env.to_s].try(:[], meth) || @config_file['common'].try(:[], meth)
+    @config_file[Rails.env].try(:[], meth) || @config_file['common'].try(:[], meth)
   end
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('less-rails-bootstrap', '>0')
   
   s.add_development_dependency('rake')
+  s.add_development_dependency('minitest')
+  s.add_development_dependency('mocha')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/test/lib/shopify_app/configuration_test.rb
+++ b/test/lib/shopify_app/configuration_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class ConfigurationTest < MiniTest::Unit::TestCase
+  def setup
+    Rails.stubs(:env).returns('development')
+    ShopifyApp::Configuration.any_instance.stubs(:load_config).returns({})
+    @config = ShopifyApp::Configuration.new
+    
+    @common_config_data = {
+      'common' => {
+        'api_key' => 'common key',
+        'secret' => 'common secret'
+      }
+    }
+    
+    @development_config_data = @common_config_data.merge({
+      'development' => {
+        'api_key' => 'development key',
+        'secret' => 'development secret'
+      }
+    })
+  end
+  
+  def test_define_method_creates_readers
+    config_instance_methods = ShopifyApp::Configuration.instance_methods(false)
+    ShopifyApp::Configuration::VALID_KEYS.each do |key|
+      assert config_instance_methods.include? key
+    end
+  end
+  
+  def test_defaults_to_empty_string
+    assert_equal '', @config.api_key
+    assert_equal '', @config.secret
+  end
+  
+  def test_environment_has_precedence_over_common
+    ShopifyApp::Configuration.any_instance.stubs(:load_config).returns(@common_config_data)
+    @config = ShopifyApp::Configuration.new
+    
+    assert_equal 'common key', @config.api_key
+    assert_equal 'common secret', @config.secret
+    
+    ShopifyApp::Configuration.any_instance.stubs(:load_config).returns(@development_config_data)
+    @config = ShopifyApp::Configuration.new
+    
+    assert_equal 'development key', @config.api_key
+    assert_equal 'development secret', @config.secret
+  end
+  
+  def test_rails_has_precedence_over_environment
+    ShopifyApp::Configuration.any_instance.stubs(:load_config).returns(@development_config_data)
+    @config = ShopifyApp::Configuration.new
+    
+    assert_equal 'development key', @config.api_key
+    assert_equal 'development secret', @config.secret
+    
+    @config.instance_variable_set '@api_key', 'rails key'
+    @config.instance_variable_set '@secret', 'rails secret'
+    
+    assert_equal 'rails key', @config.api_key
+    assert_equal 'rails secret', @config.secret
+  end
+  
+  def test_env_has_precedence_over_rails
+    @config.instance_variable_set '@api_key', 'rails key'
+    @config.instance_variable_set '@secret', 'rails secret'
+    
+    assert_equal 'rails key', @config.api_key
+    assert_equal 'rails secret', @config.secret
+    
+    ENV.expects(:[]).with('SHOPIFY_APP_API_KEY').returns('env key')
+    ENV.expects(:[]).with('SHOPIFY_APP_SECRET').returns('env secret')
+    
+    assert_equal 'env key', @config.api_key
+    assert_equal 'env secret', @config.secret
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,5 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/setup'
+
+require File.expand_path('../../lib/shopify_app.rb', __FILE__)


### PR DESCRIPTION
@kmcphillips @christopherlobay 

ShopifyApp::Configuration works the same way it did before except for a few differences:
- Multiple configuration sources
- New order of precedence:
  1. ENV variable
  2. Configuration set in a Rails `<environment>.rb` config file
  3. Configuration loaded from `<environment>` key in `shopify_app.yml`
  4. Configuration loaded from `common` key in `shopify_app.yml`
  5. Defaults to empty string

Seemed simpler to do it this way instead of involving another gem. There's some magic but it's literally all there instead of in some gem.

/cc @jeromecornet 
