### PR TITLE
Fixes CSRF OmniAuth issue

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -64,7 +64,7 @@ module ShopifyApp
         <html lang="en">
           <head>
             <meta charset="utf-8" />
-            <meta http-equiv="refresh" content="0; url=#{url_json_no_quotes}">
+            <meta http-equiv="refresh" content="1; url=#{url_json_no_quotes}">
             <title>Redirecting…</title>
             <script type="text/javascript">
               window.location.href = #{url_json};
@@ -87,7 +87,7 @@ module ShopifyApp
           <html lang="en">
             <head>
               <meta charset="utf-8" />
-              <meta http-equiv="refresh" content="0; url=#{url_json_no_quotes}">
+              <meta http-equiv="refresh" content="1; url=#{url_json_no_quotes}">
               <base target="_top">
               <title>Redirecting…</title>
               <script type="text/javascript">

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -16,7 +16,7 @@ module ShopifyApp
       auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
       get :new, shop: 'my-shop'
       assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
-      assert_match /meta http-equiv=\"refresh\" content=\"0; url=#{Regexp.escape(auth_url)}\"/, response.body
+      assert_match /meta http-equiv=\"refresh\" content=\"1; url=#{Regexp.escape(auth_url)}\"/, response.body
     end
 
     test "#new should authenticate the shop if the shop param exists non embedded" do
@@ -24,7 +24,7 @@ module ShopifyApp
       auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
       get :new, shop: 'my-shop'
       assert_match /window\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
-      assert_match /meta http-equiv=\"refresh\" content=\"0; url=#{Regexp.escape(auth_url)}\"/, response.body
+      assert_match /meta http-equiv=\"refresh\" content=\"1; url=#{Regexp.escape(auth_url)}\"/, response.body
     end
 
     test "#new should trust the shop param over the current session" do
@@ -35,7 +35,7 @@ module ShopifyApp
       auth_url = "/auth/shopify?shop=#{new_shop_domain}"
       get :new, shop: new_shop_domain
       assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
-      assert_match /meta http-equiv=\"refresh\" content=\"0; url=#{Regexp.escape(auth_url)}\"/, response.body
+      assert_match /meta http-equiv=\"refresh\" content=\"1; url=#{Regexp.escape(auth_url)}\"/, response.body
     end
 
     test "#new should render a full-page if the shop param doesn't exist" do
@@ -50,7 +50,7 @@ module ShopifyApp
         auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
         post :create, shop: good_url
         assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
-        assert_match /meta http-equiv=\"refresh\" content=\"0; url=#{Regexp.escape(auth_url)}\"/, response.body
+        assert_match /meta http-equiv=\"refresh\" content=\"1; url=#{Regexp.escape(auth_url)}\"/, response.body
       end
     end
 
@@ -61,7 +61,7 @@ module ShopifyApp
         auth_url = '/auth/shopify?shop=my-shop.myshopify.io'
         post :create, shop: good_url
         assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
-        assert_match /meta http-equiv=\"refresh\" content=\"0; url=#{Regexp.escape(auth_url)}\"/, response.body
+        assert_match /meta http-equiv=\"refresh\" content=\"1; url=#{Regexp.escape(auth_url)}\"/, response.body
       end
     end
 


### PR DESCRIPTION
@nwtn @kevinhughes27 I ran into the same issue as mentioned here https://github.com/Shopify/shopify_app/issues/230?_pjax=%23js-repo-pjax-container. 

We're making 2 authentication requests and (I think) the last one is beating the first one, causing the token to be invalid. There's some mention of it in this issue here https://github.com/intridea/omniauth-oauth2/issues/58#issuecomment-55061098. 

The error I get through Heroku logs is `Authentication failure! csrf_detected: OmniAuth::Strategies::OAuth2::CallbackError, csrf_detected | CSRF detected`

I changed the refresh to 3 and had no issues, then changed it back to 0 and ran into the same issue. I then decreased from there and saw no issues with it at 1. 

I'm not certain this fixes the root cause, but it's seems to work. 

To replicate the broken version (same steps to :tophat: this branch):

1. Create a new app
2. Successfully install it on your shop
3. The app should be loaded and working
4. Close completely out of your browser
5. Re-open the browser and go back to your shop
6. Try to open the app

You should see one of a few rails error screens, all along the lines of OmniAuth. The logs are telling as well, you'll see the 2 requests fire at once. If it doesn't error the first time, try one or two more, but typically first time's the charm.