### PR TITLE
Adds login_url to login_protection to allow https redirection properly

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -39,14 +39,14 @@ module ShopifyApp
         head :unauthorized
       else
         session[:return_to] = request.fullpath if request.get?
-        redirect_to login_path(shop: params[:shop])
+        redirect_to login_url(shop: params[:shop])
       end
     end
 
     def close_session
       session[:shopify] = nil
       session[:shopify_domain] = nil
-      redirect_to login_path
+      redirect_to login_url
     end
 
     def login_path(params = {})
@@ -55,5 +55,10 @@ module ShopifyApp
       shopify_app.login_path(params)
     end
 
+    def login_url(params = {})
+      main_app.login_url(params)
+    rescue NoMethodError => e
+      shopify_app.login_url(params)
+    end
   end
 end

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -52,23 +52,23 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
-  test "login_again_if_different_shop removes current session and redirects to login path" do
+  test "login_again_if_different_shop removes current session and redirects to login url" do
     with_application_test_routes do
       session[:shopify] = "foobar"
       session[:shopify_domain] = "foobar"
       sess = stub(url: 'https://foobar.myshopify.com')
       ShopifyApp::SessionRepository.expects(:retrieve).returns(sess).once
       get :second_login, shop: 'other_shop'
-      assert_redirected_to @controller.send(:login_path, shop: 'other_shop')
+      assert_redirected_to @controller.send(:login_url, shop: 'other_shop')
       assert_nil session[:shopify]
       assert_nil session[:shopify_domain]
     end
   end
 
-  test '#shopify_session with no Shopify session, redirects to the login path' do
+  test '#shopify_session with no Shopify session, redirects to the login url' do
     with_application_test_routes do
       get :index, shop: 'foobar'
-      assert_redirected_to @controller.send(:login_path, shop: 'foobar')
+      assert_redirected_to @controller.send(:login_url, shop: 'foobar')
     end
   end
 


### PR DESCRIPTION
I was having a problem with my application being redirected to a path with http instead of https. This allows the full url to be passed along with the secure protocol on this redirection. 