### PR TITLE
Fix `bundle install` to execute properly during generator run.

### DIFF
--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -53,7 +53,10 @@ class ShopifyAppGenerator < Rails::Generators::Base
   end
   
   def display_readme
-    `bundle install`
+    Bundler.with_clean_env do
+      run 'bundle install'
+    end
+
     readme '../README'
   end
   


### PR DESCRIPTION
@jeromecornet @celsodantas for review

Without this, the `bundle install` that's run by the generator wouldn't actually be executed correctly. See https://github.com/rails/rails/issues/3153 for details.

Steps to reproduce:
- `gem uninstall therubyracer`
- `rails new test_app`
- `cd test_app`
- `echo "gem 'shopify_app'" >> Gemfile`
- `bundle install`
- `rails g shopify_app my-key my-secret`

This is what happens:

```
...
     gemfile  less-rails-bootstrap
     gemfile  therubyracer
      append  Gemfile
       route  end
       route  get 'design' => 'home#design'
/home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/resolver.rb:302:in `resolve': Could not find gem 'therubyracer (>= 0) ruby' in the gems available on this machine. (Bundler::GemNotFound)
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/resolver.rb:172:in `start'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/resolver.rb:133:in `block in resolve'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/safe_catch.rb:32:in `catch'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/safe_catch.rb:32:in `safe_catch'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/resolver.rb:132:in `resolve'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/definition.rb:203:in `resolve'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/definition.rb:133:in `specs'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/definition.rb:178:in `specs_for'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/definition.rb:167:in `requested_specs'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/environment.rb:18:in `requested_specs'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/runtime.rb:13:in `setup'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler.rb:119:in `setup'
    from /home/vagrant/.gem/ruby/2.1.1/gems/bundler-1.5.3/lib/bundler/setup.rb:17:in `<top (required)>'
    from /home/vagrant/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /home/vagrant/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'


What's next?
------------

Make sure to set the Application URL of the application in your Shopify partner account
to <tt>http://localhost:3000/login</tt>.
...
```
