### PR TITLE
Solves Error: A copy of Shop has been removed from the module tree but is still active!

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Your ActiveRecord model would look something like this:
 ```ruby
 class Shop < ActiveRecord::Base
   def self.store(session)
-    shop = Shop.new(domain: session.url, token: session.token)
+    shop = self.new(domain: session.url, token: session.token)
     shop.save!
     shop.id
   end
 
   def self.retrieve(id)
-    if shop = Shop.where(id: id).first
+    if shop = self.where(id: id).first
       ShopifyAPI::Session.new(shop.domain, shop.token)
     end
   end

--- a/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
+++ b/lib/generators/shopify_app/templates/config/initializers/shopify_session_repository.rb
@@ -8,13 +8,13 @@
 #
 # class Shop < ActiveRecord::Base
 #   def self.store(session)
-#     shop = Shop.new(domain: session.url, token: session.token)
+#     shop = self.new(domain: session.url, token: session.token)
 #     shop.save!
 #     shop.id
 #   end
 #
 #   def self.retrieve(id)
-#     if shop = Shop.where(id: id).first
+#     if shop = self.where(id: id).first
 #       ShopifyAPI::Session.new(shop.domain, shop.token)
 #     end
 #   end


### PR DESCRIPTION
when ShopifySessionRepository.storage = Shop is enabled in
    config/initializers/shopify_session_repository.rb
    and the Shop model is modified
    it gives error :
    ArgumentError (A copy of Shop has been removed from the module tree but is still active!)
    in development.
    
    to solve the error Shop is replaced with identifier self.
    this solves the error in a simple manner

PS: I have never sent pull request. So, please merge to the branch you think suitable. (If mergeable)