### PR TITLE
Remove hard requirement on shopify_api ~>3.2.0

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "6.0.4"
+  VERSION = "6.0.5"
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rails', '>= 3.1', '< 5.0')
 
-  s.add_runtime_dependency('shopify_api', '~> 3.2.0')
+  s.add_runtime_dependency('shopify_api', '>= 3.2.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.4')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
And bump gem to `6.0.5`

@kevinhughes27 @shawnfrench 