### PR TITLE
Add callback_url to shopify_provider.rb generator

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -4,4 +4,6 @@
 
     :redirect_uri => ShopifyApp.configuration.redirect_uri,
 
+    :callback_url => ShopifyApp.configuration.redirect_uri,
+
     :scope => ShopifyApp.configuration.scope


### PR DESCRIPTION
Ensures that `ShopifyApp.configuration.redirect_uri` is actually used in oauth flow for apps using install generator.
Resolves issues #165 and #160