### PR TITLE
only include login protection where required

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 7.0.12
 ------
+* Don't include ShopifyApp::LoginProtection in Application controller.
+  Include in Authenticate and Session Controller directly.
 * Add ability to override the ActiveJob queue names in initializer file
 
 7.0.11

--- a/app/controllers/shopify_app/authenticated_controller.rb
+++ b/app/controllers/shopify_app/authenticated_controller.rb
@@ -1,5 +1,6 @@
 module ShopifyApp
   class AuthenticatedController < ApplicationController
+    include ShopifyApp::LoginProtection
     before_action :login_again_if_different_shop
     around_action :shopify_session
     layout ShopifyApp.configuration.embedded_app? ? 'embedded_app' : 'application'

--- a/example/app/controllers/application_controller.rb
+++ b/example/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  include ShopifyApp::LoginProtection
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -43,14 +43,6 @@ module ShopifyApp
         end
       end
 
-      def inject_into_application_controller
-        inject_into_class(
-          "app/controllers/application_controller.rb",
-          'ApplicationController',
-          "  include ShopifyApp::LoginProtection\n"
-        )
-      end
-
       def create_embedded_app_layout
         if embedded_app?
           copy_file 'embedded_app.html.erb', 'app/views/layouts/embedded_app.html.erb'

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -2,6 +2,10 @@ module ShopifyApp
   module SessionsConcern
     extend ActiveSupport::Concern
 
+    included do
+      include ShopifyApp::LoginProtection
+    end
+
     def new
       authenticate if params[:shop].present?
     end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -69,13 +69,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "injects into application controller" do
-    run_generator
-    assert_file "app/controllers/application_controller.rb" do |controller|
-      assert_match "  include ShopifyApp::LoginProtection\n", controller
-    end
-  end
-
   test "creates the embedded_app layout" do
     run_generator
     assert_file "app/views/layouts/embedded_app.html.erb"


### PR DESCRIPTION
I recently made this change in some of my apps and think it belongs up stream. With this change ShopifyApp only modifies controllers it owns and it doesn't make anything any harder for the developer.

SessionsController and AuthenticatedController (both in the ShopifyApp namespace) require the module and therefore include it. Other controllers that inherit from ApplicationController don't have to worry about any name clash or added behaviour.

I ran an install flow 🎩  locally

For review:
@SebastianSzturo @alexcoco 