### PR TITLE
Fix #304 - Handle skip_before_action based on Rails version

### DIFF
--- a/lib/shopify_app/app_proxy_verification.rb
+++ b/lib/shopify_app/app_proxy_verification.rb
@@ -3,7 +3,12 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      skip_before_action :verify_authenticity_token, raise: false
+      if Rails.version >= '5.0'
+        skip_before_action :verify_authenticity_token, raise: false
+      else
+        skip_before_action :verify_authenticity_token
+      end
+
       before_action :verify_proxy_request
     end
 

--- a/lib/shopify_app/webhook_verification.rb
+++ b/lib/shopify_app/webhook_verification.rb
@@ -3,7 +3,12 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      skip_before_action :verify_authenticity_token, raise: false
+      if Rails.version >= '5.0'
+        skip_before_action :verify_authenticity_token, raise: false
+      else
+        skip_before_action :verify_authenticity_token
+      end
+
       before_action :verify_request
     end
 
@@ -30,6 +35,5 @@ module ShopifyApp
     def shopify_hmac
       request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
     end
-
   end
 end

--- a/test/shopify_app/app_proxy_verification_test.rb
+++ b/test/shopify_app/app_proxy_verification_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class AppProxyVerificationController < ActionController::Base
+  self.allow_forgery_protection = true
+  protect_from_forgery with: :exception
+
   include ShopifyApp::AppProxyVerification
 
   def basic

--- a/test/shopify_app/webhook_verification_test.rb
+++ b/test/shopify_app/webhook_verification_test.rb
@@ -3,7 +3,11 @@ require 'action_controller'
 require 'action_controller/base'
 
 class WebhookVerificationController < ActionController::Base
+  self.allow_forgery_protection = true
+  protect_from_forgery with: :exception
+
   include ShopifyApp::WebhookVerification
+
   def carts_update
     head :ok
   end
@@ -44,7 +48,7 @@ class WebhookVerificationTest < ActionController::TestCase
   def with_application_test_routes
     with_routing do |set|
       set.draw do
-        get '/carts_update' => 'webhook_verification#carts_update'
+        post '/carts_update' => 'webhook_verification#carts_update'
       end
       yield
     end


### PR DESCRIPTION
Fixes a regression caused in 653942f which added `raise: false` for Rails 5 compatibility.

This does end up affecting Rails 4 apps as well so now we're explicitly handling this based on Rails version.

Another issue was that the tests weren't raising this error so the regression wasn't found. This also fixes the controller tests to ensure they will raise errors in the future.

@kevinhughes27 