### PR TITLE
Fixed protocol stripping, since gsub! returns nil if no change

### DIFF
--- a/lib/generators/shopify_app/templates/app/controllers/sessions_controller.rb
+++ b/lib/generators/shopify_app/templates/app/controllers/sessions_controller.rb
@@ -44,7 +44,7 @@ class SessionsController < ApplicationController
     return unless params[:shop].present?
     name = params[:shop].to_s.strip
     name += '.myshopify.com' if !name.include?("myshopify.com") && !name.include?(".")
-    name.gsub!('https://', '').sub('http://', '')
+    name.sub!(%r|https?://|, '')
 
     u = URI("http://#{name}")
     u.host.ends_with?(".myshopify.com") ? u.host : nil


### PR DESCRIPTION
Fixes issue #82. `String#gsub!` returns nil if there's no pattern found, so the previous chaining didn't work.
