### PR TITLE
update install generator to use rails generator arguments properly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * more robust redirects, with valid HTML in HTTP response bodies
 * `ShopifyApp::Controller` has been removed. You’ll need to replace all includes of `ShopifyApp::Controller` with `ShopifyApp::LoginProtection`
 * adds add_webhook generator to make it easier to add new webhooks to your app
+* update the install generator to use standard rails generate arguments, usage has changed from `-api_key=your_key` to `--api_key your_key`
 
 6.4.2
 -----

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Generators
 The default generator will run the `install`, `shop`, and `home_controller` generators. This is the recommended way to start your app.
 
 ```sh
-$ rails generate shopify_app -api_key=<your_api_key> -secret=<your_app_secret>
+$ rails generate shopify_app --api_key <your_api_key> --secret <your_app_secret>
 ```
 
 
@@ -79,12 +79,12 @@ $ rails generate shopify_app:install
 
 # or optionally with arguments:
 
-$ rails generate shopify_app:install -api_key=<your_api_key> -secret=<your_app_secret>
+$ rails generate shopify_app:install --api_key <your_api_key> --secret <your_app_secret>
 ```
 
 Other options include:
 * `scope` - the Oauth access scope required for your app, eg 'read_products, write_orders'. For more information read the [docs](http://docs.shopify.com/api/tutorials/oauth)
-* `embedded` - the default is to generate an [embedded app](http://docs.shopify.com/embedded-app-sdk), if you want a legacy non-embedded app then set this to false, `-embedded false`
+* `embedded` - the default is to generate an [embedded app](http://docs.shopify.com/embedded-app-sdk), if you want a legacy non-embedded app then set this to false, `--embedded false`
 * `redirect_uri` - the default is `http://localhost:3000/auth/shopify/callback` which will allow you to develop locally. You'll need to change it to match your domain for production.
 
 You can update any of these settings later on easily, the arguments are simply for convenience.

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -6,26 +6,19 @@ module ShopifyApp
     class InstallGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
       source_root File.expand_path('../templates', __FILE__)
-      attr_reader :opts
 
-      def initialize(args, *options)
-        @opts = Hash[options.first.join(' ').scan(/--?([^=\s]+)(?:=(\S+))?/)]
-        @opts = @opts.with_indifferent_access
-        @opts.reverse_merge!(defaults)
-        super(args, *options)
-      end
-
-      def defaults
-        {
-          api_key: '<api_key>',
-          secret: '<secret>',
-          redirect_uri: 'http://localhost:3000/auth/shopify/callback',
-          scope: 'read_orders, read_products',
-          embedded: 'true'
-        }
-      end
+      class_option :api_key, type: :string, default: '<api_key>'
+      class_option :secret, type: :string, default: '<secret>'
+      class_option :redirect_uri, type: :string, default: 'http://localhost:3000/auth/shopify/callback'
+      class_option :scope, type: :string, default: 'read_orders, read_products'
+      class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer
+        @api_key = options['api_key']
+        @secret = options['secret']
+        @redirect_uri = options['redirect_uri']
+        @scope = options['scope']
+
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'
       end
 
@@ -74,7 +67,7 @@ module ShopifyApp
       private
 
       def embedded_app?
-        opts[:embedded] != 'false'
+        options['embedded'] == 'true'
       end
     end
   end

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -1,7 +1,7 @@
 ShopifyApp.configure do |config|
-  config.api_key = "<%= opts[:api_key] %>"
-  config.secret = "<%= opts[:secret] %>"
-  config.redirect_uri = "<%= opts[:redirect_uri] %>"
-  config.scope = "<%= opts[:scope] %>"
+  config.api_key = "<%= @api_key %>"
+  config.secret = "<%= @secret %>"
+  config.redirect_uri = "<%= @redirect_uri %>"
+  config.scope = "<%= @scope %>"
   config.embedded_app = <%= embedded_app? %>
 end


### PR DESCRIPTION
This PR cleans up the way the install generator receives arguments to use the code built into Rails. The install generator will also match the new add_webhook (#227) generator in terms of args now. I also cleaned up the tests and they are now easier to read and better test the generator since the args are passed in correctly.

This is sort of a breaking change since it affects how to use the generators but most users only do this once and we are already about to ship a major version.

@Hammadk @nwtn 