### PR TITLE
remove callback url override since its been fixed upstream

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -1,9 +1,5 @@
   provider :shopify,
     ShopifyApp.configuration.api_key,
     ShopifyApp.configuration.secret,
-
-    :redirect_uri => ShopifyApp.configuration.redirect_uri,
-
-    :callback_url => ShopifyApp.configuration.redirect_uri,
-
-    :scope => ShopifyApp.configuration.scope
+    redirect_uri: ShopifyApp.configuration.redirect_uri,
+    scope: ShopifyApp.configuration.scope


### PR DESCRIPTION
thanks to #185 and the new omniauth gem we don't need to set the callback url any more.

@clayton-shopify @christhomson 