### PR TITLE
Fix typo in the ShopifySessionRepository.store example

### DIFF
--- a/index.md
+++ b/index.md
@@ -82,7 +82,7 @@ Your ActiveRecord model would look something like this:
         shop.id
       end
 
-      def retrieve(id)
+      def self.retrieve(id)
         shop = Shop.find(id)
         ShopifyAPI::Session.new(shop.domain, shop.token)
       end


### PR DESCRIPTION
There was a typo in the ShopifySessionRepository.store example on the
Github pages. The same typo used to exist in the Readme but was fixed in
83fdda7.