### PR TITLE
create shop fixtures as part of shop model generator

### DIFF
--- a/lib/generators/shopify_app/shop_model/shop_model_generator.rb
+++ b/lib/generators/shopify_app/shop_model/shop_model_generator.rb
@@ -23,6 +23,10 @@ module ShopifyApp
         copy_file 'shopify_session_repository.rb', 'config/initializers/shopify_session_repository.rb', force: true
       end
 
+      def create_shop_fixtures
+        copy_file 'shops.yml', 'test/fixtures/shops.yml'
+      end
+
       private
 
       def copy_migration(migration_name, config = {})

--- a/lib/generators/shopify_app/shop_model/templates/shops.yml
+++ b/lib/generators/shopify_app/shop_model/templates/shops.yml
@@ -1,0 +1,3 @@
+regular_shop:
+  shopify_domain: 'regular-shop.myshopify.com'
+  shopify_token: 'token'

--- a/test/generators/shop_model_generator_test.rb
+++ b/test/generators/shop_model_generator_test.rb
@@ -37,4 +37,11 @@ class ShopModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "creates default shop fixtures" do
+    run_generator
+    assert_file "test/fixtures/shops.yml" do |file|
+      assert_match "regular_shop:", file
+    end
+  end
+
 end


### PR DESCRIPTION
While creating a new app with @christinejordan we realized that the shop model generator doesn't add any fixtures or even create the fixtures file. This PR adds that and it means one less thing for the user of this gem to do when setting up a new app.

for review:
@christinejordan @christhomson 