### PR TITLE
Create shop helper with shop model generation

### DIFF
--- a/lib/generators/shopify_app/shop_model/shop_model_generator.rb
+++ b/lib/generators/shopify_app/shop_model/shop_model_generator.rb
@@ -23,6 +23,14 @@ module ShopifyApp
         copy_file 'shops.yml', 'test/fixtures/shops.yml'
       end
 
+      def inject_into_authenticated_controller
+        inject_into_file(
+          'app/controllers/shopify_app/authenticated_controller.rb',
+          File.read(File.expand_path(find_in_source_paths('shop_helper.rb'))),
+          before: "\nend"
+        )
+      end
+
       private
 
       def copy_migration(migration_name, config = {})

--- a/lib/generators/shopify_app/shop_model/templates/db/migrate/create_shops.rb
+++ b/lib/generators/shopify_app/shop_model/templates/db/migrate/create_shops.rb
@@ -1,6 +1,6 @@
 class CreateShops < ActiveRecord::Migration
   def self.up
-    create_table :shops  do |t|
+    create_table :shops do |t|
       t.string :shopify_domain, null: false
       t.string :shopify_token, null: false
       t.timestamps

--- a/lib/generators/shopify_app/shop_model/templates/shop_helper.rb
+++ b/lib/generators/shopify_app/shop_model/templates/shop_helper.rb
@@ -1,0 +1,7 @@
+
+  protected
+
+  def shop
+    @shop ||= Shop.find_by(id: session[:shopify])
+  end
+  helper_method :shop

--- a/test/app_templates/app/controllers/shopify_app/authenticated_controller.rb
+++ b/test/app_templates/app/controllers/shopify_app/authenticated_controller.rb
@@ -1,0 +1,7 @@
+module ShopifyApp
+  class AuthenticatedController < ApplicationController
+    before_action :login_again_if_different_shop
+    around_filter :shopify_session
+    layout ShopifyApp.configuration.embedded_app? ? 'embedded_app' : 'application'
+  end
+end

--- a/test/generators/shop_model_generator_test.rb
+++ b/test/generators/shop_model_generator_test.rb
@@ -4,7 +4,11 @@ require 'generators/shopify_app/shop_model/shop_model_generator'
 class ShopModelGeneratorTest < Rails::Generators::TestCase
   tests ShopifyApp::Generators::ShopModelGenerator
   destination File.expand_path("../tmp", File.dirname(__FILE__))
-  setup :prepare_destination
+
+  setup do
+    prepare_destination
+    provide_existing_authenticated_controller
+  end
 
   test "create the shop model" do
     run_generator
@@ -18,7 +22,14 @@ class ShopModelGeneratorTest < Rails::Generators::TestCase
   test "creates ShopModel migration" do
     run_generator
     assert_migration "db/migrate/create_shops.rb" do |migration|
-      assert_match "create_table :shops  do |t|", migration
+      assert_match "create_table :shops do |t|", migration
+    end
+  end
+
+  test "injects into authenticated controller" do
+    run_generator
+    assert_file "app/controllers/shopify_app/authenticated_controller.rb" do |controller|
+      assert_match "def shop", controller
     end
   end
 

--- a/test/support/generator_test_helpers.rb
+++ b/test/support/generator_test_helpers.rb
@@ -5,6 +5,10 @@ module GeneratorTestHelpers
     copy_to_generator_root("app/controllers", "application_controller.rb")
   end
 
+  def provide_existing_authenticated_controller
+    copy_to_generator_root("app/controllers/shopify_app", "authenticated_controller.rb")
+  end
+
   def provide_existing_application_file
     copy_to_generator_root("config", "application.rb")
   end


### PR DESCRIPTION
In all the apps I've been creating, in all apps I've seen on Shopify, and I'm pretty sure in all apps relying on the Shop model for memory store, we always need to retrieve the shop model at one point or another, from the database. Since this is a snippet of code we've been copying over and over again, I figure it could make sense to have it as part of the generator?

The output would be appended to `application_controller.rb`, allowing any other controller to rely on the `shop` helper.

What do you think? Worth it or not?

@kevinhughes27 