### PR TITLE
yield ready javascript

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -76,7 +76,7 @@ module ShopifyApp
         if embedded_app?
           prepend_to_file(
             'app/views/home/index.html.erb',
-            File.read(File.expand_path(find_in_source_paths('shopify_app_ready_script.html')))
+            File.read(File.expand_path(find_in_source_paths('shopify_app_ready_script.html.erb')))
           )
         end
       end

--- a/lib/generators/shopify_app/install/templates/shopify_app_ready_script.html
+++ b/lib/generators/shopify_app/install/templates/shopify_app_ready_script.html
@@ -1,8 +1,0 @@
-<script type="text/javascript">
-  ShopifyApp.ready(function(){
-    ShopifyApp.Bar.initialize({
-      title: "Home",
-      icon: "<%= asset_path('favicon.ico') %>"
-    });
-  });
-</script>

--- a/lib/generators/shopify_app/install/templates/shopify_app_ready_script.html.erb
+++ b/lib/generators/shopify_app/install/templates/shopify_app_ready_script.html.erb
@@ -1,0 +1,11 @@
+<% content_for :javascript do %>
+  <script type="text/javascript">
+    ShopifyApp.ready(function(){
+      ShopifyApp.Bar.initialize({
+        title: "Home",
+        icon: "<%= asset_path('favicon.ico') %>"
+      });
+    });
+  </script>
+<% end %>
+


### PR DESCRIPTION
Breaking up #194 into smaller PRs. This one puts the `ready` JS into a `content_for :javascript` block. Depends on the `yield :javascript` in #198.

@kevinhughes27 @Shopify/channels-fed