### PR TITLE
Use more obvious method name

### DIFF
--- a/example/app/views/layouts/_flash_messages.html.erb
+++ b/example/app/views/layouts/_flash_messages.html.erb
@@ -4,11 +4,11 @@
 
     document.addEventListener(eventName, function() {
       <% if flash[:notice] %>
-        ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
+        ShopifyApp.flashNotice("<%= escape_javascript flash[:notice].html_safe %>");
       <% end %>
 
       <% if flash[:error] %>
-        ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
+        ShopifyApp.flashError("<%= escape_javascript flash[:error].html_safe %>");
       <% end %>
     });
   </script>


### PR DESCRIPTION
For this generated example, we can use `#escape_javascript` instead of `#j`, as it's more obvious what the former does.

/review @kevinhughes27 @alexcoco please