### PR TITLE
Silently return nil for session when client supplies unknown session id

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ class Shop < ActiveRecord::Base
   end
 
   def self.retrieve(id)
-    shop = Shop.find(id)
-    ShopifyAPI::Session.new(shop.domain, shop.token)
+    if shop = Shop.where(id: id).first
+      ShopifyAPI::Session.new(shop.domain, shop.token)
+    end
   end
 end
 ```

--- a/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
+++ b/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
@@ -13,8 +13,9 @@
 #   end
 #
 #   def self.retrieve(id)
-#     shop = Shop.find(id)
-#     ShopifyAPI::Session.new(shop.domain, shop.token)
+#     if shop = Shop.where(id: id).first
+#       ShopifyAPI::Session.new(shop.domain, shop.token)
+#     end
 #   end
 # end
 


### PR DESCRIPTION
When using ActiveRecord for session storage, it raises `ActiveRecord::RecordNotFound` for nonexistent session ids. Gotta handle that.
