### PR TITLE
Use root_url from main_app when redirecting the user in authenticate

### DIFF
--- a/lib/shopify_app/sessions_controller.rb
+++ b/lib/shopify_app/sessions_controller.rb
@@ -35,7 +35,7 @@ module ShopifyApp
 
     def authenticate
       if shop_name = sanitize_shop_param(params)
-        fullpage_redirect_to "#{main_app.root_url}auth/shopify?shop=#{shop_name}"
+        fullpage_redirect_to "#{main_app.root_path}auth/shopify?shop=#{shop_name}"
       else
         redirect_to return_address
       end

--- a/lib/shopify_app/sessions_controller.rb
+++ b/lib/shopify_app/sessions_controller.rb
@@ -35,7 +35,7 @@ module ShopifyApp
 
     def authenticate
       if shop_name = sanitize_shop_param(params)
-        fullpage_redirect_to "/auth/shopify?shop=#{shop_name}"
+        fullpage_redirect_to "#{main_app.root_url}auth/shopify?shop=#{shop_name}"
       else
         redirect_to return_address
       end


### PR DESCRIPTION
The `main_app.root_url` parameter is used to set the appropriate leading value for the path. This should fix issue #154 .