### PR TITLE
add a webhooks manager to the framework

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ Master
 * Move SessionStorage from a generated class to a re-usable module. To
   migrate to the new module, delete the old generated SessionStorage class
   in the models directory and include the SessionStorage module in your Shop model.
+* Adds a WebhooksManager class and allows you to configure what webhooks your app
+  needs. The rest is taken care of by ShopifyApp provided you set up a backgroud queue
+  with ActiveJob
 
 6.2.1
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ Master
 * Adds a WebhooksManager class and allows you to configure what webhooks your app
   needs. The rest is taken care of by ShopifyApp provided you set up a backgroud queue
   with ActiveJob
+* Adds a WebhooksController module which can be included to handle the boiler plate code
+  for a controller receiving webhooks from Shopify
 
 6.2.1
 -----

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ ShopifyApp.configure do |config|
 end
 ```
 
+
+WebhooksManager
+---------------
+
+ShopifyApp can manage your app's webhooks for you (requires ActiveJob). Set which webhooks you require in the initializer:
+
+```ruby
+ShopifyApp.configure do |config|
+  config.webhooks = [
+    {topic: 'carts/update', address: 'example-app.com/webhooks', format: 'json'}
+  ]
+end
+```
+
+When the oauth callback is completed successfully ShopifyApp will queue a background job which will ensure all the specified webhooks exist for that shop. Because this runs on every oauth callback it means your app will always have the webhooks it needs even if the user uninstalls and re-installs the app.
+
+
 ShopifyApp::SessionRepository
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ShopifyApp can manage your app's webhooks for you (requires ActiveJob). Set whic
 ```ruby
 ShopifyApp.configure do |config|
   config.webhooks = [
-    {topic: 'carts/update', address: 'example-app.com/webhooks', format: 'json'}
+    {topic: 'carts/update', address: 'example-app.com/webhooks'}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ end
 
 When the oauth callback is completed successfully ShopifyApp will queue a background job which will ensure all the specified webhooks exist for that shop. Because this runs on every oauth callback it means your app will always have the webhooks it needs even if the user uninstalls and re-installs the app.
 
+There is also a WebhooksController module that you can include in a controller that receives Shopify webhooks. For example:
+
+```ruby
+class WebhooksController < ApplicationController
+  include ShopifyApp::WebhooksController
+
+  def carts_update
+    SomeJob.perform_later(shopify_domain: shop_domain)
+    head :ok
+  end
+end
+```
+
+The module skips the `verify_authenticity_token` before_action and adds an action to verify that the webhook came from Shopify.
+
 
 ShopifyApp::SessionRepository
 -----------------------------

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -20,6 +20,7 @@ require 'shopify_app/controller'
 require 'shopify_app/sessions_controller'
 require 'shopify_app/login_protection'
 require 'shopify_app/webhooks_manager'
+require 'shopify_app/webhooks_controller'
 require 'shopify_app/utils'
 
 # session repository

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -10,12 +10,16 @@ require 'shopify_app/configuration'
 # engine
 require 'shopify_app/engine'
 
+# jobs
+require 'shopify_app/webhooks_manager_job'
+
 # helpers and concerns
 require 'shopify_app/shop'
 require 'shopify_app/session_storage'
 require 'shopify_app/controller'
 require 'shopify_app/sessions_controller'
 require 'shopify_app/login_protection'
+require 'shopify_app/webhooks_manager'
 require 'shopify_app/utils'
 
 # session repository

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -10,12 +10,17 @@ module ShopifyApp
     attr_accessor :scope
     attr_accessor :embedded_app
     alias_method  :embedded_app?, :embedded_app
+    attr_accessor :webhooks
 
     # configure myshopify domain for local shopify development
     attr_accessor :myshopify_domain
 
     def initialize
       @myshopify_domain = 'myshopify.com'
+    end
+
+    def has_webhooks?
+      webhooks.present?
     end
   end
 

--- a/lib/shopify_app/webhooks_controller.rb
+++ b/lib/shopify_app/webhooks_controller.rb
@@ -1,0 +1,35 @@
+module ShopifyApp
+  module WebhooksController
+    extend ActiveSupport::Concern
+
+    included do
+      skip_before_action :verify_authenticity_token
+      before_action :verify_request
+    end
+
+    private
+
+    def verify_request
+      request.body.rewind
+      data = request.body.read
+
+      unless validate_hmac(ShopifyApp.configuration.secret, data)
+        head :unauthorized
+      end
+    end
+
+    def validate_hmac(secret, data)
+      digest  = OpenSSL::Digest.new('sha256')
+      shopify_hmac == Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
+    end
+
+    def shop_domain
+      request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN']
+    end
+
+    def shopify_hmac
+      request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
+    end
+
+  end
+end

--- a/lib/shopify_app/webhooks_manager.rb
+++ b/lib/shopify_app/webhooks_manager.rb
@@ -1,0 +1,67 @@
+module ShopifyApp
+  class WebhooksManager
+    class CreationFailed < StandardError; end
+
+    def self.queue(shop_name, token)
+      ShopifyApp::WebhooksManagerJob.perform_later(shop_name: shop_name, token: token)
+    end
+
+    def initialize(shop_name, token)
+      @shop_name, @token = shop_name, token
+    end
+
+    def recreate_webhooks!
+      destroy_webhooks
+      create_webhooks
+    end
+
+    def create_webhooks
+      return unless required_webhooks.present?
+
+      with_shopify_session do
+        required_webhooks.each do |webhook|
+          create_webhook(webhook) unless webhook_exists?(webhook[:topic])
+        end
+      end
+    end
+
+    def destroy_webhooks
+      with_shopify_session do
+        ShopifyAPI::Webhook.all.each do |webhook|
+          ShopifyAPI::Webhook.delete(webhook.id) if is_required_webhook?(webhook)
+        end
+      end
+      @current_webhooks = nil
+    end
+
+    private
+
+    def required_webhooks
+      ShopifyApp.configuration.webhooks
+    end
+
+    def is_required_webhook?(webhook)
+      required_webhooks.map{ |w| w[:address] }.include? webhook.address
+    end
+
+    def with_shopify_session
+      ShopifyAPI::Session.temp(@shop_name, @token) do
+        yield
+      end
+    end
+
+    def create_webhook(attributes)
+      webhook = ShopifyAPI::Webhook.create(attributes)
+      raise CreationFailed unless webhook.persisted?
+      webhook
+    end
+
+    def webhook_exists?(topic)
+      current_webhooks[topic]
+    end
+
+    def current_webhooks
+      @current_webhooks ||= ShopifyAPI::Webhook.all.index_by(&:topic)
+    end
+  end
+end

--- a/lib/shopify_app/webhooks_manager.rb
+++ b/lib/shopify_app/webhooks_manager.rb
@@ -51,6 +51,7 @@ module ShopifyApp
     end
 
     def create_webhook(attributes)
+      attributes.reverse_merge!(format: 'json')
       webhook = ShopifyAPI::Webhook.create(attributes)
       raise CreationFailed unless webhook.persisted?
       webhook

--- a/lib/shopify_app/webhooks_manager_job.rb
+++ b/lib/shopify_app/webhooks_manager_job.rb
@@ -1,0 +1,11 @@
+module ShopifyApp
+  class WebhooksManagerJob < ActiveJob::Base
+    def perform(params = {})
+      shop_name = params.fetch(:shop_name)
+      token = params.fetch(:token)
+
+      manager = WebhooksManager.new(shop_name, token)
+      manager.create_webhooks
+    end
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -78,7 +78,7 @@ class SessionsControllerTest < ActionController::TestCase
 
   test "#callback should start the WebhooksManager if webhooks are configured" do
     ShopifyApp.configure do |config|
-      config.webhooks = [{topic: 'carts/update', address: 'example-app.com/webhooks', format: 'json'}]
+      config.webhooks = [{topic: 'carts/update', address: 'example-app.com/webhooks'}]
     end
 
     ShopifyApp::WebhooksManager.expects(:queue)

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -26,4 +26,24 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "myshopify.io", ShopifyApp.configuration.myshopify_domain
   end
 
+  test "can configure webhooks for creation" do
+    webhook = {topic: 'carts/update', address: 'example-app.com/webhooks', format: 'json'}
+
+    ShopifyApp.configure do |config|
+      config.webhooks = [webhook]
+    end
+
+    assert_equal webhook, ShopifyApp.configuration.webhooks.first
+  end
+
+  test "has_webhooks? is true if webhooks have been configured" do
+    refute ShopifyApp.configuration.has_webhooks?
+
+    ShopifyApp.configure do |config|
+      config.webhooks = [{topic: 'carts/update', address: 'example-app.com/webhooks', format: 'json'}]
+    end
+
+    assert ShopifyApp.configuration.has_webhooks?
+  end
+
 end

--- a/test/shopify_app/webhooks_controller_test.rb
+++ b/test/shopify_app/webhooks_controller_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+require 'action_controller'
+require 'action_controller/base'
+
+class WebhooksController < ActionController::Base
+  include ShopifyApp::WebhooksController
+  def carts_update
+    head :ok
+  end
+end
+
+class WebhooksControllerTest < ActionController::TestCase
+  tests WebhooksController
+
+  setup do
+    ShopifyApp::SessionRepository.storage = InMemorySessionStore
+    ShopifyApp.configure do |config|
+      config.secret = 'secret'
+    end
+  end
+
+  test "#carts_update should verify request" do
+    with_application_test_routes do
+      data = {foo: :bar}.to_json
+      @controller.expects(:validate_hmac).with('secret', data.to_s).returns(true)
+      post :carts_update, data
+      assert_response :ok
+    end
+  end
+
+  test "un-verified request returns unauthorized" do
+    with_application_test_routes do
+      data = {foo: :bar}.to_json
+      @controller.expects(:validate_hmac).with('secret', data.to_s).returns(false)
+      post :carts_update, data
+      assert_response :unauthorized
+    end
+  end
+
+  private
+
+  def with_application_test_routes
+    with_routing do |set|
+      set.draw do
+        get '/carts_update' => 'webhooks#carts_update'
+      end
+      yield
+    end
+  end
+end

--- a/test/shopify_app/webhooks_manager_test.rb
+++ b/test/shopify_app/webhooks_manager_test.rb
@@ -5,9 +5,9 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
   setup do
     ShopifyApp.configure do |config|
       config.webhooks = [
-        {topic: 'app/uninstalled', address: "https://example-app.com/webhooks/app_uninstalled", format: 'json'},
-        {topic: 'orders/create', address: "https://example-app.com/webhooks/order_create", format: 'json'},
-        {topic: 'orders/updated', address: "https://example-app.com/webhooks/order_updated", format: 'json'},
+        {topic: 'app/uninstalled', address: "https://example-app.com/webhooks/app_uninstalled"},
+        {topic: 'orders/create', address: "https://example-app.com/webhooks/order_create"},
+        {topic: 'orders/updated', address: "https://example-app.com/webhooks/order_updated"},
       ]
     end
 

--- a/test/shopify_app/webhooks_manager_test.rb
+++ b/test/shopify_app/webhooks_manager_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
+
+  setup do
+    ShopifyApp.configure do |config|
+      config.webhooks = [
+        {topic: 'app/uninstalled', address: "https://example-app.com/webhooks/app_uninstalled", format: 'json'},
+        {topic: 'orders/create', address: "https://example-app.com/webhooks/order_create", format: 'json'},
+        {topic: 'orders/updated', address: "https://example-app.com/webhooks/order_updated", format: 'json'},
+      ]
+    end
+
+    @manager = ShopifyApp::WebhooksManager.new("regular-shop.myshopify.com", "token")
+  end
+
+  test "#create_webhooks makes calls to create webhooks" do
+    ShopifyAPI::Webhook.stubs(all: [])
+
+    expect_webhook_creation('app/uninstalled', "https://example-app.com/webhooks/app_uninstalled")
+    expect_webhook_creation('orders/create', "https://example-app.com/webhooks/order_create")
+    expect_webhook_creation('orders/updated', "https://example-app.com/webhooks/order_updated")
+
+    @manager.create_webhooks
+  end
+
+  test "#create_webhooks when creating a webhook fails, raises an error" do
+    ShopifyAPI::Webhook.stubs(all: [])
+    webhook = stub(persisted?: false)
+    ShopifyAPI::Webhook.stubs(create: webhook)
+
+    assert_raise ShopifyApp::WebhooksManager::CreationFailed do
+      @manager.create_webhooks
+    end
+  end
+
+  test "#create_webhooks when creating a webhook fails and the webhook exists, do not raise an error" do
+    webhook = stub(persisted?: false)
+    webhooks = all_webhook_topics.map{|t| stub(topic: t)}
+    ShopifyAPI::Webhook.stubs(create: webhook, all: webhooks)
+
+    assert_nothing_raised ShopifyApp::WebhooksManager::CreationFailed do
+      @manager.create_webhooks
+    end
+  end
+
+  test "#recreate_webhooks! destroys all webhooks and recreates" do
+    @manager.expects(:destroy_webhooks)
+    @manager.expects(:create_webhooks)
+
+    @manager.recreate_webhooks!
+  end
+
+  test "#destroy_webhooks makes calls to destroy webhooks" do
+    ShopifyAPI::Webhook.stubs(:all).returns(Array.wrap(all_mock_webhooks.first))
+    ShopifyAPI::Webhook.expects(:delete).with(all_mock_webhooks.first.id)
+
+    @manager.destroy_webhooks
+  end
+
+  test "#destroy_webhooks does not destroy webhooks that do not have a matching address" do
+    ShopifyAPI::Webhook.stubs(:all).returns([stub(address: 'http://something-or-the-other.com/webhooks/product_update', id: 7214109)])
+    ShopifyAPI::Webhook.expects(:delete).never
+
+    @manager.destroy_webhooks
+  end
+
+  private
+
+  def expect_webhook_creation(topic, address)
+    stub_webhook = stub(persisted?: true)
+    ShopifyAPI::Webhook.expects(:create).with(topic: topic, address: address, format: 'json').returns(stub_webhook)
+  end
+
+  def all_webhook_topics
+    @webhooks ||= ['app/uninstalled', 'orders/create', 'orders/updated']
+  end
+
+  def all_mock_webhooks
+    [
+      stub(id: 1, address: "https://example-app.com/webhooks/app_uninstalled", topic: 'app/uninstalled'),
+      stub(id: 2, address: "https://example-app.com/webhooks/order_create", topic: 'orders/create'),
+      stub(id: 3, address: "https://example-app.com/webhooks/order_updated", topic: 'orders/updated'),
+    ]
+  end
+end


### PR DESCRIPTION
This PR brings in the WebhooksManager that has made its way into most of our apps that require webhooks. It allows developers to say which webhooks their app needs in the ShopifyApp initializer and then the framework takes care of the rest. In the callback method when the shop is being installed or logged in we queue the webhooks manager to make sure all the required hooks are in place. This does require ActiveJob to be configured for the app to work properly since we wouldn't want to block waiting to talk to shopify again after the callback.

* This is totally optional and won't have any affect on existing apps unless they opt in and use this class
* If an app is using a background queue directly they can still use this. for example Sidekiq can live happily next to ActiveJob.

for review:
@t6d @christhomson 