### PR TITLE
Bump min version of omniauth-shopify-oauth2, remove hard requirement on shopify_api

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "6.0.4"
+  VERSION = "6.0.5"
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rails', '>= 3.1', '< 5.0')
 
-  s.add_runtime_dependency('shopify_api', '~> 3.2.0')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.4')
+  s.add_runtime_dependency('shopify_api', '~> 4.0.2')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.8')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')


### PR DESCRIPTION
Now that 1.1.8 of omniauth-shopify-oauth2 is out we can bump the min version and remove the hard requirement on shopify_api 3.2.0.

@kevinhughes27 @clayton-shopify @Shopify/platform 