### PR TITLE
Securely compare webhook hmac

### DIFF
--- a/lib/shopify_app/webhooks_controller.rb
+++ b/lib/shopify_app/webhooks_controller.rb
@@ -19,7 +19,7 @@ module ShopifyApp
     def hmac_valid?(data)
       secret = ShopifyApp.configuration.secret
       digest = OpenSSL::Digest.new('sha256')
-      ActiveSupport::SecurityUtils.secure_compare(
+      ActiveSupport::SecurityUtils.variable_size_secure_compare(
         shopify_hmac,
         Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
       )

--- a/lib/shopify_app/webhooks_controller.rb
+++ b/lib/shopify_app/webhooks_controller.rb
@@ -13,14 +13,16 @@ module ShopifyApp
       request.body.rewind
       data = request.body.read
 
-      unless validate_hmac(ShopifyApp.configuration.secret, data)
-        head :unauthorized
-      end
+      return head :unauthorized unless hmac_valid?(data)
     end
 
-    def validate_hmac(secret, data)
-      digest  = OpenSSL::Digest.new('sha256')
-      shopify_hmac == Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
+    def hmac_valid?(data)
+      secret = ShopifyApp.configuration.secret
+      digest = OpenSSL::Digest.new('sha256')
+      ActiveSupport::SecurityUtils.secure_compare(
+        shopify_hmac,
+        Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
+      )
     end
 
     def shop_domain

--- a/test/shopify_app/webhooks_controller_test.rb
+++ b/test/shopify_app/webhooks_controller_test.rb
@@ -22,7 +22,7 @@ class WebhooksControllerTest < ActionController::TestCase
   test "#carts_update should verify request" do
     with_application_test_routes do
       data = {foo: :bar}.to_json
-      @controller.expects(:validate_hmac).with('secret', data.to_s).returns(true)
+      @controller.expects(:hmac_valid?).with(data.to_s).returns(true)
       post :carts_update, data
       assert_response :ok
     end
@@ -31,7 +31,7 @@ class WebhooksControllerTest < ActionController::TestCase
   test "un-verified request returns unauthorized" do
     with_application_test_routes do
       data = {foo: :bar}.to_json
-      @controller.expects(:validate_hmac).with('secret', data.to_s).returns(false)
+      @controller.expects(:hmac_valid?).with(data.to_s).returns(false)
       post :carts_update, data
       assert_response :unauthorized
     end


### PR DESCRIPTION
This PR updates `WebhookController` so we use ` ActiveSupport::SecurityUtils.secure_compare` to compare webhook data with the actual HMAC. This improves our ability to handle timing attacks.

@kevinhughes27 @djoume Please review.