### PR TITLE
Updated the favicon file name in shopify_app_ready_script.html

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_app_ready_script.html
+++ b/lib/generators/shopify_app/install/templates/shopify_app_ready_script.html
@@ -2,7 +2,7 @@
   ShopifyApp.ready(function(){
     ShopifyApp.Bar.initialize({
       title: "Home",
-      icon: "<%= asset_path('faveicon.png') %>"
+      icon: "<%= asset_path('favicon.ico') %>"
     });
   });
 </script>


### PR DESCRIPTION
The filename for the favicon was wrong, so I updated it to use the correct favicon filename.

The default favicon file is empty, so I replaced it with a 1UP mushroom for testing purposes, which is displayed beside the app name:

![favicon-showing-up](https://cloud.githubusercontent.com/assets/15325413/10888702/b506178c-815b-11e5-9a72-64bde07fd41a.png)

@kevinhughes27 @shawnfrench 