### PR TITLE
Update shopify_session_repository.rb instructions

### DIFF
--- a/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
+++ b/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
@@ -1,8 +1,9 @@
 # You should replace InMemorySessionStore with what you will be using
-# in Production
+# in Production. For example a model called "Shop":
+#
+# ShopifySessionRepository.storage = 'Shop'
 #
 # Interface to implement are self.retrieve(id) and self.store(ShopifyAPI::Session)
-#
 # Here is how you would add these functions to an ActiveRecord:
 #
 # class Shop < ActiveRecord::Base


### PR DESCRIPTION
I got stuck at this part because I implemented the (old) ``ShopifySessionRepository.storage = Shop`` instead of ``ShopifySessionRepository.storage = 'Shop'`` that fixed #103 in #112.

Thought this might help some other people too.