### PR TITLE
Require Ruby 2.2.2 instead of 2.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ gemfile:
 
 matrix:
   include:
-  - rvm: 2.2.4
+  - rvm: 2.2.2
     gemfile: Gemfile.ruby22
-  - rvm: 2.2.4
+  - rvm: 2.2.2
     gemfile: Gemfile.ruby22.rails50

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = %q{This gem is used to get quickly started with the Shopify API}
 
-  s.required_ruby_version = ">= 2.2.4"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.add_runtime_dependency('rails', '>= 4.2.6')
   s.add_runtime_dependency('shopify_api', '>= 4.2.2')


### PR DESCRIPTION
2.2.4 was a bit arbitrary and this matches up with Rails 5.0 better which also requires >= 2.2.2

We could tag this as 7.1.1

@kevinhughes27 

/cc @sshaw