### PR TITLE
Allow override myshopify_domain from shopify_app.yml

### DIFF
--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -1,5 +1,5 @@
 class ShopifyApp::Configuration
-  VALID_KEYS = [:api_key, :secret]
+  VALID_KEYS = [:api_key, :secret, :myshopify_domain]
   attr_writer *VALID_KEYS
 
   def initialize(params={})

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "5.0.1"
+  VERSION = "5.0.2"
 end

--- a/test/config/development_config_file.yml
+++ b/test/config/development_config_file.yml
@@ -5,3 +5,4 @@ common:
 development:
   api_key: development key
   secret: development secret
+  myshopify_domain: myshopify.com

--- a/test/config/other_config_file.yml
+++ b/test/config/other_config_file.yml
@@ -1,3 +1,4 @@
 common:
   api_key: api key from other file
   secret: secret from other file
+  myshopify_domain: example.com

--- a/test/config/shopify_app.yml
+++ b/test/config/shopify_app.yml
@@ -1,3 +1,4 @@
 common:
   api_key: api key from default file
   secret: secret from default file
+  myshopify_domain: myshopify.com

--- a/test/lib/shopify_app/configuration_test.rb
+++ b/test/lib/shopify_app/configuration_test.rb
@@ -14,6 +14,7 @@ class ConfigurationTest < Minitest::Test
     config = ShopifyApp::Configuration.new
     config.respond_to?(:api_key)
     config.respond_to?(:secret)
+    config.respond_to?(:myshopify_domain)
   end
 
   def test_defaults_to_empty_string
@@ -21,6 +22,7 @@ class ConfigurationTest < Minitest::Test
 
     assert_equal '', config.api_key
     assert_equal '', config.secret
+    assert_equal '', config.myshopify_domain
   end
 
   def test_environment_has_precedence_over_common
@@ -28,6 +30,7 @@ class ConfigurationTest < Minitest::Test
 
     assert_equal 'development key', config.api_key
     assert_equal 'development secret', config.secret
+    assert_equal 'myshopify.com', config.myshopify_domain
   end
 
   def test_rails_has_precedence_over_environment
@@ -35,44 +38,54 @@ class ConfigurationTest < Minitest::Test
 
     assert_equal 'development key', config.api_key
     assert_equal 'development secret', config.secret
+    assert_equal 'myshopify.com', config.myshopify_domain
 
     config.api_key = 'rails key'
     config.secret = 'rails secret'
+    config.myshopify_domain = 'example.com'
 
     assert_equal 'rails key', config.api_key
     assert_equal 'rails secret', config.secret
+    assert_equal 'example.com', config.myshopify_domain
   end
 
   def test_env_has_precedence_over_rails
     config = ShopifyApp::Configuration.new
     config.api_key = 'rails key'
     config.secret = 'rails secret'
+    config.myshopify_domain = 'myshopify.com'
 
     assert_equal 'rails key', config.api_key
     assert_equal 'rails secret', config.secret
+    assert_equal 'myshopify.com', config.myshopify_domain
 
     ENV.expects(:[]).with('SHOPIFY_APP_API_KEY').returns('env key')
     ENV.expects(:[]).with('SHOPIFY_APP_SECRET').returns('env secret')
+    ENV.expects(:[]).with('SHOPIFY_APP_MYSHOPIFY_DOMAIN').returns('example.com')
 
     assert_equal 'env key', config.api_key
     assert_equal 'env secret', config.secret
+    assert_equal 'example.com', config.myshopify_domain
   end
 
   def test_reads_config_from_default_config_file
     config = ShopifyApp::Configuration.new
     assert_equal 'api key from default file', config.api_key
     assert_equal 'secret from default file', config.secret
+    assert_equal 'myshopify.com', config.myshopify_domain
   end
 
   def test_reads_config_from_specified_config_file
     config = ShopifyApp::Configuration.new(config_file: config_file('other_config_file.yml'))
     assert_equal 'api key from other file', config.api_key
     assert_equal 'secret from other file', config.secret
+    assert_equal 'example.com', config.myshopify_domain
   end
 
   def test_handles_missing_config_file
     config = ShopifyApp::Configuration.new(config_file: config_file('missing_config_file.yml'))
     assert_equal '', config.api_key
     assert_equal '', config.secret
+    assert_equal '', config.myshopify_domain
   end
 end


### PR DESCRIPTION
@jamesmacaulay @awd @ilikeorangutans 

Allow us to override the `myshopify_domain` from inside the `shopify_app.yml`. For internal use.

Bumps gem version to `5.0.2`.