### PR TITLE
Close session in login_again_if_different_shop

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -27,6 +27,7 @@ module ShopifyApp
     def login_again_if_different_shop
       if shop_session && params[:shop] && params[:shop].is_a?(String) && shop_session.url != params[:shop]
         session[:shopify] = nil
+        session[:shopify_domain] = nil
         redirect_to_login
       end
     end
@@ -40,6 +41,7 @@ module ShopifyApp
 
     def close_session
       session[:shopify] = nil
+      session[:shopify_domain] = nil
       redirect_to login_path
     end
 

--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -26,6 +26,7 @@ module ShopifyApp
 
     def login_again_if_different_shop
       if shop_session && params[:shop] && params[:shop].is_a?(String) && shop_session.url != params[:shop]
+        session[:shopify] = nil
         redirect_to_login
       end
     end

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -6,7 +6,13 @@ class LoginProtectionController < ActionController::Base
   include ShopifyApp::LoginProtection
   helper_method :shop_session
 
+  before_action :login_again_if_different_shop, only: [:second_login]
+
   def index
+    render nothing: true
+  end
+
+  def second_login
     render nothing: true
   end
 end
@@ -45,12 +51,24 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
+  test "login_again_if_different_shop removes current session and redirects to login path" do
+    with_application_test_routes do
+      session[:shopify] = "foobar"
+      sess = stub(url: 'https://foobar.myshopify.com')
+      ShopifyApp::SessionRepository.expects(:retrieve).returns(sess).once
+      get :second_login, shop: 'other_shop'
+      assert_redirected_to @controller.send(:login_path, shop: 'other_shop')
+      assert_nil session[:shopify]
+    end
+  end
+
   private
 
   def with_application_test_routes
     with_routing do |set|
       set.draw do
         get '/' => 'login_protection#index'
+        get '/second_login' => 'login_protection#second_login'
       end
       yield
     end

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -54,11 +54,13 @@ class LoginProtectionTest < ActionController::TestCase
   test "login_again_if_different_shop removes current session and redirects to login path" do
     with_application_test_routes do
       session[:shopify] = "foobar"
+      session[:shopify_domain] = "foobar"
       sess = stub(url: 'https://foobar.myshopify.com')
       ShopifyApp::SessionRepository.expects(:retrieve).returns(sess).once
       get :second_login, shop: 'other_shop'
       assert_redirected_to @controller.send(:login_path, shop: 'other_shop')
       assert_nil session[:shopify]
+      assert_nil session[:shopify_domain]
     end
   end
 


### PR DESCRIPTION
@kevinhughes27 @stephenminded I think this fixes the issue I found with `login_again_if_different_shop` not actually redirecting to the new shop.

There might be a better way to test this. Thoughts?