### PR TITLE
Fix a minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you just run `rails generate shopify_app` then all the generators will be run
 Managing Api Keys
 -----------------
 
-The `install` generator places your Api credentials directly into the shopify_app initializer which is convient and fine for development but once your app goes into production **your api credentials should not be in source control**. When we develop apps we keep our keys in environment variables so a production shopify_app initializer would look like this:
+The `install` generator places your Api credentials directly into the shopify_app initializer which is convenient and fine for development but once your app goes into production **your api credentials should not be in source control**. When we develop apps we keep our keys in environment variables so a production shopify_app initializer would look like this:
 
 ```ruby
 ShopifyApp.configure do |config|


### PR DESCRIPTION
a minor spelling fix in the [README](https://github.com/Shopify/shopify_app/blob/4063b808f80c4e8cc89fb6d6378d50b9b377dab6/README.md#managing-api-keys)