### PR TITLE
Bump gemspec to require rails 4.2.6+

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+7.0.3
+-----
+
+* Bump required Rails version to >= 4.2.6 since we are now using ActiveSupport::SecurityUtils:Module
+
 7.0.2
 -----
 

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.0.2'
+  VERSION = '7.0.3'
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = %q{This gem is used to get quickly started with the Shopify API}
 
-  s.add_dependency('rails', '>= 4.2', '< 5.0')
+  s.add_dependency('rails', '>= 4.2.6', '< 5.0')
 
   s.add_runtime_dependency('shopify_api', '~> 4.0.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')


### PR DESCRIPTION
This PR closes https://github.com/Shopify/shopify_app/issues/251 by updating the required Rails version to `4.2.6`. 

@kevinhughes27 Please review.