### PR TITLE
Add application_name config and update sessions#new view copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Loosen ShopifyAPI dependency requirements to `>= 4.2.2` and allow ShopifyAPI 4.3.0 and above.
 * Move application.js to inside HEAD in Embedded App Template.
 * Add ability to override the ActiveJob queue names in initializer file.
+* Add application_name configuration option
+* Update login page copy
 
 7.0.11
 ------

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Shopify App
 
 
 Shopify Application Rails engine and generator
- 
-  
+
+
 Table of Contents
 -----------------
 * [**Description**](#description)
@@ -177,6 +177,7 @@ The `install` generator places your Api credentials directly into the shopify_ap
 
 ```ruby
 ShopifyApp.configure do |config|
+  config.application_name = 'Your app name' # Optional
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
   config.scope = 'read_customers, read_orders, write_products'
@@ -262,7 +263,7 @@ The engine provides a mixin for verifying incoming HTTP requests sent via an App
 ### Recommended Usage
 
 The App Proxy Controller Generator automatically adds the mixin to the generated app_proxy_controller.rb
-Additional controllers for resources within the App_Proxy namespace, will need to include the mixin like so: 
+Additional controllers for resources within the App_Proxy namespace, will need to include the mixin like so:
 
 ```ruby
 # app/controllers/app_proxy/reviews_controller.rb

--- a/app/views/shopify_app/sessions/new.html.erb
+++ b/app/views/shopify_app/sessions/new.html.erb
@@ -76,15 +76,16 @@
 
   <main class="container" role="main">
     <header>
-      <h1>Shopify App — Installation</h1>
+      <% application_name = ShopifyApp.configuration.application_name %>
+      <h1><%= application_name.presence || 'Shopify App – Installation' %></h1>
       <p class="subhead">
-        <label for="shop">Please enter the “myshopify” domain of your store</label>
+        <label for="shop">Enter your shop domain to log in or install this app.</label>
       </p>
     </header>
 
     <div class="container__form">
       <form method="GET" action="login">
-        <input type="text" name="shop" id="shop" placeholder="blabla.myshopify.com"/>
+        <input type="text" name="shop" id="shop" placeholder="example.myshopify.com"/>
         <button type="submit">Install</button>
       </form>
     </div>

--- a/example/config/initializers/shopify_app.rb
+++ b/example/config/initializers/shopify_app.rb
@@ -1,4 +1,5 @@
 ShopifyApp.configure do |config|
+  config.application_name = 'Example App'
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
   config.scope = 'read_customers, read_orders, write_products'

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -4,6 +4,7 @@ module ShopifyApp
     # Shopify App settings. These values should match the configuration
     # for the app in your Shopify Partners page. Change your settings in
     # `config/initializers/shopify_app.rb`
+    attr_accessor :application_name
     attr_accessor :api_key
     attr_accessor :secret
     attr_accessor :scope


### PR DESCRIPTION
@kevinhughes27 /cc @christianblais 

This adds a new configuration field called `application_name`. This name will be used (if present) on the login page instead of "Shopify App – Installation". I've also updated the copy on the login page.

### Before

<img width="490" alt="screen shot 2016-07-25 at 4 20 07 pm" src="https://cloud.githubusercontent.com/assets/898172/17116068/0fdca618-5284-11e6-8ec0-31fe858c20c0.png">

### After

<img width="438" alt="screen shot 2016-07-25 at 4 18 05 pm" src="https://cloud.githubusercontent.com/assets/898172/17116069/0fdccd1e-5284-11e6-97f0-12354a41f56f.png">
