### PR TITLE
add Shop.connect helper method

### DIFF
--- a/lib/shopify_app/shop.rb
+++ b/lib/shopify_app/shop.rb
@@ -12,13 +12,8 @@ module ShopifyApp
     end
 
     def connect
-      ShopifyAPI::Base.activate_session(
-        ShopifyAPI::Session.new(
-          ShopifyApp::Utils.sanitize_shop_domain(shopify_domain),
-          shopify_token
-        )
-      )
-      nil
+      session = ShopifyAPI::Session.new(shopify_domain, shopify_token)
+      ShopifyAPI::Base.activate_session(session)
     end
 
   end

--- a/lib/shopify_app/shop.rb
+++ b/lib/shopify_app/shop.rb
@@ -11,5 +11,15 @@ module ShopifyApp
       ShopifyAPI::Session.temp(shopify_domain, shopify_token, &block)
     end
 
+    def connect
+      ShopifyAPI::Base.activate_session(
+        ShopifyAPI::Session.new(
+          ShopifyApp::Utils.sanitize_shop_domain(shopify_domain),
+          shopify_token
+        )
+      )
+      nil
+    end
+
   end
 end


### PR DESCRIPTION
I use this method a lot when I'm playing around in the console. You call `Shop.first.connect` and then you're free to make api calls to that store for the rest of your console session. Whereas you should favour using `with_shopify_session` pretty much everywhere else in your app, the `connect` method is much more convenient to use when writing throwaway code because you don't have to wrap all of your api calls in a block.