### PR TITLE
Adds ScripttagManager and job to auto create ScriptTag on shop creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ rails g shopify_app:add_webhook -t carts/update -a https://example.com/webhooks/
 
 where `-t` is the topic and `-a` is the address the webhook should be sent to.
 
+ScripttagsManager
+-----------------
+
+As with webhooks, ShopifyApp can manage your app's scripttags for you by setting which scripttags you require in the initializer:
+
+```ruby
+ShopifyApp.configure do |config|
+  config.scripttags = [
+    {event:'onload', src: 'https://my-shopifyapp.herokuapp.com/fancy.js'}
+  ]
+end
+```
+
+Scripttags are created in the same way as the Webhooks, with a background job which will create the required scripttags.
+
 ShopifyApp::SessionRepository
 -----------------------------
 

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -12,6 +12,7 @@ require 'shopify_app/engine'
 
 # jobs
 require 'shopify_app/webhooks_manager_job'
+require 'shopify_app/scripttags_manager_job'
 
 # helpers and concerns
 require 'shopify_app/shop'

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -19,6 +19,7 @@ require 'shopify_app/session_storage'
 require 'shopify_app/sessions_concern'
 require 'shopify_app/login_protection'
 require 'shopify_app/webhooks_manager'
+require 'shopify_app/scripttags_manager'
 require 'shopify_app/webhook_verification'
 require 'shopify_app/utils'
 

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -10,6 +10,7 @@ module ShopifyApp
     attr_accessor :embedded_app
     alias_method  :embedded_app?, :embedded_app
     attr_accessor :webhooks
+    attr_accessor :scripttags
 
     # configure myshopify domain for local shopify development
     attr_accessor :myshopify_domain
@@ -20,6 +21,10 @@ module ShopifyApp
 
     def has_webhooks?
       webhooks.present?
+    end
+
+    def has_scripttags?
+      scripttags.present?
     end
   end
 

--- a/lib/shopify_app/scripttags_manager.rb
+++ b/lib/shopify_app/scripttags_manager.rb
@@ -53,7 +53,7 @@ module ShopifyApp
     def create_scripttag(attributes)
       attributes.reverse_merge!(format: 'json')
       scripttag = ShopifyAPI::ScriptTag.create(attributes)
-      raise CreationFailed, scripttag.errors.messages.join(". ") unless scripttag.persisted?
+      raise CreationFailed, scripttag.errors.full_messages.to_sentence unless scripttag.persisted?
       scripttag
     end
 

--- a/lib/shopify_app/scripttags_manager.rb
+++ b/lib/shopify_app/scripttags_manager.rb
@@ -53,7 +53,7 @@ module ShopifyApp
     def create_scripttag(attributes)
       attributes.reverse_merge!(format: 'json')
       scripttag = ShopifyAPI::ScriptTag.create(attributes)
-      raise CreationFailed unless scripttag.persisted?
+      raise CreationFailed, scripttag.errors.messages.join(". ") unless scripttag.persisted?
       scripttag
     end
 

--- a/lib/shopify_app/scripttags_manager.rb
+++ b/lib/shopify_app/scripttags_manager.rb
@@ -1,0 +1,68 @@
+module ShopifyApp
+  class ScripttagsManager
+    class CreationFailed < StandardError; end
+
+    def self.queue(shop_name, token)
+      ShopifyApp::ScripttagsManagerJob.perform_later(shop_name: shop_name, token: token)
+    end
+
+    def initialize(shop_name, token)
+      @shop_name, @token = shop_name, token
+    end
+
+    def recreate_scripttags!
+      destroy_scripttags
+      create_scripttags
+    end
+
+    def create_scripttags
+      return unless required_scripttags.present?
+
+      with_shopify_session do
+        required_scripttags.each do |scripttag|
+          create_scripttag(scripttag) unless scripttag_exists?(scripttag[:src])
+        end
+      end
+    end
+
+    def destroy_scripttags
+      with_shopify_session do
+        ShopifyAPI::ScriptTag.all.each do |scripttag|
+          ShopifyAPI::ScriptTag.delete(scripttag.id) if is_required_scripttag?(scripttag)
+        end
+      end
+      @current_scripttags = nil
+    end
+
+    private
+
+    def required_scripttags
+      ShopifyApp.configuration.scripttags
+    end
+
+    def is_required_scripttag?(scripttag)
+      required_scripttags.map{ |w| w[:src] }.include? scripttag.src
+    end
+
+    def with_shopify_session
+      ShopifyAPI::Session.temp(@shop_name, @token) do
+        yield
+      end
+    end
+
+    def create_scripttag(attributes)
+      attributes.reverse_merge!(format: 'json')
+      scripttag = ShopifyAPI::ScriptTag.create(attributes)
+      raise CreationFailed unless scripttag.persisted?
+      scripttag
+    end
+
+    def scripttag_exists?(src)
+      current_scripttags[src]
+    end
+
+    def current_scripttags
+      @current_scripttags ||= ShopifyAPI::ScriptTag.all.index_by(&:src)
+    end
+  end
+end

--- a/lib/shopify_app/scripttags_manager_job.rb
+++ b/lib/shopify_app/scripttags_manager_job.rb
@@ -1,0 +1,11 @@
+module ShopifyApp
+  class ScripttagsManagerJob < ActiveJob::Base
+    def perform(params = {})
+      shop_name = params.fetch(:shop_name)
+      token = params.fetch(:token)
+
+      manager = ScripttagsManager.new(shop_name, token)
+      manager.create_scripttags
+    end
+  end
+end

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -20,6 +20,7 @@ module ShopifyApp
         session[:shopify_domain] = shop_name
 
         WebhooksManager.queue(shop_name, token) if ShopifyApp.configuration.has_webhooks?
+        ScripttagsManager.queue(shop_name, token) if ShopifyApp.configuration.has_scripttags?
 
         flash[:notice] = "Logged in"
         redirect_to_with_fallback return_address

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -31,16 +31,6 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     end
   end
 
-  test "#create_scripttags when creating a scripttag fails and the scripttag exists, do not raise an error" do
-    scripttag = stub(persisted?: false)
-    scripttags = all_scripttag_srcs.map{|t| stub(src: t)}
-    ShopifyAPI::ScriptTag.stubs(create: scripttag, all: scripttags)
-
-    assert_nothing_raised ShopifyApp::ScripttagsManager::CreationFailed do
-      @manager.create_scripttags
-    end
-  end
-
   test "#recreate_scripttags! destroys all scripttags and recreates" do
     @manager.expects(:destroy_scripttags)
     @manager.expects(:create_scripttags)

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
+
+  setup do
+    ShopifyApp.configure do |config|
+      config.scripttags = [
+        {event: 'onload', src: 'https://example-app.com/fancy.js'},
+        {event: 'onload', src: 'https://example-app.com/foobar.js'}
+      ]
+    end
+
+    @manager = ShopifyApp::ScripttagsManager.new("regular-shop.myshopify.com", "token")
+  end
+
+  test "#create_scripttags makes calls to create scripttags" do
+    ShopifyAPI::ScriptTag.stubs(all: [])
+
+    expect_scripttag_creation('onload', 'https://example-app.com/fancy.js')
+    expect_scripttag_creation('onload', 'https://example-app.com/foobar.js')
+    @manager.create_scripttags
+  end
+
+  test "#create_scripttags when creating a scripttag fails, raises an error" do
+    ShopifyAPI::ScriptTag.stubs(all: [])
+    scripttag = stub(persisted?: false)
+    ShopifyAPI::ScriptTag.stubs(create: scripttag)
+
+    assert_raise ShopifyApp::ScripttagsManager::CreationFailed do
+      @manager.create_scripttags
+    end
+  end
+
+  test "#create_scripttags when creating a scripttag fails and the scripttag exists, do not raise an error" do
+    scripttag = stub(persisted?: false)
+    scripttags = all_scripttag_srcs.map{|t| stub(src: t)}
+    ShopifyAPI::ScriptTag.stubs(create: scripttag, all: scripttags)
+
+    assert_nothing_raised ShopifyApp::ScripttagsManager::CreationFailed do
+      @manager.create_scripttags
+    end
+  end
+
+  test "#recreate_scripttags! destroys all scripttags and recreates" do
+    @manager.expects(:destroy_scripttags)
+    @manager.expects(:create_scripttags)
+
+    @manager.recreate_scripttags!
+  end
+
+  test "#destroy_scripttags makes calls to destroy scripttags" do
+    ShopifyAPI::ScriptTag.stubs(:all).returns(Array.wrap(all_mock_scripttags.first))
+    ShopifyAPI::ScriptTag.expects(:delete).with(all_mock_scripttags.first.id)
+
+    @manager.destroy_scripttags
+  end
+
+  test "#destroy_scripttags does not destroy scripttags that do not have a matching address" do
+    ShopifyAPI::ScriptTag.stubs(:all).returns([stub(src: 'http://something-or-the-other.com/badscript.js', id: 7214109)])
+    ShopifyAPI::ScriptTag.expects(:delete).never
+
+    @manager.destroy_scripttags
+  end
+
+  private
+
+  def expect_scripttag_creation(event, src)
+    stub_scripttag = stub(persisted?: true)
+    ShopifyAPI::ScriptTag.expects(:create).with(event: event, src: src, format: 'json').returns(stub_scripttag)
+  end
+
+  def all_scripttag_srcs
+    @scripttags ||= ['https://example-app.com/fancy.js', 'https://example-app.com/foobar.js']
+  end
+
+  def all_mock_scripttags
+    [
+      stub(id: 1, src: "https://example-app.com/fancy.js", event: 'onload'),
+      stub(id: 2, src: "https://example-app.com/foobar.js", event: 'onload'),
+      
+    ]
+  end
+end

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -23,7 +23,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
 
   test "#create_scripttags when creating a scripttag fails, raises an error" do
     ShopifyAPI::ScriptTag.stubs(all: [])
-    scripttag = stub(persisted?: false, errors: stub(messages: ["Source needs to be https"]))
+    scripttag = stub(persisted?: false, errors: stub(full_messages: ["Source needs to be https"]))
     ShopifyAPI::ScriptTag.stubs(create: scripttag)
 
     assert_raise ShopifyApp::ScripttagsManager::CreationFailed do

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -23,7 +23,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
 
   test "#create_scripttags when creating a scripttag fails, raises an error" do
     ShopifyAPI::ScriptTag.stubs(all: [])
-    scripttag = stub(persisted?: false)
+    scripttag = stub(persisted?: false, errors: stub(messages: ["Source needs to be https"]))
     ShopifyAPI::ScriptTag.stubs(create: scripttag)
 
     assert_raise ShopifyApp::ScripttagsManager::CreationFailed do


### PR DESCRIPTION
resolves #209 

I've basically followed the same pattern of the WebhooksManager and WebhooksManagerJob to create a ScripttagsManager and ScripttagsManagerJob.

I've updated readme with instructions. I've tested this on my developing shopify app.

