### PR TITLE
add appinfive screencast to readme under Quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This gem includes some common code and generators for writing Rails applications
 *Note: It's recommended to use this on a new Rails project, so that the generator won't overwrite/delete some of your files.*
 
 
+Quickstart
+----------
+
+Check out this screencast on how to create and deploy a new Shopify App to Heroku in 5 minutes:
+
+[https://vimeo.com/130247240](https://vimeo.com/130247240)
+
+
 Becoming a Shopify App Developer
 --------------------------------
 If you don't have a Shopify Partner account yet head over to http://shopify.com/partners to create one, you'll need it before you can start developing apps.


### PR DESCRIPTION
Adds a link to my App In Five screen cast under a new readme section called Quickstart. When I get around to doing the blog post I'll link it in the same section.

@joshubrown @atleeclark 