### PR TITLE
Managers are now shopify session agnostic

### DIFF
--- a/lib/shopify_app/scripttags_manager.rb
+++ b/lib/shopify_app/scripttags_manager.rb
@@ -2,12 +2,8 @@ module ShopifyApp
   class ScripttagsManager
     class CreationFailed < StandardError; end
 
-    def self.queue(shop_name, token)
-      ShopifyApp::ScripttagsManagerJob.perform_later(shop_name: shop_name, token: token)
-    end
-
-    def initialize(shop_name, token)
-      @shop_name, @token = shop_name, token
+    def self.queue(shop_domain, shop_token)
+      ShopifyApp::ScripttagsManagerJob.perform_later(shop_domain: shop_domain, shop_token: shop_token)
     end
 
     def recreate_scripttags!
@@ -18,19 +14,16 @@ module ShopifyApp
     def create_scripttags
       return unless required_scripttags.present?
 
-      with_shopify_session do
-        required_scripttags.each do |scripttag|
-          create_scripttag(scripttag) unless scripttag_exists?(scripttag[:src])
-        end
+      required_scripttags.each do |scripttag|
+        create_scripttag(scripttag) unless scripttag_exists?(scripttag[:src])
       end
     end
 
     def destroy_scripttags
-      with_shopify_session do
-        ShopifyAPI::ScriptTag.all.each do |scripttag|
-          ShopifyAPI::ScriptTag.delete(scripttag.id) if is_required_scripttag?(scripttag)
-        end
+      ShopifyAPI::ScriptTag.all.each do |scripttag|
+        ShopifyAPI::ScriptTag.delete(scripttag.id) if is_required_scripttag?(scripttag)
       end
+
       @current_scripttags = nil
     end
 
@@ -42,12 +35,6 @@ module ShopifyApp
 
     def is_required_scripttag?(scripttag)
       required_scripttags.map{ |w| w[:src] }.include? scripttag.src
-    end
-
-    def with_shopify_session
-      ShopifyAPI::Session.temp(@shop_name, @token) do
-        yield
-      end
     end
 
     def create_scripttag(attributes)

--- a/lib/shopify_app/scripttags_manager_job.rb
+++ b/lib/shopify_app/scripttags_manager_job.rb
@@ -1,11 +1,10 @@
 module ShopifyApp
   class ScripttagsManagerJob < ActiveJob::Base
-    def perform(params = {})
-      shop_name = params.fetch(:shop_name)
-      token = params.fetch(:token)
-
-      manager = ScripttagsManager.new(shop_name, token)
-      manager.create_scripttags
+    def perform(shop_domain:, shop_token:)
+      ShopifyAPI::Session.temp(shop_domain, shop_token) do
+        manager = ScripttagsManager.new
+        manager.create_scripttags
+      end
     end
   end
 end

--- a/lib/shopify_app/webhooks_manager_job.rb
+++ b/lib/shopify_app/webhooks_manager_job.rb
@@ -1,11 +1,10 @@
 module ShopifyApp
   class WebhooksManagerJob < ActiveJob::Base
-    def perform(params = {})
-      shop_name = params.fetch(:shop_name)
-      token = params.fetch(:token)
-
-      manager = WebhooksManager.new(shop_name, token)
-      manager.create_webhooks
+    def perform(shop_domain:, shop_token:)
+      ShopifyAPI::Session.temp(shop_domain, shop_token) do
+        manager = WebhooksManager.new
+        manager.create_webhooks
+      end
     end
   end
 end

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -10,7 +10,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
       ]
     end
 
-    @manager = ShopifyApp::ScripttagsManager.new("regular-shop.myshopify.com", "token")
+    @manager = ShopifyApp::ScripttagsManager.new
   end
 
   test "#create_scripttags makes calls to create scripttags" do
@@ -67,7 +67,6 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     [
       stub(id: 1, src: "https://example-app.com/fancy.js", event: 'onload'),
       stub(id: 2, src: "https://example-app.com/foobar.js", event: 'onload'),
-      
     ]
   end
 end

--- a/test/shopify_app/webhooks_manager_test.rb
+++ b/test/shopify_app/webhooks_manager_test.rb
@@ -11,7 +11,7 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
       ]
     end
 
-    @manager = ShopifyApp::WebhooksManager.new("regular-shop.myshopify.com", "token")
+    @manager = ShopifyApp::WebhooksManager.new
   end
 
   test "#create_webhooks makes calls to create webhooks" do


### PR DESCRIPTION
Here's the solution we discussed earlier. All managers would now be session agnostic, which gives to the caller the responsibility to instantiate it. With that being done, we'll be able to expose methods such as `create_webhook` and `create_scriptag` as independent methods, without the fear to interfere with an already existing session.  

@kevinhughes27 @alanhill