### PR TITLE
Make it possible to override shopify_token validation

### DIFF
--- a/lib/shopify_app/shop.rb
+++ b/lib/shopify_app/shop.rb
@@ -4,11 +4,19 @@ module ShopifyApp
 
     included do
       validates :shopify_domain, presence: true, uniqueness: true
-      validates :shopify_token, presence: true
+      if shopify_token_needs_to_exist?
+        validates :shopify_token, presence: true
+      end
     end
 
     def with_shopify_session(&block)
       ShopifyAPI::Session.temp(shopify_domain, shopify_token, &block)
+    end
+
+    module ClassMethods
+      def shopify_token_needs_to_exist?
+        true
+      end
     end
 
   end


### PR DESCRIPTION
I have run into a situation where I wanted to create Shop records that didn't have `shopify_token` created  just yet. Turns out I cannot save a record without them, because the `validates presence: true` condition needs to be satisfied.

This change will check if token **needs** to exist by exposing a class method.

Please review: @kevinhughes27 @j-mutter 