### PR TITLE
Return an HTTP 401 for XHRs that aren't logged in

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+6.2.0
+-----
+
+* Return an HTTP 401 for XHRs that aren't logged in
+
 6.1.3
 -----
 * add redirect_uri which is now required

--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -35,8 +35,12 @@ module ShopifyApp
     protected
 
     def redirect_to_login
-      session[:return_to] = request.fullpath if request.get?
-      redirect_to login_path(shop: params[:shop])
+      if request.xhr?
+        head :unauthorized
+      else
+        session[:return_to] = request.fullpath if request.get?
+        redirect_to login_path(shop: params[:shop])
+      end
     end
 
     def close_session

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = "6.1.3"
+  VERSION = '6.2.0'
 end

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -6,6 +6,7 @@ class LoginProtectionController < ActionController::Base
   include ShopifyApp::LoginProtection
   helper_method :shop_session
 
+  around_action :shopify_session, only: [:index]
   before_action :login_again_if_different_shop, only: [:second_login]
 
   def index
@@ -61,6 +62,20 @@ class LoginProtectionTest < ActionController::TestCase
       assert_redirected_to @controller.send(:login_path, shop: 'other_shop')
       assert_nil session[:shopify]
       assert_nil session[:shopify_domain]
+    end
+  end
+
+  test '#shopify_session with no Shopify session, redirects to the login path' do
+    with_application_test_routes do
+      get :index, shop: 'foobar'
+      assert_redirected_to @controller.send(:login_path, shop: 'foobar')
+    end
+  end
+
+  test '#shopify_session with no Shopify session, sets session[:return_to]' do
+    with_application_test_routes do
+      get :index, shop: 'foobar'
+      assert_equal '/?shop=foobar', session[:return_to]
     end
   end
 

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -79,6 +79,13 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
+  test '#shopify_session with no Shopify session, when the request is an XHR, returns an HTTP 401' do
+    with_application_test_routes do
+      xhr :get, :index, shop: 'foobar'
+      assert_equal 401, response.status
+    end
+  end
+
   private
 
   def with_application_test_routes


### PR DESCRIPTION
## Problem

`session[:return_to]` shouldn't be set if the request is an XHR, because browsing sessions rarely mean to be able to return to XHR paths.

## Solution

Don't set it if the request is an XHR.

/related Shopify/facebook-commerce#3525
/review @kevinhughes27, @peterjm