### PR TITLE
version bump after markup modernization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+6.4.0
+-----
+
+* More semantic and accessible markup in the sessions/new, embedded_app, and product
+  index views.
+* Moved all JavaScript to load at the bottom of the page instead of the head, for
+  page loading better performance.
+
 6.3.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ $ bundle exec spring stop
 
 Run shopify_app generator again.
 
+Testing an embedded app outside the Shopify admin
+-------------------------------------------------
+
+By default, loading your embedded app will redirect to the Shopify admin, with the app view loaded in an `iframe`. If you need to load your app outside of the Shopify admin (e.g., for performance testing), you can change `forceRedirect: false` to `true` in `ShopifyApp.init` block in the `embedded_app` view. To keep the redirect on in production but off in your `development` and `test` environments, you can use:
+
+```javascript
+forceRedirect: <%= Rails.env.development? || Rails.env.test? ? 'false' : 'true' %>
+```
 
 Questions or problems?
 ----------------------

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -25,7 +25,7 @@
         apiKey: "<%= ShopifyApp.configuration.api_key %>",
         shopOrigin: "<%= "https://#{ @shop_session.url }" if @shop_session %>",
         debug: <%= Rails.env.development? ? 'true' : 'false' %>,
-        forceRedirect: <%= Rails.env.development? || Rails.env.test? ? 'false' : 'true' %>
+        forceRedirect: false
       });
     </script>
 

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '6.3.0'
+  VERSION = '6.4.0'
 end


### PR DESCRIPTION
This PR updates some of the generated view markup and gets the output a little closer to how we use these apps. This is based on what we’re currently doing in channels, so forgive me if I'm making some faulty assumptions about what other apps might do.

Changes:

* more semantic/accessible markup
* remove the flash layout view, since we're no longer exposing errors in this way
* move render-blocking javascript to the bottom of the page to improve render time
* version bump, since some of this could be considered breaking changes (especially the flash message stuff)

closes https://github.com/Shopify/assets/issues/262

@kevinhughes27 @Shopify/channels-fed 