### PR TITLE
Depend on shopify_api 4.2.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+7.0.4
+-----
+
+* Bump required shopify_api version to 4.x.
+
 7.0.3
 -----
 

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.0.3'
+  VERSION = '7.0.4'
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rails', '>= 4.2.6', '< 5.0')
 
-  s.add_runtime_dependency('shopify_api', '~> 4.0.2')
+  s.add_runtime_dependency('shopify_api', '~> 4.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Bump dependency on shopify_api to 4.2.x. The current version 4.0.2 will be a year old tomorrow...

@kevinhughes27 @christianblais 