### PR TITLE
Bump omniauth-shopify-oauth2 gem and use the default setup lambda.

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -3,9 +3,3 @@
     ShopifyApp.configuration.secret,
 
     :scope => ShopifyApp.configuration.scope,
-
-    :setup => lambda {|env|
-       params = Rack::Utils.parse_query(env['QUERY_STRING'])
-       site_url = "https://#{params['shop']}"
-       env['omniauth.strategy'].options[:client_options][:site] = site_url
-    }

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rails', '>= 3.1', '< 5.0')
 
   s.add_runtime_dependency('shopify_api', '~> 4.0.2')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.8')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.10')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')


### PR DESCRIPTION
@stephenminded & @kevinhughes27 for review

Require the latest version of omniauth-shopify-oauth2 gem and use the default setup lambda so that it doesn't need to be generated for each app.