### PR TITLE
Don't write to config if args not present

### DIFF
--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -21,15 +21,13 @@ class ShopifyAppGenerator < Rails::Generators::Base
   end
   
   def add_config_variables
-    api_key_str = api_key.nil? ? "ENV['SHOPIFY_API_KEY']" : api_key.inspect
-    api_secret_str = secret.nil? ? "ENV['SHOPIFY_API_SECRET']" : secret.inspect
+    return if api_key.blank? || secret.blank?
     
     inject_into_file 'config/application.rb', <<-DATA, :after => "class Application < Rails::Application\n"
     
     # Shopify API connection credentials:
-    config.shopify.api_key = #{api_key_str}
-    config.shopify.secret = #{api_secret_str}
-    
+    config.shopify.api_key = '#{api_key}'
+    config.shopify.secret = '#{secret}'
     DATA
   end
 


### PR DESCRIPTION
@peterjm @kmcphillips 

The new configuration class reads from ENV if it's available so we don't need to default the missing api_key/secret to the ENV variable in the config file.
