### PR TITLE
Change Railtie callback to before_initialize

### DIFF
--- a/lib/shopify_app/railtie.rb
+++ b/lib/shopify_app/railtie.rb
@@ -2,7 +2,7 @@ require 'rails'
 
 class ShopifyApp::Railtie < ::Rails::Railtie
 
-  config.before_configuration do
+  config.before_initialize do
     config.shopify = ShopifyApp.configuration
   end
   


### PR DESCRIPTION
As mentioned in #70, in Rails 4.1.0.beta1 (and earlier versions?) `Rails.root` is `nil` in `before_configuration`. Changing it to `before_initialize` works nicely.
