### PR TITLE
when app proxy verification fails, send 403 instead of 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+8.2.3
+-----
+* Send head :forbidden instead of :unauthorized when AppProxyVerification fails
+
 8.2.2
 -----
 * Changes how the ESDK concern allows iframes. Fixes an issue with the first request for some people

--- a/lib/shopify_app/controller_concerns/app_proxy_verification.rb
+++ b/lib/shopify_app/controller_concerns/app_proxy_verification.rb
@@ -8,7 +8,7 @@ module ShopifyApp
     end
 
     def verify_proxy_request
-      return head :unauthorized unless query_string_valid?(request.query_string)
+      return head :forbidden unless query_string_valid?(request.query_string)
     end
 
     private

--- a/test/shopify_app/controller_concerns/app_proxy_verification_test.rb
+++ b/test/shopify_app/controller_concerns/app_proxy_verification_test.rb
@@ -35,7 +35,7 @@ class AppProxyVerificationTest < ActionController::TestCase
     assert query_string_valid? 'shop=some-random-store.myshopify.com&path_prefix=%2Fapps%2Fmy-app&timestamp=1466106083&foo=bar&baz[1]&baz[2]=b&baz[c[0]]=whatup&baz[c[1]]=notmuch&signature=bbf3aa60e098f08919a2ea4c64a388414f164e6a117a63b03479ac7aa9464b4f'
   end
 
-  test 'request with invalid signature should fail' do
+  test 'request with invalid signature should fail with 403' do
     with_test_routes do
       invalid_params = {
         shop: 'some-random-store.myshopify.com',
@@ -44,7 +44,7 @@ class AppProxyVerificationTest < ActionController::TestCase
         signature: 'wrong233558b1c50102a6f33c0b63ad1e1072a2fc126cb58d4500f75223cefcd'
       }
       get :basic, params: invalid_params
-      assert_response :unauthorized
+      assert_response :forbidden
     end
   end
 


### PR DESCRIPTION
Fix for #318
