### PR TITLE
Travis CI - test multiple Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 rvm:
   - 2.2.4
+  - 2.3.1
 
 gemfile:
   - Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
+cache: bundler
+sudo: false
 
 rvm:
   - 2.2.4
 
 gemfile:
   - Gemfile
-
-script: "bundle exec rake test"
+  - Gemfile.rails50

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'rails', '~> 5.0'
+gem 'activeresource', github: 'rails/activeresource'

--- a/lib/shopify_app/app_proxy_verification.rb
+++ b/lib/shopify_app/app_proxy_verification.rb
@@ -3,7 +3,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      skip_before_action :verify_authenticity_token
+      skip_before_action :verify_authenticity_token, raise: false
       before_action :verify_proxy_request
     end
 

--- a/lib/shopify_app/webhook_verification.rb
+++ b/lib/shopify_app/webhook_verification.rb
@@ -3,7 +3,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      skip_before_action :verify_authenticity_token
+      skip_before_action :verify_authenticity_token, raise: false
       before_action :verify_request
     end
 

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -8,8 +8,9 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = %q{This gem is used to get quickly started with the Shopify API}
 
-  s.add_dependency('rails', '>= 4.2.6')
+  s.required_ruby_version = ">= 2.2.4"
 
+  s.add_runtime_dependency('rails', '>= 4.2.6')
   s.add_runtime_dependency('shopify_api', '~> 4.2.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -38,7 +38,7 @@ module ShopifyApp
     test "#new should render a full-page if the shop param doesn't exist" do
       get :new
       assert_response :ok
-      assert_template :new
+      assert_match %r{Shopify App — Installation}, response.body
     end
 
     ['my-shop', 'my-shop.myshopify.com', 'https://my-shop.myshopify.com', 'http://my-shop.myshopify.com'].each do |good_url|


### PR DESCRIPTION
Ref: https://github.com/Shopify/shopify_app/pull/288

Adds a Gemfile to ensure we're testing against Rails `~> 5.0`. Even though it's the latest version, this gem will still resolve to Rails `4.2.6` by default.

This also adds Ruby `2.3.1` to be tested in Travis.

/cc @kevinhughes27