### PR TITLE
App Proxy Generator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
-7.0.12
+7.1.0
 ------
-* Don't include ShopifyApp::LoginProtection in Application controller.
+* Add new optional App Proxy Controller Generator to the Engine. Refer README for details
+* Don't include ShopifyApp::LoginProtection in Application controller
   Include in Authenticate and Session Controller directly.
+* Loosen ShopifyAPI dependency requirements to '>= 4.2.2' and allow ShopifyAPI 4.3.0 and above
 * Add ability to override the ActiveJob queue names in initializer file
 
 7.0.11

--- a/lib/generators/shopify_app/app_proxy_controller/app_proxy_controller_generator.rb
+++ b/lib/generators/shopify_app/app_proxy_controller/app_proxy_controller_generator.rb
@@ -1,0 +1,25 @@
+require 'rails/generators/base'
+
+module ShopifyApp
+  module Generators
+    class AppProxyControllerGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+
+      def create_app_proxy_controller
+        template 'app_proxy_controller.rb', 'app/controllers/app_proxy_controller.rb'
+      end
+
+      def create_app_proxy_index_view
+        copy_file 'index.html.erb', 'app/views/app_proxy/index.html.erb'
+      end
+
+      def add_app_proxy_route
+        inject_into_file(
+          'config/routes.rb',
+          File.read(File.expand_path(find_in_source_paths('app_proxy_route.rb'))),
+          after: "mount ShopifyApp::Engine, at: '/'\n"
+        )  			 
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/app_proxy_controller/templates/app_proxy_controller.rb
+++ b/lib/generators/shopify_app/app_proxy_controller/templates/app_proxy_controller.rb
@@ -1,0 +1,8 @@
+class AppProxyController < ApplicationController
+   include ShopifyApp::AppProxyVerification
+
+  def index
+    render layout: false, content_type: 'application/liquid'
+  end
+
+end

--- a/lib/generators/shopify_app/app_proxy_controller/templates/app_proxy_route.rb
+++ b/lib/generators/shopify_app/app_proxy_controller/templates/app_proxy_route.rb
@@ -1,0 +1,10 @@
+
+  namespace :app_proxy do
+    root action: 'index'
+    # simple routes without a specified controller will go to AppProxyController
+    
+    # more complex routes will go to controllers in the AppProxy namespace
+    # 	resources :reviews
+    # GET /app_proxy/reviews will now be routed to
+    # AppProxy::ReviewsController#index, for example
+  end

--- a/lib/generators/shopify_app/app_proxy_controller/templates/index.html.erb
+++ b/lib/generators/shopify_app/app_proxy_controller/templates/index.html.erb
@@ -1,0 +1,19 @@
+<h2>App Proxy Page</h2>
+
+<p>Congratulations! You have successfully configured App Proxy for your shopify application.</p>
+<p>Any valid liquid code included in this page will be parsed and rendered by Shopify.</p>
+
+<br>
+
+<pre>
+Your Shop Details:
+<hr>
+	Shop Name 			: {{ shop.name }}
+	myshopify name 			: {{ shop.permanent_domain }}
+	Primary Domain of Shop 		: {{ shop.domain }}
+	Shop URL 			: {{ shop.url }}
+	Shop Currency 			: {{ shop.currency }}
+	No. of products in this shop 	: {{ shop.products_count }}
+<br>	
+<hr>	
+</pre>

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.0.11'
+  VERSION = '7.1.0'
 end

--- a/test/generators/app_proxy_controller_generator_test.rb
+++ b/test/generators/app_proxy_controller_generator_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+require 'generators/shopify_app/app_proxy_controller/app_proxy_controller_generator'
+
+class AppProxyControllerGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::AppProxyControllerGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+
+  setup do
+    prepare_destination
+    provide_existing_routes_file
+  end
+
+  test "creates the app_proxy controller" do
+    run_generator
+    assert_file "app/controllers/app_proxy_controller.rb"
+  end
+
+  test "creates the app_proxy index view" do
+    run_generator
+    assert_file "app/views/app_proxy/index.html.erb"
+  end
+
+  test "adds app_proxy route to routes" do
+    run_generator
+    assert_file "config/routes.rb" do |routes|
+      assert_match "mount ShopifyApp::Engine, at: '/'\n", routes
+      assert "namespace :app_proxy do\n", routes
+    end
+  end
+
+end


### PR DESCRIPTION
This branch deals with the addition of an optional App Proxy Controller Generator that is based on existing generators within shopify_app.

It creates:

- The AppProxyController which inherits from ApplicationController and conditionally includes the AppProxyVerification mixin alongwith sending "Content-Type='application/liquid'" header for only production environment.
- The associated view for index action that displays current shop info.

Additionally it injects the namespace route for the controller as currently defined into the routes.rb.