### PR TITLE
Add new application_name option to the app generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ $ rails generate shopify_app:install --api_key <your_api_key> --secret <your_app
 ```
 
 Other options include:
+* `application_name` - the name of your app
 * `scope` - the Oauth access scope required for your app, eg 'read_products, write_orders'. For more information read the [docs](http://docs.shopify.com/api/tutorials/oauth)
 * `embedded` - the default is to generate an [embedded app](http://docs.shopify.com/embedded-app-sdk), if you want a legacy non-embedded app then set this to false, `--embedded false`
 

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -7,12 +7,14 @@ module ShopifyApp
       include Rails::Generators::Migration
       source_root File.expand_path('../templates', __FILE__)
 
+      class_option :application_name, type: :string
       class_option :api_key, type: :string, default: '<api_key>'
       class_option :secret, type: :string, default: '<secret>'
       class_option :scope, type: :string, default: 'read_orders, read_products'
       class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer
+        @application_name = options['application_name']
         @api_key = options['api_key']
         @secret = options['secret']
         @scope = options['scope']

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Shopify Embedded Example App</title>
+    <% application_name = ShopifyApp.configuration.application_name %>
+    <title><%= application_name.presence || 'Embedded Shopify App Example' %></title>
     <%= stylesheet_link_tag 'application' %>
     <%= javascript_include_tag 'application', "data-turbolinks-track" => true %>
     <%= csrf_meta_tags %>

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -1,4 +1,7 @@
 ShopifyApp.configure do |config|
+<% if @application_name.present? %>
+  config.application_name = "<%= @application_name %>"
+<% end %>
   config.api_key = "<%= @api_key %>"
   config.secret = "<%= @secret %>"
   config.scope = "<%= @scope %>"

--- a/test/app_templates/config/initializers/shopify_app.rb
+++ b/test/app_templates/config/initializers/shopify_app.rb
@@ -1,4 +1,5 @@
 ShopifyApp.configure do |config|
+  config.application_name = "name"
   config.api_key = "key"
   config.secret = "secret"
   config.scope = 'read_orders, read_products'

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -23,8 +23,9 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates the ShopifyApp initializer with args" do
-    run_generator %w(--api_key key --secret shhhhh --scope read_orders,write_products)
+    run_generator %w(--application_name name --api_key key --secret shhhhh --scope read_orders,write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
+      assert_match 'config.application_name = "name"', shopify_app
       assert_match 'config.api_key = "key"', shopify_app
       assert_match 'config.secret = "shhhhh"', shopify_app
       assert_match 'config.scope = "read_orders,write_products"', shopify_app


### PR DESCRIPTION
### Add application_name option to the ShopifyApp engine
- [x] Add application_name to relevant files.
 - [x] Install Generator & its templates.
 - [x] ShopifyApp Configuration.
 - [x] Test Files.
- [x] Update ReadMe.
- [x] Green Build.