### PR TITLE
Embedded app default layout

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -53,10 +53,15 @@ module ShopifyApp
       end
 
       def inject_into_application_controller
+        injection = "  include ShopifyApp::Controller\n"
+        if embedded_app?
+          injection << "  layout \"embedded_app\"\n"
+        end
+
         inject_into_class(
           "app/controllers/application_controller.rb",
           'ApplicationController',
-          "  include ShopifyApp::Controller\n"
+          injection
         )
       end
 

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -63,7 +63,15 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "injects into application controller" do
+  test "injects into application controller for embedded app" do
+    run_generator
+    assert_file "app/controllers/application_controller.rb" do |controller|
+      assert_match "  include ShopifyApp::Controller\n  layout \"embedded_app\"\n", controller
+    end
+  end
+
+  test "injects into application controller for non-embedded app" do
+    stub_embedded_false
     run_generator
     assert_file "app/controllers/application_controller.rb" do |controller|
       assert_match "  include ShopifyApp::Controller\n", controller
@@ -73,7 +81,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "creates the embedded_app layout" do
     run_generator
     assert_file "app/views/layouts/embedded_app.html.erb"
-    assert_file "app/views/layouts/_flash_messages.html.erb"
   end
 
   test "creates the home controller" do


### PR DESCRIPTION
Breaking up #194 into smaller PRs. This makes `embedded_app` the default layout if `embedded_app?` is `true`.

There was discussion in the other thread about the best way to handle this. I’m no Ruby dev, so I’ll defer to you smart people on this — feel free to suggest changes or even add commits to this branch.

@christianblais @gmalette @kevinhughes27 @Shopify/channels-fed