### PR TITLE
remove routes, views and controllers generators from the all generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ Now we are ready to run any of the shopify_app generators. The following section
 Generators
 ----------
 
+### Default Generator
+
+The default generator will run the `install`, `shop`, and `home_controller` generators. This is the recommended way to start your app.
+
+```sh
+$ rails generate shopify_app -api_key=<your_api_key> -secret=<your_app_secret>
+```
+
+
 ### Install Generator
 
 ```sh
@@ -93,15 +102,19 @@ The install generator doesn't create any database models for you and if you are 
 
 *Note that you will need to run rake db:migrate after this generator*
 
+
+### Home Controller Generator
+
+```sh
+$ rails generate shopify_app:home_controller
+```
+
+This generator creates an example home controller and view which fetches and displays products using the ShopifyAPI
+
+
 ### Controllers, Routes and Views
 
-The last group of generators are for your convenience when you want to start overriding code included as part of the Rails engine. For example by default the engine provides a simple SessionController, if you run the `rails generate shopify_app:controllers` generator then this code gets copied out into your app so you can start adding to it. Routes and views follow the exact same pattern.
-
-
-### Default Generator
-
-If you just run `rails generate shopify_app` then all the generators will be run for you. This is how we do it internally!
-
+The last group of generators are for your convenience if you want to start overriding code included as part of the Rails engine. For example by default the engine provides a simple SessionController, if you run the `rails generate shopify_app:controllers` generator then this code gets copied out into your app so you can start adding to it. Routes and views follow the exact same pattern.
 
 
 Managing Api Keys

--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -1,7 +1,6 @@
 module ShopifyApp
   module Generators
     class ShopifyAppGenerator < Rails::Generators::Base
-
       def initialize(args, *options)
         @opts = options.first
         super(args, *options)
@@ -9,14 +8,9 @@ module ShopifyApp
 
       def run_all_generators
         generate "shopify_app:install #{@opts.join(' ')}"
-        generate "shopify_app:home_controller"
         generate "shopify_app:shop_model"
-
-        generate "shopify_app:controllers"
-        generate "shopify_app:views"
-        generate "shopify_app:routes"
+        generate "shopify_app:home_controller"
       end
-
     end
   end
 end

--- a/test/generators/shopify_app_generator.rb
+++ b/test/generators/shopify_app_generator.rb
@@ -1,15 +1,12 @@
 require 'test_helper'
 require 'generators/shopify_app/shopify_app_generator'
 
-class ViewsGeneratorTest < Rails::Generators::TestCase
-  tests ShopifyApp::Generators::ViewsGenerator
+class ShopifyAppGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::ShopifyAppGenerator
   destination File.expand_path("../tmp", File.dirname(__FILE__))
   setup :prepare_destination
 
-  test "copies ShopifyApp views to the host application" do
+  test "shopify_app_generator runs" do
     run_generator
-    assert_directory "app/views"
-    assert_file "app/views/sessions/new.html.erb"
   end
-
 end


### PR DESCRIPTION
for the upcoming major version bump I am removing the controller, views and routes generator from the default all generator. Its unlikely that a developer needs to run these generators and it is preferred to let the engine own as much code as possible.

This is similar to how devise (probably the most popular engine) handles things.

I updated the readme to explain the process better.

@Krystosterone @gmalette 