### PR TITLE
add configurable myshopify_domain

### DIFF
--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -13,12 +13,16 @@ module ShopifyApp
     # use the built in session routes?
     attr_accessor :routes
 
+    # configure myshopify domain for local shopify development
+    attr_accessor :myshopify_domain
+
     def routes_enabled?
       @routes
     end
 
     def initialize
       @routes = true
+      @myshopify_domain = 'myshopify.com'
     end
   end
 

--- a/lib/shopify_app/sessions_controller.rb
+++ b/lib/shopify_app/sessions_controller.rb
@@ -47,18 +47,18 @@ module ShopifyApp
       @sanitized_shop_name ||= sanitize_shop_param(params)
     end
 
-  def sanitize_shop_param(params)
-    return unless params[:shop].present?
+    def sanitize_shop_param(params)
+      return unless params[:shop].present?
 
-    name = params[:shop].to_s.strip
-    name += ".myshopify.com" if !name.include?("myshopify.com") && !name.include?(".")
-    name.sub!(%r|https?://|, '')
+      name = params[:shop].to_s.strip
+      name += ".#{ShopifyApp.configuration.myshopify_domain}" if !name.include?("#{ShopifyApp.configuration.myshopify_domain}") && !name.include?(".")
+      name.sub!(%r|https?://|, '')
 
-    u = URI("http://#{name}")
-    u.host && u.host.ends_with?(".myshopify.com") ? u.host : nil
-  rescue URI::InvalidURIError
-    nil
-  end
+      u = URI("http://#{name}")
+      u.host && u.host.ends_with?(".#{ShopifyApp.configuration.myshopify_domain}") ? u.host : nil
+    rescue URI::InvalidURIError
+      nil
+    end
 
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -42,6 +42,15 @@ class SessionsControllerTest < ActionController::TestCase
     end
   end
 
+  ['my-shop', 'my-shop.myshopify.io', 'https://my-shop.myshopify.io', 'http://my-shop.myshopify.io'].each do |good_url|
+    test "#create should authenticate the shop for the URL (#{good_url}) with custom myshopify_domain" do
+      ShopifyApp.configuration.stubs(:myshopify_domain).returns('myshopify.io')
+      auth_url = '/auth/shopify?shop=my-shop.myshopify.io'
+      post :create, shop: good_url
+      assert response.body.match(/window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/)
+    end
+  end
+
   ['myshop.com', 'myshopify.com', 'shopify.com', 'two words', 'store.myshopify.com.evil.com', '/foo/bar'].each do |bad_url|
     test "#create should return an error for a non-myshopify URL (#{bad_url})" do
       post :create, shop: bad_url

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class ConfigurationTest < ActiveSupport::TestCase
 
+  setup do
+    ShopifyApp.configuration = nil
+  end
+
   test "configure" do
     ShopifyApp.configure do |config|
       config.embedded_app = true
@@ -10,8 +14,28 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal true, ShopifyApp.configuration.embedded_app
   end
 
- test "routes enabled" do
+  test "routes enabled" do
     assert_equal true, ShopifyApp.configuration.routes_enabled?
+  end
+
+  test "disable routes" do
+    ShopifyApp.configure do |config|
+      config.routes = false
+    end
+
+    assert_equal false, ShopifyApp.configuration.routes_enabled?
+  end
+
+  test "defaults to myshopify_domain" do
+    assert_equal "myshopify.com", ShopifyApp.configuration.myshopify_domain
+  end
+
+  test "can set myshopify_domain" do
+    ShopifyApp.configure do |config|
+      config.myshopify_domain = 'myshopify.io'
+    end
+
+    assert_equal "myshopify.io", ShopifyApp.configuration.myshopify_domain
   end
 
 end


### PR DESCRIPTION
This PR adds a configurable myshopify_domain to the ShopifyApp gem for internal use (and I suppose external use if an app dev has made a mock local shopify server).

@shawnfrench @stephenminded 