### PR TITLE
Fix up session initializer documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ class Shop < ActiveRecord::Base
     shop.id
   end
 
-  def retrieve(id)
+  def self.retrieve(id)
+    return nil if id.blank?
     shop = Shop.find(id)
     ShopifyAPI::Session.new(shop.domain, shop.token)
   end

--- a/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
+++ b/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
@@ -13,6 +13,7 @@
 #   end
 #
 #   def self.retrieve(id)
+#     return nil if id.blank?
 #     shop = Shop.find(id)
 #     ShopifyAPI::Session.new(shop.domain, shop.token)
 #   end


### PR DESCRIPTION
The example session code doesn't work, it errors with the following when you try to log in from the app's root:

ActiveRecord::RecordNotFound (Couldn't find Shop without an ID):
app/models/shop.rb:10:in `retrieve'

I fixed it up to return nil if id is blank.

Additionally, the example code in the README didn't have the self. update from the last doc update.

Russell.
