### PR TITLE
add shopify domain to session

### DIFF
--- a/lib/shopify_app/sessions_controller.rb
+++ b/lib/shopify_app/sessions_controller.rb
@@ -12,8 +12,10 @@ module ShopifyApp
 
     def callback
       if response = request.env['omniauth.auth']
-        sess = ShopifyAPI::Session.new(params[:shop], response['credentials']['token'])
+        shop_name = response.uid
+        sess = ShopifyAPI::Session.new(shop_name, response['credentials']['token'])
         session[:shopify] = ShopifyApp::SessionRepository.store(sess)
+        session[:shopify_domain] = shop_name
         flash[:notice] = "Logged in"
         redirect_to return_address
       else
@@ -24,8 +26,8 @@ module ShopifyApp
 
     def destroy
       session[:shopify] = nil
+      session[:shopify_domain] = nil
       flash[:notice] = "Successfully logged out."
-
       redirect_to action: 'new'
     end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -73,14 +73,18 @@ class SessionsControllerTest < ActionController::TestCase
 
     get :callback, shop: 'shop'
     assert_not_nil session[:shopify]
+    assert_equal 'shop.myshopify.com', session[:shopify_domain]
   end
 
   test "#destroy should clear shopify from session and redirect to login with notice" do
     shop_id = 1
     session[:shopify] = shop_id
+    session[:shopify_domain] = 'shop1.myshopify.com'
 
     get :destroy
+
     assert_nil session[:shopify]
+    assert_nil session[:shopify_domain]
     assert_redirected_to login_path
     refute flash[:notice].empty?
   end
@@ -88,7 +92,7 @@ class SessionsControllerTest < ActionController::TestCase
   private
 
   def mock_shopify_omniauth
-    OmniAuth.config.add_mock(:shopify, provider: :shopify, credentials: {token: '1234'})
+    OmniAuth.config.add_mock(:shopify, provider: :shopify, uid: 'shop.myshopify.com', credentials: {token: '1234'})
     request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:shopify] if request
     request.env['omniauth.params'] = { shop: 'shop.myshopify.com' } if request
   end


### PR DESCRIPTION
This PR adds the shopify shop name / domain to the session so its easier to see which shop the session is for. The main use for this is with exception catching tools that include the session with the exception. Currently all thats in the session is the id of the shop in the apps database which means you have to lookup which shop it actually is. With this addition you can see this right away.

for review
@shawnfrench @stephenminded 