### PR TITLE
Replacing the obsolete links

### DIFF
--- a/lib/generators/shopify_app/templates/app/views/home/index.html.erb
+++ b/lib/generators/shopify_app/templates/app/views/home/index.html.erb
@@ -49,11 +49,11 @@
   
     <h3>Once you're ready</h3>
   
-    <p>We'd love to see what you create using the Shopify API. You can keep up to date on the latest and greatest via the <%= link_to 'Shopify API Twitter Account', 'http://www.twitter.com/shopifyapi' %>. You can also read the latest information on the <%= link_to 'API Publishing Page', 'http://www.shopify.com/developers/publishing/' %>.</p>
+    <p>We'd love to see what you create using the Shopify API. You can keep up to date on the latest and greatest via the <%= link_to 'Shopify Developers Twitter Account', 'https://twitter.com/shopifydevs' %>. You can also read the latest information on the <%= link_to 'Building a Shopify App', 'http://docs.shopify.com/partners/partner-resources/for-partners/building-a-shopify-app' %>.</p>
     
     <br/>
     
-    <a href="https://twitter.com/shopifyapi" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @shopifyapi</a>
+    <a href="https://twitter.com/shopifydevs" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @ShopifyDevs</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div> <!-- span3 / left-column -->
 


### PR DESCRIPTION
Using the Webarchive, I found that the new location for "http://www.shopify.com/developers/publishing" is "http://docs.shopify.com/partners/partner-resources/for-partners/building-a-shopify-app"
Also, the twitter account of https://twitter.com/shopifyapi is moved to https://twitter.com/shopifydevs
