### PR TITLE
Use around_action and fix deprecation warnings

### DIFF
--- a/app/controllers/shopify_app/authenticated_controller.rb
+++ b/app/controllers/shopify_app/authenticated_controller.rb
@@ -1,7 +1,7 @@
 module ShopifyApp
   class AuthenticatedController < ApplicationController
     before_action :login_again_if_different_shop
-    around_filter :shopify_session
+    around_action :shopify_session
     layout ShopifyApp.configuration.embedded_app? ? 'embedded_app' : 'application'
   end
 end


### PR DESCRIPTION
Rails 5 deprecated all `_filter` callbacks in favour of `_action`.

@kevinhughes27 