### PR TITLE
passes the options through to the install generator

### DIFF
--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -2,8 +2,13 @@ module ShopifyApp
   module Generators
     class ShopifyAppGenerator < Rails::Generators::Base
 
+      def initialize(args, *options)
+        @opts = options.first
+        super(args, *options)
+      end
+
       def run_all_generators
-        generate "shopify_app:install"
+        generate "shopify_app:install #{@opts.join(' ')}"
         generate "shopify_app:shop_model"
 
         generate "shopify_app:controllers"


### PR DESCRIPTION
closes #131 

This passes the arguments down into the install generator which uses them. Most users of this gem will probably use the simple `generate shopify_app` which does everything so it would be nice if cmd args worked here.

I wish passing args in between generators was cleaner but this works at least

for review:
@celsodantas @stephenminded 