### PR TITLE
prevents shop params from being dropped on second installation attempt

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -46,7 +46,7 @@ module ShopifyApp
     def close_session
       session[:shopify] = nil
       session[:shopify_domain] = nil
-      redirect_to_with_fallback login_url
+      redirect_to_with_fallback main_or_engine_login_url(shop: params[:shop])
     end
 
     def main_or_engine_login_url(params = {})

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -16,6 +16,10 @@ class LoginProtectionController < ActionController::Base
   def second_login
     render nothing: true
   end
+
+  def raise_unauthorized
+    raise ActiveResource::UnauthorizedAccess.new('unauthorized')
+  end
 end
 
 class LoginProtectionTest < ActionController::TestCase
@@ -86,6 +90,13 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
+  test '#shopify_session when rescuing from unauthorized access, redirects to the login url' do
+    with_application_test_routes do
+      get :raise_unauthorized, shop: 'foobar'
+      assert_redirected_to @controller.send(:main_or_engine_login_url, shop: 'foobar')
+    end
+  end
+
   private
 
   def with_application_test_routes
@@ -93,6 +104,7 @@ class LoginProtectionTest < ActionController::TestCase
       set.draw do
         get '/' => 'login_protection#index'
         get '/second_login' => 'login_protection#second_login'
+        get '/raise_unauthorized' => 'login_protection#raise_unauthorized'
       end
       yield
     end


### PR DESCRIPTION
This fixes #245 by ensuring that the shop params are passed when the app is uninstalled, but session persists.

[Screencast here](https://screenshot.click/24-12-1dekx-sljz3.mp4)

@kevinhughes27, @jamiemtdwyer for 👀 

