### PR TITLE
Add QUICKSTART to gh-pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -55,7 +55,7 @@ Check out this screencast on how to create and deploy a new Shopify App to Herok
 
 [https://vimeo.com/130247240](https://vimeo.com/130247240)
 
-Or if you prefer text instructions the steps in the video are written out [here](https://github.com/Shopify/shopify_app/blob/master/QUICKSTART.md)
+Or if you prefer text instructions, the steps in the video are written out [here](quickstart.md)
 
 Becoming a Shopify App Developer
 --------------------------------

--- a/index.md
+++ b/index.md
@@ -128,6 +128,7 @@ $ rails generate shopify_app:install --api_key <your_api_key> --secret <your_app
 ```
 
 Other options include:
+* `application_name` - the name of your app
 * `scope` - the Oauth access scope required for your app, eg 'read_products, write_orders'. For more information read the [docs](http://docs.shopify.com/api/tutorials/oauth)
 * `embedded` - the default is to generate an [embedded app](http://docs.shopify.com/embedded-app-sdk), if you want a legacy non-embedded app then set this to false, `--embedded false`
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,76 @@
+---
+layout: index
+---
+
+Quickstart
+==========
+
+Build and deploy a new Shopify App to Heroku in minutes
+
+1. New Rails App (with PostgreSQL)
+--------------------------------
+
+```
+rails new test-app --database=postgresql
+cd test-app
+git init
+git add .
+git commit -m 'new rails app'
+```
+
+2. Create a new Heroku app
+--------------------------
+
+The next step is to create a new heroku app. Pull up your heroku dashboard and make a new app!
+
+cli:
+```
+heroku create name
+heroku git:remote -a name
+  ```
+
+now we need to let git know where the remote server is so we'll be able to deploy later
+
+web:
+```
+https://dashboard.heroku.com/new
+git remote add heroku git@heroku.com:appinfive.git
+```
+
+3. Create a new App in the partners area
+-----------------------------------------
+[https://app.shopify.com/services/partners/api_clients](https://app.shopify.com/services/partners/api_clients)
+* set the callback url to `https://<name>.herokuapp.com/`
+* choose an embedded app
+* set the redirect_uri to `https://<name>.herokuapp.com/auth/shopify/callback`
+
+
+4. Add ShopifyApp to gemfile
+----------------------------
+```
+$ echo "gem 'shopify_app'" >> Gemfile
+
+bundle install
+```
+
+Note - its recommended to use the latest released version. Check the git tags to see the latest release and then add it to your Gemfile e.g `gem 'shopify_app', '~> 7.1.0'`
+
+5. Run the ShopifyApp generator
+-------------------------------
+```
+use the keys from your app in the partners area
+rails generate shopify_app --api_key a366cbafaccebd2f615aebdfc932fa1c --secret 8750306a895b3dbc7f4136c2ae2ea293
+git add .
+git commit -m 'generated shopify app'
+```
+
+6. Deploy
+---------
+```
+git push heroku
+heroku run rake db:migrate
+```
+
+7. Install the App!
+-------------------
+`https://<name>.herokuapp.com/`


### PR DESCRIPTION
Currently, the link to Quickstart follows the page on the master branch instead of gh-pages.
This PR changes that and additionally syncs the index page to README on master

- [x] Add Quickstart page
- [x] Update link href in index.md
- [x] Sync Index to README on master 