### PR TITLE
Fix example session storage model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class Shop < ActiveRecord::Base
     shop.id
   end
 
-  def retrieve(id)
+  def self.retrieve(id)
     shop = Shop.find(id)
     ShopifyAPI::Session.new(shop.domain, shop.token)
   end


### PR DESCRIPTION
Christopher fixed it in config/initializers/shopify_session_repository.rb in b560395fee112a9f4b0cb6512e027564015cab14 but not here :)
