### PR TITLE
add add_webhook generator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * rename SessionsController module to SessionsConcern
 * more robust redirects, with valid HTML in HTTP response bodies
 * `ShopifyApp::Controller` has been removed. You’ll need to replace all includes of `ShopifyApp::Controller` with `ShopifyApp::LoginProtection`
+* adds add_webhook generator to make it easier to add new webhooks to your app
 
 6.4.2
 -----

--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ The module skips the `verify_authenticity_token` before_action and adds an actio
 
 The WebhooksManager uses ActiveJob, if ActiveJob is not configured then by default Rails will run the jobs inline. However it is highly recommended to configure a proper background processing queue like sidekiq or resque in production.
 
+ShopifyApp can create webhooks for you using the `add_webhook` generator. This will add the new webhook to your config and create the required job class for you.
+
+```
+rails g shopify_app:add_webhook -t carts/update -a https://example.com/webhooks/carts_update
+```
+
+where `-t` is the topic and `-a` is the address the webhook should be sent to.
 
 ShopifyApp::SessionRepository
 -----------------------------

--- a/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
@@ -1,0 +1,61 @@
+require 'rails/generators/base'
+
+module ShopifyApp
+  module Generators
+    class AddWebhookGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+
+      class_option :topic, type: :string, aliases: "-t", required: true
+      class_option :address, type: :string, aliases: "-a", required: true
+
+      def init_webhook_config
+        initializer = load_initializer
+        return if initializer.include?("config.webhooks")
+
+        inject_into_file(
+          'config/initializers/shopify_app.rb',
+          "  config.webhooks = [\n  ]\n",
+          before: 'end'
+        )
+      end
+
+      def inject_webhook_to_shopify_app_initializer
+        inject_into_file(
+          'config/initializers/shopify_app.rb',
+          webhook_config,
+          after: "config.webhooks = ["
+        )
+
+        initializer = load_initializer
+
+        unless initializer.include?(webhook_config)
+          shell.say "Error adding webhook to config. Add this line manually: #{webhook_config}", :red
+        end
+      end
+
+      def add_webhook_job
+        @job_file_name = address.split('/').last + '_job'
+        @job_class_name  = @job_file_name.classify
+        template 'webhook_job.rb', "app/jobs/#{@job_file_name}.rb"
+      end
+
+      private
+
+      def load_initializer
+        File.read(File.join(destination_root, 'config/initializers/shopify_app.rb'))
+      end
+
+      def webhook_config
+        "\n    {topic: '#{topic}', address: '#{address}', format: 'json'},"
+      end
+
+      def topic
+        options['topic']
+      end
+
+      def address
+        options['address']
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb
+++ b/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb
@@ -1,0 +1,8 @@
+class <%= @job_class_name %> < ActiveJob::Base
+  def perform(shop_domain:, webhook:)
+    shop = Shop.find_by(shopify_domain: shop_domain)
+
+    shop.with_shopify_session do
+    end
+  end
+end

--- a/test/app_templates/config/initializers/shopify_app_with_webhooks.rb
+++ b/test/app_templates/config/initializers/shopify_app_with_webhooks.rb
@@ -1,0 +1,9 @@
+ShopifyApp.configure do |config|
+  config.api_key = "key"
+  config.secret = "secret"
+  config.scope = 'read_orders, read_products'
+  config.embedded_app = true
+  config.webhooks = [
+    {topic: 'carts/update', address: 'https://example.com/webhooks/carts_update', format: 'json'}
+  ]
+end

--- a/test/generators/add_webhook_generator_test.rb
+++ b/test/generators/add_webhook_generator_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'generators/shopify_app/add_webhook/add_webhook_generator'
+
+class AddWebhookGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::AddWebhookGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+  arguments %w(-t products/update -a https://example.com/webhooks/product_update)
+
+  setup do
+    prepare_destination
+  end
+
+  test "adds new webhook to config without exisiting webhooks" do
+    provide_existing_initializer_file
+
+    run_generator
+
+    assert_file "config/initializers/shopify_app.rb" do |config|
+      assert_match 'config.webhooks = [', config
+      assert_match new_webhook, config
+    end
+  end
+
+  test "adds new webhook to config exisiting webhooks" do
+    provide_existing_initializer_file_with_webhooks
+
+    run_generator
+
+    assert_file "config/initializers/shopify_app.rb" do |config|
+      assert_match 'config.webhooks = [', config
+      assert_match exisiting_webhook, config
+      assert_match new_webhook, config
+    end
+  end
+
+  test "adds the webhook job" do
+    provide_existing_initializer_file
+
+    run_generator
+
+    assert_directory "app/jobs"
+    assert_file "app/jobs/product_update_job.rb" do |job|
+      assert_match 'class ProductUpdateJob < ActiveJob::Base', job
+    end
+  end
+
+  private
+
+  def exisiting_webhook
+    "{topic: 'carts/update', address: 'https://example.com/webhooks/carts_update', format: 'json'}"
+  end
+
+  def new_webhook
+    "{topic: 'products/update', address: 'https://example.com/webhooks/product_update', format: 'json'}"
+  end
+end

--- a/test/generators/routes_generator_test.rb
+++ b/test/generators/routes_generator_test.rb
@@ -8,7 +8,6 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
   setup do
     prepare_destination
     provide_existing_routes_file
-    provide_existing_initializer_file
   end
 
   test "copies ShopifyApp routes to the host application" do

--- a/test/support/generator_test_helpers.rb
+++ b/test/support/generator_test_helpers.rb
@@ -17,13 +17,24 @@ module GeneratorTestHelpers
     copy_to_generator_root("config/initializers", "shopify_app.rb")
   end
 
+  def provide_existing_initializer_file_with_webhooks
+    copy_to_generator_root("config/initializers", "shopify_app_with_webhooks.rb", rename: 'shopify_app.rb')
+  end
+
   private
 
-  def copy_to_generator_root(destination, template)
+  def copy_to_generator_root(destination, template, rename: nil)
     template_file = File.join(TEMPLATE_PATH, destination, template)
     destination = File.join(destination_root, destination)
 
     FileUtils.mkdir_p(destination)
     FileUtils.cp(template_file, destination)
+
+    if rename
+      FileUtils.mv(
+        File.join(destination, template),
+        File.join(destination, rename),
+      )
+    end
   end
 end


### PR DESCRIPTION
This PR adds a generator to accompany the new code for handling webhooks added in #217.

#217 added a fairly specific and Rails style way of handling webhooks and given the convention it added I think it makes sense to add a generator to add new webhooks to your app. Its a simple generator and the code can be added manually if the docs are read and understood.

The generator:
- Adds a new webhook to your ShopifyApp config
- Adds a new webhook_job using the delegation name convention and adds the jobs perform method

For review:
@Hammadk @nwtn @gavinballard 