### PR TITLE
yield flash message js

### DIFF
--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,3 +1,4 @@
+<% content_for :javascript do %>
 <script type="text/javascript">
   var eventName = typeof(Turbolinks) !== 'undefined' ? 'page:change' : 'DOMContentLoaded';
 
@@ -11,3 +12,4 @@
     <% end %>
   });
 </script>
+<% end %>


### PR DESCRIPTION
Breaking up #194 into smaller PRs. Decided to leave the flash message stuff more or less alone since banners would require the assets gem. This PR just puts the flash JS into a content_for :javascript block.

@kevinhughes27 @Shopify/channels-fed