### PR TITLE
Fix display when there are no products / orders

### DIFF
--- a/lib/generators/shopify_app/templates/app/views/home/index.html.erb
+++ b/lib/generators/shopify_app/templates/app/views/home/index.html.erb
@@ -11,21 +11,21 @@
 
 <div class="row">
   <div class="span3">
-    <div class="well">  
+    <div class="well">
       <h3>Check out the <code>home_controller</code></h3>
       <hr style="margin:2px 0 7px"/>
       <p>The controller in this demo application fetches the newest 5 orders and products and makes them available as instance variables <code>@orders</code> and <code>@products</code></p>
-    
+
       <br/>
-    
+
       <h3>Take a look at <code>index.html.erb</code></h3>
       <hr style="margin:2px 0 7px"/>
       <p>Index is the Ruby template you are currently viewing. Have a look at the markup and Ruby code to see how the Shopify API is being used. It's located at <code>views/home/index.html.erb</code></p>
     </div>
-    
+
     <h3>Additional Docs</h3>
     <p>You can become an expert pretty quickly by reading up on these docs:</p>
-    
+
     <ul>
       <li>
         <%= link_to 'API documentation', 'http://docs.shopify.com/api' %>
@@ -44,15 +44,15 @@
         <span class="note">Ask questions and see what others already wanted to know</span>
       </li>
     </ul>
-  
+
     <hr/>
-  
+
     <h3>Once you're ready</h3>
-  
+
     <p>We'd love to see what you create using the Shopify API. You can keep up to date on the latest and greatest via the <%= link_to 'Shopify Developers Twitter Account', 'https://twitter.com/shopifydevs' %>. You can also read the latest information on the <%= link_to 'Building a Shopify App', 'http://docs.shopify.com/partners/partner-resources/for-partners/building-a-shopify-app' %>.</p>
-    
+
     <br/>
-    
+
     <a href="https://twitter.com/shopifydevs" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @ShopifyDevs</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div> <!-- span3 / left-column -->
@@ -60,16 +60,16 @@
 
   <div class="span8 offset1">
     <h2>Recent orders</h2>
-  
-    <% if @orders.blank? %>
+
+    <% if @orders.none? %>
       <table class="table table-striped">
         <tr>
           <td><em>There are no orders in your store.</em></td>
         </tr>
       </table>
-    
+
     <% else %>
-  
+
       <table class="table table-striped">
         <thead>
           <tr>
@@ -99,43 +99,43 @@
         </tr>
       <% end %>
       </table>
-      
+
     <% end %>
-    
+
     <br/>
-    
+
     <h2>New Products</h2>
-    
-    <div class="accordion" id="accordion">      
-      
-      <% if @products.blank? %>
-      
+
+    <div class="accordion" id="accordion">
+
+      <% if @products.none? %>
+
         <div class="accordion-group">
           <div class="accordion-heading">
             <em>There are no products in your store.</em>
           </div>
         </div>
-      
+
       <% else %>
-      
+
         <%  @products.each_with_index do |product, index| %>
           <div class="accordion-group">
             <div class="accordion-heading">
-              
+
               <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#<%= product.id %>">
                 <%= product.title %> <span class="pull-right muted"><%= product.price_range %> <%= shop_session.shop.currency %></span>
               </a>
             </div>
-        
+
             <div id="<%= product.id %>" class="accordion-body collapse <% if index == 1 %>in<% end %>">
               <div class="accordion-inner">
-                
+
                 <% if !product.images.empty? %>
                   <div class="polaroid">
                     <%= link_to image_tag(product.images.first.medium), '#modal-'+product.id.to_s, :'data-toggle' => 'modal' %>
                   </div>
                 <% end %>
-                
+
                 <p><strong>Type:</strong> <%= product.product_type %></p>
                 <p><strong>Vendor:</strong> <%= product.vendor %></p>
                 <p><%= raw(product.body_html) %></p><br/>
@@ -144,10 +144,10 @@
                 <% end %>
                 <p><%= link_to raw('View in your Shopify Admin <i class="icon-chevron-right" style="opacity:.25"></i>'), "https://#{shop_session.url}/admin/products/#{product.id}", :target => 'blank', :class => 'btn btn-primary' %></p>
               </div>
-              
+
             </div>
           </div>
-          
+
           <div class="modal hide fade" id="modal-<%= product.id %>" style="display:none;">
             <div class="modal-header">
               <a class="close" data-dismiss="modal">×</a>
@@ -160,9 +160,9 @@
             </div>
           </div>
         <% end %>
-      
+
       <% end %>
-      
+
     </div> <!-- accordion -->
   </div> <!-- span8 / right-column -->
 </div>


### PR DESCRIPTION
Changing `.blank?` to `.none?` so that the proper table shows on the default index page when there are no products or no orders.

Changes this : 

![](http://snapify.shopify.com/Shopify_Demo_App_2015-01-08_18-26-35_2015-01-08_18-26-36.jpg)

... to this : 

![](http://snapify.shopify.com/Shopify_Demo_App_2015-01-08_18-28-43_2015-01-08_18-28-44.jpg)

@jamesmacaulay @silverstreaked 