### PR TITLE
use https for esdk include

### DIFF
--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -18,7 +18,7 @@
 
     <%= render 'layouts/flash_messages' %>
 
-    <script src="//cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
+    <script src="https://cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
 
     <script type="text/javascript">
       ShopifyApp.init({


### PR DESCRIPTION
This include has been like this in our examples forever as far as I know but it recently started working (I did a bit of digging and it looks like chrome is getting more strict about mixed content now). This updates the generator to explicitly use https to grab the ESDK

@celsodantas @kmcphillips 