### PR TITLE
add redirect uri to shopify app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ rails generate shopify_app:install
 
 # or optionally with arguments:
 
-$ rails generate shopify_app:install -api_key=<your_api_key> -secret=<your_app_secret>
+$ rails generate shopify_app:install -api_key=<your_api_key> -secret=<your_app_secret> -redirect_uri=<your_redirect_uri>
 ```
 
 Other options include:
@@ -101,6 +101,7 @@ The `install` generator places your Api credentials directly into the shopify_ap
 ShopifyApp.configure do |config|
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
+  config.redirect_uri = "<%= your_redirect_uri %>"
   config.scope = 'read_customers, read_orders, write_products'
   config.embedded_app = true
 end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -19,6 +19,7 @@ module ShopifyApp
         {
           api_key: '<api_key>',
           secret: '<secret>',
+          redirect_uri: '<redirect_uri>',
           scope: 'read_orders, read_products',
           embedded: 'true'
         }

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -1,6 +1,7 @@
 ShopifyApp.configure do |config|
   config.api_key = "<%= opts[:api_key] %>"
   config.secret = "<%= opts[:secret] %>"
+  config.redirect_uri = "<%= opts[:redirect_uri] %>"
   config.scope = "<%= opts[:scope] %>"
   config.embedded_app = <%= embedded_app? %>
 end

--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -2,4 +2,6 @@
     ShopifyApp.configuration.api_key,
     ShopifyApp.configuration.secret,
 
+    :redirect_uri => ShopifyApp.configuration.redirect_uri,
+
     :scope => ShopifyApp.configuration.scope

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -6,6 +6,7 @@ module ShopifyApp
     # `config/initializers/shopify_app.rb`
     attr_accessor :api_key
     attr_accessor :secret
+    attr_accessor :redirect_uri
     attr_accessor :scope
     attr_accessor :embedded_app
     alias_method  :embedded_app?, :embedded_app

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -17,6 +17,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.api_key = "<api_key>"', shopify_app
       assert_match 'config.secret = "<secret>"', shopify_app
+      assert_match 'config.redirect_uri = "<redirect_uri>"', shopify_app
       assert_match 'config.scope = "read_orders, read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
     end


### PR DESCRIPTION
since https://github.com/Shopify/shopify/pull/46095 redirect_uri is a required param for apps. This PR adds redirect_uri to the ShopifyApp config and the omniauth provider. It can be passed into the generators the same as api_key and other params.

@ShayneP and I top hatted a new app locally and were successful.

ToDo
- [ ] Update appinfive screencast somehow - what are our options here? @joshubrown. Seems like lots of people are using it and then running into issues since it is now out of date
- [ ] Update shopify_api and shopify_python_api READMEs to indicate that this param is no longer optional. @ShayneP can you take this please

for review @EiNSTeiN- @awd 