### PR TITLE
bump rails version required

### DIFF
--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = %q{This gem is used to get quickly started with the Shopify API}
 
-  s.add_dependency('rails', '>= 3.1', '< 5.0')
+  s.add_dependency('rails', '>= 4.2', '< 5.0')
 
   s.add_runtime_dependency('shopify_api', '~> 4.0.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')


### PR DESCRIPTION
fixes #211

I briefly looked into the other option of requiring activejob manually but its not quite as simple as I'd like and I think since most people will be using this gem with new applications that it is better to bump the minimum required version of rails.

I'll release a new version after this

for review @gmalette