### PR TITLE
Bumping version of omniauth-shopify-oauth2 and project

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "4.4.2"
+  VERSION = "4.4.3"
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('rails', '>= 3.1', '< 5.0')
   s.add_runtime_dependency('shopify_api', '~> 3.2.0')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.3')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.4')
   s.add_runtime_dependency('less-rails-bootstrap', '~> 2.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
https://github.com/Shopify/omniauth-shopify-oauth2/pull/15
https://github.com/Shopify/omniauth-shopify-oauth2/pull/16

Just updated the version of the `omniauth-shopify-oauth2` repo. Bumping the version here to match it.
