### PR TITLE
Authenticated controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ ShopifyApp::SessionRepository.storage = 'Shop'
 If you run the `shop_model` generator it will create the required code to use the generated Shop model as the SessionRepository and update the initializer.
 
 
+AuthenticatedController
+-----------------------
+
+The engine includes a controller called `AuthenticatedController` which inherits from `ApplicationController`. It adds some before_filters which ensure the user is authenticated and will redirect to the login page if not. It is best practice to have all controllers that belong to the Shopify part of your app inherit from this controller. The HomeController that is generated already inherits from AuthenticatedController.
+
+
 Questions or problems?
 ----------------------
 http://api.shopify.com <= Read up on the possible API calls!

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,0 +1,4 @@
+class AuthenticatedController < ApplicationController
+  before_action :login_again_if_different_shop
+  around_filter :shopify_session
+end

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,4 +1,5 @@
 class AuthenticatedController < ApplicationController
   before_action :login_again_if_different_shop
   around_filter :shopify_session
+  layout ShopifyApp.configuration.embedded_app? ? 'embedded_app' : 'application'
 end

--- a/lib/generators/shopify_app/install/templates/home_controller.rb
+++ b/lib/generators/shopify_app/install/templates/home_controller.rb
@@ -1,10 +1,5 @@
 class HomeController < AuthenticatedController
-<% if embedded_app? -%>
-  layout 'embedded_app'
-<% end -%>
-
   def index
     @products = ShopifyAPI::Product.find(:all, :params => {:limit => 10})
   end
-
 end

--- a/lib/generators/shopify_app/install/templates/home_controller.rb
+++ b/lib/generators/shopify_app/install/templates/home_controller.rb
@@ -1,6 +1,4 @@
-class HomeController < ApplicationController
-  before_action :login_again_if_different_shop
-  around_filter :shopify_session
+class HomeController < AuthenticatedController
 <% if embedded_app? -%>
   layout 'embedded_app'
 <% end -%>

--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -2,4 +2,4 @@
     ShopifyApp.configuration.api_key,
     ShopifyApp.configuration.secret,
 
-    :scope => ShopifyApp.configuration.scope,
+    :scope => ShopifyApp.configuration.scope

--- a/test/generators/controllers_generator_test.rb
+++ b/test/generators/controllers_generator_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'generators/shopify_app/controllers/controllers_generator'
+
+class ControllersGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::ControllersGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+  setup :prepare_destination
+
+  test "copies ShopifyApp controllers to the host application" do
+    run_generator
+    assert_directory "app/controllers"
+    assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/authenticated_controller.rb"
+  end
+
+end


### PR DESCRIPTION
I've noticed that its a pretty common error to refactor code into the ApplicationController and not realize that it affects the sessions controller. A pattern that I use a lot is to create an AuthenticatedController which has the required before filters for the authenticated part of the app. This helps prevent accidentally breaking auth for your app while refactoring into the ApplicationController.

I also pulled the layout config into AuthenticatedController and out of the generated HomeController. This is an improvement since now if you inherit AuthenticatedController everything just works

It seems a bit weird to me that then ApplicationController still gets ShopifyApp::Controller included since only its derived classes use these methods. The alternative would be to not include ShopifyApp::Controller in the ApplicationController and instead include it in both the SessionsController and the AuthenticatedController - thoughts?

@qq99 @AWaselnuk @stephenminded 