### PR TITLE
Markup for embedded app view

### DIFF
--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -8,7 +8,14 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="app-wrapper">
+      <div class="app-content">
+        <main role="main">
+          <%= yield %>
+        </main>
+      </div>
+    </div>
+
     <%= render 'layouts/flash_messages' %>
 
     <script src="//cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>Shopify Embedded Example App</title>
-
     <%= stylesheet_link_tag 'application' %>
     <%= csrf_meta_tags %>
   </head>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -3,7 +3,16 @@
   <head>
     <title>Shopify Embedded Example App</title>
 
+    <%= stylesheet_link_tag 'application' %>
+    <%= csrf_meta_tags %>
+  </head>
+
+  <body>
+    <%= yield %>
+    <%= render 'layouts/flash_messages' %>
+
     <script src="//cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
+
     <script type="text/javascript">
       ShopifyApp.init({
         apiKey: "<%= ShopifyApp.configuration.api_key %>",
@@ -12,13 +21,6 @@
       });
     </script>
 
-    <%= stylesheet_link_tag 'application' %>
     <%= javascript_include_tag 'application' %>
-    <%= csrf_meta_tags %>
-  </head>
-
-  <body>
-    <%= yield %>
-    <%= render 'layouts/flash_messages' %>
   </body>
 </html>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Shopify Embedded Example App</title>
+  <head>
+    <title>Shopify Embedded Example App</title>
 
-  <script src="//cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
-  <script type="text/javascript">
-    ShopifyApp.init({
-      apiKey: "<%= ShopifyApp.configuration.api_key %>",
-      shopOrigin: "<%= "https://#{ @shop_session.url }" if @shop_session %>",
-      debug: <%= Rails.env.development? ? 'true' : 'false' %>
-    });
-  </script>
+    <script src="//cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
+    <script type="text/javascript">
+      ShopifyApp.init({
+        apiKey: "<%= ShopifyApp.configuration.api_key %>",
+        shopOrigin: "<%= "https://#{ @shop_session.url }" if @shop_session %>",
+        debug: <%= Rails.env.development? ? 'true' : 'false' %>
+      });
+    </script>
 
-  <%= stylesheet_link_tag 'application' %>
-  <%= javascript_include_tag 'application' %>
-  <%= csrf_meta_tags %>
-</head>
+    <%= stylesheet_link_tag 'application' %>
+    <%= javascript_include_tag 'application' %>
+    <%= csrf_meta_tags %>
+  </head>
 
-<body>
-  <%= yield %>
-  <%= render 'layouts/flash_messages' %>
-</body>
+  <body>
+    <%= yield %>
+    <%= render 'layouts/flash_messages' %>
+  </body>
 </html>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -17,10 +17,17 @@
       ShopifyApp.init({
         apiKey: "<%= ShopifyApp.configuration.api_key %>",
         shopOrigin: "<%= "https://#{ @shop_session.url }" if @shop_session %>",
-        debug: <%= Rails.env.development? ? 'true' : 'false' %>
+        debug: <%= Rails.env.development? ? 'true' : 'false' %>,
+        forceRedirect: <%= Rails.env.development? || Rails.env.test? ? 'false' : 'true' %>
       });
     </script>
 
-    <%= javascript_include_tag 'application' %>
+    <%= javascript_include_tag 'application', "data-turbolinks-track" => true %>
+
+    <% if content_for?(:javascript) %>
+      <div id="ContentForJavascript" data-turbolinks-temporary>
+        <%= yield :javascript %>
+      </div>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
Breaking up #194 into smaller PRs. This one moves to more performant/semantic/accessible markup for the embedded app view that’s consistent with what we’re doing in channels apps.

@kevinhughes27 @Shopify/channels-fed