### PR TITLE
Add installation note about rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ $ bundle install
 Now we are ready to run any of the shopify_app generators. The following section explains the generators and what they can do.
 
 
+#### Rails 5
+
+shopify_app is compatible with Rails 5 but since the latest ActiveResource release (4.1) is locked on Rails 4.x, you'll need to use the unreleased master version:
+
+```ruby
+gem 'shopify_app'
+gem 'activeresource', github: 'rails/activeresource'
+```
+
+
 Generators
 ----------
 


### PR DESCRIPTION
Closes #287 

Adds the rails 5 installation note from `shopify_api`. 
https://github.com/Shopify/shopify_api#rails-5

@kevinhughes27 