### PR TITLE
Fix for myshopify.com check

### DIFF
--- a/lib/generators/shopify_app/templates/app/controllers/sessions_controller.rb
+++ b/lib/generators/shopify_app/templates/app/controllers/sessions_controller.rb
@@ -47,6 +47,6 @@ class SessionsController < ApplicationController
     name.gsub!('https://', '').sub('http://', '')
 
     u = URI("http://#{name}")
-    u.host.ends_with?("myshopify.com") ? u.host : nil
+    u.host.ends_with?(".myshopify.com") ? u.host : nil
   end
 end


### PR DESCRIPTION
@jeromecornet 

Ensures that domains end with `.myshopify.com` to prevent `evilmyshopify.com` redirects. 
