### PR TITLE
Add Codecov for coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Shopify App      [![Build Status](https://travis-ci.org/Shopify/shopify_app.png)](https://travis-ci.org/Shopify/shopify_app)
+Shopify App      [![Build Status](https://travis-ci.org/Shopify/shopify_app.png)](https://travis-ci.org/Shopify/shopify_app) [![codecov.io](https://codecov.io/github/Shopify/shopify_app/coverage.svg?branch=master)](https://codecov.io/github/Shopify/shopify_app?branch=master)
 ===========
 
 Shopify Application Rails engine and generator

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sqlite3')
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')
+  s.add_development_dependency('codecov')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test}/*`.split("\n")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,14 @@ require 'rails/test_help'
 require 'mocha/setup'
 require 'byebug'
 
+if ENV['CI'] == 'true'
+    require 'simplecov'
+    SimpleCov.start
+
+    require 'codecov'
+    SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
+
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new


### PR DESCRIPTION
Hey there,

I'm the founder of Codecov and would like to showcase our coverage tools to shopify/shopify_app.

Some of our core features include:
- Seamless overlay of coverage reports in Github with our browser extensions. [Video](https://www.youtube.com/watch?v=d6wJKODB8_g)
- Awesome pull request comments. [Example](https://gist.github.com/codecov-io/ba612976215481e7f27c)
- Github commit status integration to ensure coverage meets minimum standards
- Automatic unified builds. See [pyca/cryptography](https://codecov.io/github/pyca/cryptography) for example

See the example report here: https://codecov.io/github/stevepeak/shopify_app
> Generated in my [CI build](https://travis-ci.org/stevepeak/shopify_app/builds/86150128)

Love all the feedback you have and I look forward to having Shopify on Codecov. You app is killer! Keep up the great work over there :)

Cheers,
Steve