### PR TITLE
remove the redirect uri param

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * `ShopifyApp::Controller` has been removed. You’ll need to replace all includes of `ShopifyApp::Controller` with `ShopifyApp::LoginProtection`
 * adds add_webhook generator to make it easier to add new webhooks to your app
 * update the install generator to use standard rails generate arguments, usage has changed from `-api_key=your_key` to `--api_key your_key`
+* remove the redirect uri - this is done automatically inside omniauth now
 
 6.4.2
 -----

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -56,7 +56,7 @@ bundle install
 -------------------------------
 ```
 use the keys from your app in the partners area
-rails generate shopify_app -api_key=a366cbafaccebd2f615aebdfc932fa1c -secret=8750306a895b3dbc7f4136c2ae2ea293 -redirect_uri=https://<name>.herokuapp.com/auth/shopify/callback
+rails generate shopify_app --api_key a366cbafaccebd2f615aebdfc932fa1c --secret 8750306a895b3dbc7f4136c2ae2ea293
 git add .
 git commit -m 'generated shopify app'
 ```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ $ rails generate shopify_app:install --api_key <your_api_key> --secret <your_app
 Other options include:
 * `scope` - the Oauth access scope required for your app, eg 'read_products, write_orders'. For more information read the [docs](http://docs.shopify.com/api/tutorials/oauth)
 * `embedded` - the default is to generate an [embedded app](http://docs.shopify.com/embedded-app-sdk), if you want a legacy non-embedded app then set this to false, `--embedded false`
-* `redirect_uri` - the default is `http://localhost:3000/auth/shopify/callback` which will allow you to develop locally. You'll need to change it to match your domain for production.
 
 You can update any of these settings later on easily, the arguments are simply for convenience.
 
@@ -128,7 +127,6 @@ The `install` generator places your Api credentials directly into the shopify_ap
 ShopifyApp.configure do |config|
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
-  config.redirect_uri = "http://localhost:3000/auth/shopify/callback"
   config.scope = 'read_customers, read_orders, write_products'
   config.embedded_app = true
 end

--- a/example/config/initializers/omniauth.rb
+++ b/example/config/initializers/omniauth.rb
@@ -2,6 +2,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :shopify,
     ShopifyApp.configuration.api_key,
     ShopifyApp.configuration.secret,
-    redirect_uri: ShopifyApp.configuration.redirect_uri,
     scope: ShopifyApp.configuration.scope
 end

--- a/example/config/initializers/shopify_app.rb
+++ b/example/config/initializers/shopify_app.rb
@@ -1,7 +1,6 @@
 ShopifyApp.configure do |config|
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
-  config.redirect_uri = "http://localhost:3000/auth/shopify/callback"
   config.scope = 'read_customers, read_orders, write_products'
   config.embedded_app = true
 end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -9,14 +9,12 @@ module ShopifyApp
 
       class_option :api_key, type: :string, default: '<api_key>'
       class_option :secret, type: :string, default: '<secret>'
-      class_option :redirect_uri, type: :string, default: 'http://localhost:3000/auth/shopify/callback'
       class_option :scope, type: :string, default: 'read_orders, read_products'
       class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer
         @api_key = options['api_key']
         @secret = options['secret']
-        @redirect_uri = options['redirect_uri']
         @scope = options['scope']
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -1,7 +1,6 @@
 ShopifyApp.configure do |config|
   config.api_key = "<%= @api_key %>"
   config.secret = "<%= @secret %>"
-  config.redirect_uri = "<%= @redirect_uri %>"
   config.scope = "<%= @scope %>"
   config.embedded_app = <%= embedded_app? %>
 end

--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -1,5 +1,4 @@
   provider :shopify,
     ShopifyApp.configuration.api_key,
     ShopifyApp.configuration.secret,
-    redirect_uri: ShopifyApp.configuration.redirect_uri,
     scope: ShopifyApp.configuration.scope

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -6,7 +6,6 @@ module ShopifyApp
     # `config/initializers/shopify_app.rb`
     attr_accessor :api_key
     attr_accessor :secret
-    attr_accessor :redirect_uri
     attr_accessor :scope
     attr_accessor :embedded_app
     alias_method  :embedded_app?, :embedded_app

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -17,18 +17,16 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.api_key = "<api_key>"', shopify_app
       assert_match 'config.secret = "<secret>"', shopify_app
-      assert_match 'config.redirect_uri = "http://localhost:3000/auth/shopify/callback"', shopify_app
       assert_match 'config.scope = "read_orders, read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
     end
   end
 
   test "creates the ShopifyApp initializer with args" do
-    run_generator %w(--api_key key --secret shhhhh --scope read_orders,write_products --redirect_uri http://example.com/auth/shopify/callback)
+    run_generator %w(--api_key key --secret shhhhh --scope read_orders,write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.api_key = "key"', shopify_app
       assert_match 'config.secret = "shhhhh"', shopify_app
-      assert_match 'config.redirect_uri = "http://example.com/auth/shopify/callback"', shopify_app
       assert_match 'config.scope = "read_orders,write_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
     end


### PR DESCRIPTION
closes #203

The `redirect_uri` param was added in https://github.com/Shopify/shopify_app/pull/152 since Shopify required this param as of Shopify/shopify#46095. Omniauth was originally not sending this parameter correctly but it does now without us needing to set it (I didn't actually verify this addition but it does get sent now so I don't think finding the exact change in omniauth is required, also it might have been this Shopify/omniauth-shopify-oauth2/pull/32 that fixed it).

The inclusion of the `redirect_uri` parameter seemed to add to confusion for those mounting the engine at different locations (aka not `/`). I think not having it at all will be better since then anyone submounting will need to learn all the ins and outs of omniauth routing and won't be misslead by our parameter.

This was causing confusion for other developers and myself, for example this issue https://github.com/Shopify/shopify_app/issues/165

I :tophat:ed locally and my install worked fine with this new code. I would appreciate if someone else would tophat as well. I have a script that speeds up the process if you're into that https://github.com/kevinhughes27/dotfiles/blob/master/bash/aliases#L69

For review:
@dylanahsmith @clayton-shopify @EiNSTeiN- 
cc @ShayneP @joshubrown 