### PR TITLE
Require omniauth-shopify-oauth2 ~> 1.1.11.

### DIFF
--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rails', '>= 3.1', '< 5.0')
 
   s.add_runtime_dependency('shopify_api', '~> 4.0.2')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.10')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')


### PR DESCRIPTION
@kevinhughes27 @EiNSTeiN- @christhomson

omniauth-shopify-oauth2 1.1.11 fixes an incompatibility with omniauth-oauth2 1.4.0 (https://github.com/Shopify/omniauth-shopify-oauth2/pull/32), so we should require that version.