### PR TITLE
Pass Config to Webhook and Scripttag Managers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 7.0.10
 -----
-
+* Pass configured resources (like webhooks or scripttags) into the job rather than reading the config again. This allows for dynamically setting ShopifyApp config in a web request and having the job handle it correctly. This change does not affect the usage of webhooks or scripttags
 * Loosen Rails dependency requirements to `>= 4.2.6` and allow Rails 5.0
 * Add support for App Proxies
 

--- a/lib/shopify_app/scripttags_manager.rb
+++ b/lib/shopify_app/scripttags_manager.rb
@@ -2,8 +2,18 @@ module ShopifyApp
   class ScripttagsManager
     class CreationFailed < StandardError; end
 
-    def self.queue(shop_domain, shop_token)
-      ShopifyApp::ScripttagsManagerJob.perform_later(shop_domain: shop_domain, shop_token: shop_token)
+    def self.queue(shop_domain, shop_token, scripttags)
+      ShopifyApp::ScripttagsManagerJob.perform_later(
+        shop_domain: shop_domain,
+        shop_token: shop_token,
+        scripttags: scripttags
+      )
+    end
+
+    attr_reader :required_scripttags
+
+    def initialize(scripttags)
+      @required_scripttags = scripttags
     end
 
     def recreate_scripttags!
@@ -28,10 +38,6 @@ module ShopifyApp
     end
 
     private
-
-    def required_scripttags
-      ShopifyApp.configuration.scripttags
-    end
 
     def is_required_scripttag?(scripttag)
       required_scripttags.map{ |w| w[:src] }.include? scripttag.src

--- a/lib/shopify_app/scripttags_manager_job.rb
+++ b/lib/shopify_app/scripttags_manager_job.rb
@@ -1,8 +1,8 @@
 module ShopifyApp
   class ScripttagsManagerJob < ActiveJob::Base
-    def perform(shop_domain:, shop_token:)
+    def perform(shop_domain:, shop_token:, scripttags:)
       ShopifyAPI::Session.temp(shop_domain, shop_token) do
-        manager = ScripttagsManager.new
+        manager = ScripttagsManager.new(scripttags)
         manager.create_scripttags
       end
     end

--- a/lib/shopify_app/webhooks_manager.rb
+++ b/lib/shopify_app/webhooks_manager.rb
@@ -46,7 +46,7 @@ module ShopifyApp
     def create_webhook(attributes)
       attributes.reverse_merge!(format: 'json')
       webhook = ShopifyAPI::Webhook.create(attributes)
-      raise CreationFailed unless webhook.persisted?
+      raise CreationFailed, webhook.errors.full_messages.to_sentence unless webhook.persisted?
       webhook
     end
 

--- a/lib/shopify_app/webhooks_manager.rb
+++ b/lib/shopify_app/webhooks_manager.rb
@@ -2,8 +2,18 @@ module ShopifyApp
   class WebhooksManager
     class CreationFailed < StandardError; end
 
-    def self.queue(shop_domain, shop_token)
-      ShopifyApp::WebhooksManagerJob.perform_later(shop_domain: shop_domain, shop_token: shop_token)
+    def self.queue(shop_domain, shop_token, webhooks)
+      ShopifyApp::WebhooksManagerJob.perform_later(
+        shop_domain: shop_domain,
+        shop_token: shop_token,
+        webhooks: webhooks
+      )
+    end
+
+    attr_reader :required_webhooks
+
+    def initialize(webhooks)
+      @required_webhooks = webhooks
     end
 
     def recreate_webhooks!
@@ -28,10 +38,6 @@ module ShopifyApp
     end
 
     private
-
-    def required_webhooks
-      ShopifyApp.configuration.webhooks
-    end
 
     def is_required_webhook?(webhook)
       required_webhooks.map{ |w| w[:address] }.include? webhook.address

--- a/lib/shopify_app/webhooks_manager_job.rb
+++ b/lib/shopify_app/webhooks_manager_job.rb
@@ -1,8 +1,8 @@
 module ShopifyApp
   class WebhooksManagerJob < ActiveJob::Base
-    def perform(shop_domain:, shop_token:)
+    def perform(shop_domain:, shop_token:, webhooks:)
       ShopifyAPI::Session.temp(shop_domain, shop_token) do
-        manager = WebhooksManager.new
+        manager = WebhooksManager.new(webhooks)
         manager.create_webhooks
       end
     end

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -24,9 +24,11 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     scripttag = stub(persisted?: false, errors: stub(full_messages: ["Source needs to be https"]))
     ShopifyAPI::ScriptTag.stubs(create: scripttag)
 
-    assert_raise ShopifyApp::ScripttagsManager::CreationFailed do
+    e = assert_raise ShopifyApp::ScripttagsManager::CreationFailed do
       @manager.create_scripttags
     end
+
+    assert_equal 'Source needs to be https', e.message
   end
 
   test "#recreate_scripttags! destroys all scripttags and recreates" do

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -3,14 +3,12 @@ require 'test_helper'
 class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
 
   setup do
-    ShopifyApp.configure do |config|
-      config.scripttags = [
-        {event: 'onload', src: 'https://example-app.com/fancy.js'},
-        {event: 'onload', src: 'https://example-app.com/foobar.js'}
-      ]
-    end
+    @scripttags = [
+      {event: 'onload', src: 'https://example-app.com/fancy.js'},
+      {event: 'onload', src: 'https://example-app.com/foobar.js'}
+    ]
 
-    @manager = ShopifyApp::ScripttagsManager.new
+    @manager = ShopifyApp::ScripttagsManager.new(@scripttags)
   end
 
   test "#create_scripttags makes calls to create scripttags" do

--- a/test/shopify_app/webhooks_manager_test.rb
+++ b/test/shopify_app/webhooks_manager_test.rb
@@ -24,12 +24,14 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
 
   test "#create_webhooks when creating a webhook fails, raises an error" do
     ShopifyAPI::Webhook.stubs(all: [])
-    webhook = stub(persisted?: false)
+    webhook = stub(persisted?: false, errors: stub(full_messages: ['topic already taken']))
     ShopifyAPI::Webhook.stubs(create: webhook)
 
-    assert_raise ShopifyApp::WebhooksManager::CreationFailed do
+    e = assert_raise ShopifyApp::WebhooksManager::CreationFailed do
       @manager.create_webhooks
     end
+
+    assert_equal 'topic already taken', e.message
   end
 
   test "#create_webhooks doesn't create webhooks that are already created" do


### PR DESCRIPTION
Currently our resource managers read the configuration from ShopifyApp directly to determine what they need to do which works fine in environments where this config is static (this covers probably 95% of use cases). We have some applications that host multiple Shopify Apps where this is not the case and blocks us from using the managers (One use case for multiple apps is integrations where each integration warrants a spot in the app store and a separate experience for the user but a lot of code can be shared on the backend eg. accounting export).

The solution to this problem is to pass the configuration into the manager before creating the resources. This way if the ShopifyApp config is changed by the controller the most up to date information is used by the manager. As a bonus its also easier to test the managers now 😄 

For review:
@t6d @MarcLapierre 
cc @mikeyhew @redronin