### PR TITLE
Add support for Carrier Services

### DIFF
--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -24,6 +24,7 @@ require 'shopify_app/webhooks_manager'
 require 'shopify_app/scripttags_manager'
 require 'shopify_app/carrier_services_manager'
 require 'shopify_app/webhook_verification'
+require 'shopify_app/carrier_service_verification'
 require 'shopify_app/utils'
 
 # session repository

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -13,6 +13,7 @@ require 'shopify_app/engine'
 # jobs
 require 'shopify_app/webhooks_manager_job'
 require 'shopify_app/scripttags_manager_job'
+require 'shopify_app/carrier_services_manager_job'
 
 # helpers and concerns
 require 'shopify_app/shop'
@@ -21,6 +22,7 @@ require 'shopify_app/sessions_concern'
 require 'shopify_app/login_protection'
 require 'shopify_app/webhooks_manager'
 require 'shopify_app/scripttags_manager'
+require 'shopify_app/carrier_services_manager'
 require 'shopify_app/webhook_verification'
 require 'shopify_app/utils'
 

--- a/lib/shopify_app/carrier_service_verification.rb
+++ b/lib/shopify_app/carrier_service_verification.rb
@@ -1,0 +1,35 @@
+module ShopifyApp
+  module CarrierServiceVerification
+    extend ActiveSupport::Concern
+
+    included do
+      skip_before_action :verify_authenticity_token
+      before_action :verify_request
+    end
+
+    private
+
+    def verify_request
+      data = request.raw_post
+      return head :unauthorized unless hmac_valid?(data)
+    end
+
+    def hmac_valid?(data)
+      secret = ShopifyApp.configuration.secret
+      digest = OpenSSL::Digest.new('sha256')
+      ActiveSupport::SecurityUtils.variable_size_secure_compare(
+        shopify_hmac,
+        Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
+      )
+    end
+
+    def shop_domain
+      request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN']
+    end
+
+    def shopify_hmac
+      request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
+    end
+
+  end
+end

--- a/lib/shopify_app/carrier_services_manager.rb
+++ b/lib/shopify_app/carrier_services_manager.rb
@@ -40,7 +40,7 @@ module ShopifyApp
     def create_carrier_service(attributes)
       attributes.reverse_merge!(format: 'json')
       carrier_service = ShopifyAPI::CarrierService.create(attributes)
-      binding.pry
+
       raise CreationFailed, carrier_service.errors.full_messages.to_sentence unless carrier_service.persisted?
       carrier_service
     end

--- a/lib/shopify_app/carrier_services_manager.rb
+++ b/lib/shopify_app/carrier_services_manager.rb
@@ -1,0 +1,56 @@
+module ShopifyApp
+  class CarrierServicesManager
+    class CreationFailed < StandardError; end
+
+    def self.queue(shop_domain, shop_token)
+      ShopifyApp::CarrierServicesManagerJob.perform_later(shop_domain: shop_domain, shop_token: shop_token)
+    end
+
+    def recreate_carrier_services!
+      destroy_carrier_services
+      create_carrier_services
+    end
+
+    def create_carrier_services
+      return unless required_carrier_services.present?
+
+      required_carrier_services.each do |carrier_service|
+        create_carrier_service(carrier_service) unless carrier_service_exists?(carrier_service[:name])
+      end
+    end
+
+    def destroy_carrier_services
+      ShopifyAPI::CarrierService.all.each do |carrier_service|
+        ShopifyAPI::CarrierService.delete(carrier_service.id) if is_required_carrier_service?(carrier_service)
+      end
+
+      @current_carrier_services = nil
+    end
+
+    private
+
+    def required_carrier_services
+      ShopifyApp.configuration.carrier_services
+    end
+
+    def is_required_carrier_service?(carrier_service)
+      required_carrier_services.map{ |w| w[:name] }.include? carrier_service.name
+    end
+
+    def create_carrier_service(attributes)
+      attributes.reverse_merge!(format: 'json')
+      carrier_service = ShopifyAPI::CarrierService.create(attributes)
+      binding.pry
+      raise CreationFailed, carrier_service.errors.full_messages.to_sentence unless carrier_service.persisted?
+      carrier_service
+    end
+
+    def carrier_service_exists?(name)
+      current_carrier_services[name]
+    end
+
+    def current_carrier_services
+      @current_carrier_services ||= ShopifyAPI::CarrierService.all.index_by(&:name)
+    end
+  end
+end

--- a/lib/shopify_app/carrier_services_manager.rb
+++ b/lib/shopify_app/carrier_services_manager.rb
@@ -40,7 +40,6 @@ module ShopifyApp
     def create_carrier_service(attributes)
       attributes.reverse_merge!(format: 'json')
       carrier_service = ShopifyAPI::CarrierService.create(attributes)
-
       raise CreationFailed, carrier_service.errors.full_messages.to_sentence unless carrier_service.persisted?
       carrier_service
     end

--- a/lib/shopify_app/carrier_services_manager_job.rb
+++ b/lib/shopify_app/carrier_services_manager_job.rb
@@ -1,0 +1,10 @@
+module ShopifyApp
+  class CarrierServicesManagerJob < ActiveJob::Base
+    def perform(shop_domain:, shop_token:)
+      ShopifyAPI::Session.temp(shop_domain, shop_token) do
+        manager = CarrierServicesManager.new
+        manager.create_carrier_services
+      end
+    end
+  end
+end

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -11,6 +11,7 @@ module ShopifyApp
     alias_method  :embedded_app?, :embedded_app
     attr_accessor :webhooks
     attr_accessor :scripttags
+    attr_accessor :carrier_services
 
     # configure myshopify domain for local shopify development
     attr_accessor :myshopify_domain
@@ -25,6 +26,10 @@ module ShopifyApp
 
     def has_scripttags?
       scripttags.present?
+    end
+
+    def has_carrier_services?
+      carrier_services.present?
     end
   end
 

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -21,6 +21,7 @@ module ShopifyApp
 
         WebhooksManager.queue(shop_name, token) if ShopifyApp.configuration.has_webhooks?
         ScripttagsManager.queue(shop_name, token) if ShopifyApp.configuration.has_scripttags?
+        CarrierServicesManager.queue(shop_name, token) if ShopifyApp.configuration.has_carrier_services?
 
         flash[:notice] = I18n.t('.logged_in')
         redirect_to_with_fallback return_address

--- a/test/shopify_app/carrier_service_verification_test.rb
+++ b/test/shopify_app/carrier_service_verification_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+require 'action_controller'
+require 'action_controller/base'
+
+class CarrierServiceVerificationController < ActionController::Base
+  include ShopifyApp::CarrierServiceVerification
+  def carts_update
+    head :ok
+  end
+end
+
+class CarrierServiceVerificationTest < ActionController::TestCase
+  tests CarrierServiceVerificationController
+
+  setup do
+    ShopifyApp.configure do |config|
+      config.secret = 'secret'
+    end
+  end
+
+  test "#carts_update should verify request" do
+    with_application_test_routes do
+      data = {foo: :bar}.to_json
+      digest = OpenSSL::Digest.new('sha256')
+      secret = ShopifyApp.configuration.secret
+      hmac = Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
+      @request.headers["HTTP_X_SHOPIFY_HMAC_SHA256"] = hmac
+      post :carts_update, data
+      assert_response :ok
+    end
+  end
+
+  test "un-verified request returns unauthorized" do
+    with_application_test_routes do
+      data = {foo: :bar}.to_json
+      @request.headers["HTTP_X_SHOPIFY_HMAC_SHA256"] = "invalid_hmac"
+      post :carts_update, data
+      assert_response :unauthorized
+    end
+  end
+
+  private
+
+  def with_application_test_routes
+    with_routing do |set|
+      set.draw do
+        get '/carts_update' => 'carrier_service_verification#carts_update'
+      end
+      yield
+    end
+  end
+end

--- a/test/shopify_app/carrier_services_manager_test.rb
+++ b/test/shopify_app/carrier_services_manager_test.rb
@@ -1,0 +1,100 @@
+require 'test_helper'
+
+class ShopifyApp::CarrierServicesManagerTest < ActiveSupport::TestCase
+
+  setup do
+    ShopifyApp.configure do |config|
+      config.carrier_services = [
+        {
+          name: "Example Carrier Service 1",
+          active: true,
+          service_discovery: true,
+          callback_url: "https://example-app.com/some_url_1"
+        },
+        {
+          name: "Example Carrier Service 2",
+          active: true,
+          service_discovery: true,
+          callback_url: "https://example-app.com/some_url_2"
+        }
+      ]
+    end
+
+    @manager = ShopifyApp::CarrierServicesManager.new
+  end
+
+  test "#create_carrier_services makes calls to create carrier_services" do
+    ShopifyAPI::CarrierService.stubs(all: [])
+
+    expect_carrier_service_creation('Example Carrier Service 1')
+    expect_carrier_service_creation('Example Carrier Service 2')
+
+    @manager.create_carrier_services
+  end
+
+  test "#create_carrier_services when creating a carrier_service fails, raises an error" do
+    ShopifyAPI::CarrierService.stubs(all: [])
+    carrier_service = stub(persisted?: false)
+    ShopifyAPI::CarrierService.stubs(create: carrier_service)
+
+    assert_raise ShopifyApp::CarrierServicesManager::CreationFailed do
+      @manager.create_carrier_services
+    end
+  end
+
+  test "#create_carrier_services when creating a carrier_service fails and the carrier_service exists, do not raise an error" do
+    carrier_service = stub(persisted?: false)
+    carrier_services = [
+      stub(name: "Example Carrier Service 1"),
+      stub(name: "Example Carrier Service 2"),
+    ]
+    ShopifyAPI::CarrierService.stubs(create: carrier_service, all: carrier_services)
+
+    assert_nothing_raised ShopifyApp::CarrierServicesManager::CreationFailed do
+      @manager.create_carrier_services
+    end
+  end
+
+  test "#recreate_carrier_services! destroys all carrier_services and recreates" do
+    @manager.expects(:destroy_carrier_services)
+    @manager.expects(:create_carrier_services)
+
+    @manager.recreate_carrier_services!
+  end
+
+  test "#destroy_carrier_services makes calls to destroy carrier_services" do
+    ShopifyAPI::CarrierService.stubs(:all).returns(Array.wrap(all_mock_carrier_services.first))
+    ShopifyAPI::CarrierService.expects(:delete).with(all_mock_carrier_services.first.id)
+
+    @manager.destroy_carrier_services
+  end
+
+  test "#destroy_carrier_services does not destroy carrier_services that do not have a matching address" do
+    ShopifyAPI::CarrierService.stubs(:all).returns([
+      stub(name: 'Some Other Carrier Service', id: 7214109)
+    ])
+    ShopifyAPI::CarrierService.expects(:delete).never
+
+    @manager.destroy_carrier_services
+  end
+
+  private
+
+  def expect_carrier_service_creation(name)
+    stub_carrier_service = stub(persisted?: true)
+    ShopifyAPI::CarrierService.expects(:create).with(name: name).returns(stub_carrier_service)
+  end
+
+  def all_mock_carrier_services
+    [
+      stub(
+        id: 1,
+        name: "Example Carrier Service 1",
+      ),
+      stub(
+        id: 2,
+        name: "Example Carrier Service 2",
+      ),
+    ]
+  end
+end

--- a/test/shopify_app/carrier_services_manager_test.rb
+++ b/test/shopify_app/carrier_services_manager_test.rb
@@ -34,7 +34,10 @@ class ShopifyApp::CarrierServicesManagerTest < ActiveSupport::TestCase
 
   test "#create_carrier_services when creating a carrier_service fails, raises an error" do
     ShopifyAPI::CarrierService.stubs(all: [])
-    carrier_service = stub(persisted?: false)
+    carrier_service = stub(
+      persisted?: false,
+      errors: stub(full_messages: stub(to_sentence: 'There were errors'))
+    )
     ShopifyAPI::CarrierService.stubs(create: carrier_service)
 
     assert_raise ShopifyApp::CarrierServicesManager::CreationFailed do
@@ -82,7 +85,7 @@ class ShopifyApp::CarrierServicesManagerTest < ActiveSupport::TestCase
 
   def expect_carrier_service_creation(name)
     stub_carrier_service = stub(persisted?: true)
-    ShopifyAPI::CarrierService.expects(:create).with(name: name).returns(stub_carrier_service)
+    ShopifyAPI::CarrierService.expects(:create).with(has_entry(name: name)).returns(stub_carrier_service)
   end
 
   def all_mock_carrier_services


### PR DESCRIPTION
Adds `CarrierServicesManager`, `CarrierServicesManagerJob`, `CarrierServiceVerification` and adds a call to `CarrierServicesManager.queue` from `SessionsConcern`. Also adds associated tests.

A couple of notes:
- There may be potential for adding routes and a controller, similar to what is done with webhooks. Delegating to jobs wouldn't work though because unlike webhooks, carrier_service requests need to be processed before responding. For now, we can just provide `CarrierServiceVerification`, until a useful pattern emerges.
- As mentioned in #280, there is lots of duplication with webhooks and scripttags. Adding CarrierServiceVerification was actually just a copy/paste + find/replace of WebhookVerification. Whether this code gets merged in its current state or not, we'll want to abstract away the common points soon before it gets to difficult to maintain. (Once this and #270 get merged, there will be the same code in 4 different places!)
