### PR TITLE
include the flash messages partial in the embedded app generator

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -63,6 +63,7 @@ module ShopifyApp
       def create_embedded_app_layout
         if embedded_app?
           copy_file 'embedded_app.html.erb', 'app/views/layouts/embedded_app.html.erb'
+          copy_file '_flash_messages.html.erb', 'app/views/layouts/_flash_messages.html.erb'
         end
       end
 

--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+  var eventName = typeof(Turbolinks) !== 'undefined' ? 'page:change' : 'DOMContentLoaded';
+
+  document.addEventListener(eventName, function() {
+    <% if flash[:notice] %>
+      ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
+    <% end %>
+
+    <% if flash[:error] %>
+      ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
+    <% end %>
+  });
+</script>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -19,5 +19,6 @@
 
 <body>
   <%= yield %>
+  <%= render 'layouts/flash_messages' %>
 </body>
 </html>

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -73,6 +73,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "creates the embedded_app layout" do
     run_generator
     assert_file "app/views/layouts/embedded_app.html.erb"
+    assert_file "app/views/layouts/_flash_messages.html.erb"
   end
 
   test "creates the home controller" do


### PR DESCRIPTION
This PR adds the esdk flash messages template during app generation if the app is embedded. I also made the script smart enough to detect turoblinks and use the appropriate event (tophatted both locally). I don't think we should bother including anything flash related for non-embedded apps since there is a lot of different ways to do that and it would require some sort of default styling to actually work out of the box.

for review:
@christhomson @kwestein 