### PR TITLE
Bypass application layout rendering for SessionsController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.2.0
+-----
+* Disable application layout rendering for the `/login` page
+
 7.1.1
 -----
 * Lower required Ruby version to 2.2.2 to better match up with Rails 5.0

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -1,6 +1,5 @@
 module ShopifyApp
   class SessionsController < ApplicationController
     include ShopifyApp::SessionsConcern
-    layout false
   end
 end

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -1,5 +1,6 @@
 module ShopifyApp
   class SessionsController < ApplicationController
     include ShopifyApp::SessionsConcern
+    layout false
   end
 end

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -4,11 +4,11 @@ module ShopifyApp
 
     included do
       include ShopifyApp::LoginProtection
+      layout false, only: :new
     end
 
     def new
       authenticate if params[:shop].present?
-      render layout: false
     end
 
     def create

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -8,6 +8,7 @@ module ShopifyApp
 
     def new
       authenticate if params[:shop].present?
+      render layout: false
     end
 
     def create

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.1.1'
+  VERSION = '7.2.0'
 end


### PR DESCRIPTION
The SessionsController inherits rendering using the application layout.

By default, render with no layout at all.

/review @kevinhughes27 @alexcoco @swalkinshaw
/cc @nickhoffman 