### PR TITLE
soften shopify_api dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,15 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.2.4
   - 2.3.1
 
 gemfile:
   - Gemfile
   - Gemfile.rails50
+
+matrix:
+  include:
+  - rvm: 2.2.4
+    gemfile: Gemfile.ruby22
+  - rvm: 2.2.4
+    gemfile: Gemfile.ruby22.rails50

--- a/Gemfile.ruby22
+++ b/Gemfile.ruby22
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in shopify_app.gemspec
+gemspec
+
+gem 'shopify_api', '< 4.3'

--- a/Gemfile.ruby22.rails50
+++ b/Gemfile.ruby22.rails50
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in shopify_app.gemspec
+gemspec
+
+gem 'rails', '~> 5.0'
+gem 'activeresource', github: 'rails/activeresource'
+
+gem 'shopify_api', '< 4.3'

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.4"
 
   s.add_runtime_dependency('rails', '>= 4.2.6')
-  s.add_runtime_dependency('shopify_api', '>= 4.2.2', '< 5.0')
+  s.add_runtime_dependency('shopify_api', '>= 4.2.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 
   s.add_development_dependency('rake')

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.4"
 
   s.add_runtime_dependency('rails', '>= 4.2.6')
-  s.add_runtime_dependency('shopify_api', '~> 4.2.2')
+  s.add_runtime_dependency('shopify_api', '>= 4.2.2', '< 5.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Allows `shopify_api` versions above 4.2 while disallowing < 4.2.2, fixing the regression in 13d92a8415b1f08d260a529b762077b04f3dd619