### PR TITLE
Bump ruby version to 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.0.0
+  - 2.2.4
 
 gemfile:
   - Gemfile


### PR DESCRIPTION
As of February 24th, 2016;

> **About Ruby 2.0.0**
> As it has been announced before, all support for Ruby 2.0.0 has ended today. Bug and security fixes from more recent Ruby versions will no longer be backported to 2.0.0, and no further patch release of 2.0.0 will be released.
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/

The current stable version is 2.3.0. While it introduces a lot of breaking changes (keyword arguments, frozen literals, the lonely operator, etc), I believe now is a good time to make the switch and avoid running on a deprecated version for too long. If you believe this is too much of a breaking change, I'd suggest to at least bump to 2.2.4. But I strongly believe a bump should happen.