### PR TITLE
Dynamic scripttags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.2.1
+-----
+* Add support for dynamically generating scripttag URLs
+
 7.2.0
 -----
 * Disable application layout rendering for the `/login` page

--- a/README.md
+++ b/README.md
@@ -268,11 +268,14 @@ As with webhooks, ShopifyApp can manage your app's scripttags for you by setting
 ShopifyApp.configure do |config|
   config.scripttags = [
     {event:'onload', src: 'https://my-shopifyapp.herokuapp.com/fancy.js'}
+    {event:'onload', src: ->(domain) { dynamic_tag_url(domain) } }
   ]
 end
 ```
 
 Scripttags are created in the same way as the Webhooks, with a background job which will create the required scripttags.
+
+If `src` responds to `call` its return value will be used as the scripttag's source. It will be called on scripttag creation and deletion.
 
 ShopifyApp::SessionRepository
 -----------------------------

--- a/lib/shopify_app/scripttags_manager_job.rb
+++ b/lib/shopify_app/scripttags_manager_job.rb
@@ -7,7 +7,7 @@ module ShopifyApp
 
     def perform(shop_domain:, shop_token:, scripttags:)
       ShopifyAPI::Session.temp(shop_domain, shop_token) do
-        manager = ScripttagsManager.new(scripttags)
+        manager = ScripttagsManager.new(scripttags, shop_domain)
         manager.create_scripttags
       end
     end

--- a/test/shopify_app/scripttags_manager_job_test.rb
+++ b/test/shopify_app/scripttags_manager_job_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ShopifyApp::ScripttagsManagerJobTest < ActiveSupport::TestCase
+  test "#perform creates scripttags" do
+    token = 'token'
+    domain = 'example-app.com'
+
+    ShopifyAPI::Session.expects(:temp).with(domain, token).yields
+
+    manager = mock('manager')
+    manager.expects(:create_scripttags)
+    ShopifyApp::ScripttagsManager.expects(:new).with([], domain).returns(manager)
+
+    job = ShopifyApp::ScripttagsManagerJob.new
+    job.perform(shop_domain: domain, shop_token: token, scripttags: [])
+  end
+end

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -22,7 +22,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     @manager.create_scripttags
   end
 
-  test "#create_scripttags when creating a dynamic src, does overwrite the src with its result" do
+  test "#create_scripttags when creating a dynamic src, does not overwrite the src with its result" do
     ShopifyAPI::ScriptTag.stubs(all: [])
 
     stub_scripttag = stub(persisted?: true)
@@ -76,7 +76,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     @manager.destroy_scripttags
   end
 
-  test "#destroy_scripttags when deleting a dynamic src, does overwrite the src with its result" do
+  test "#destroy_scripttags when deleting a dynamic src, does not overwrite the src with its result" do
     ShopifyAPI::ScriptTag.stubs(all: Array.wrap(all_mock_scripttags.last))
     ShopifyAPI::ScriptTag.expects(:delete).with(all_mock_scripttags.last.id)
 
@@ -108,10 +108,6 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
   def expect_scripttag_creation(event, src)
     stub_scripttag = stub(persisted?: true)
     ShopifyAPI::ScriptTag.expects(:create).with(event: event, src: src, format: 'json').returns(stub_scripttag)
-  end
-
-  def all_scripttag_srcs
-    @scripttags ||= ['https://example-app.com/fancy.js', 'https://example-app.com/foobar.js']
   end
 
   def all_mock_scripttags

--- a/test/shopify_app/scripttags_manager_test.rb
+++ b/test/shopify_app/scripttags_manager_test.rb
@@ -1,14 +1,16 @@
 require 'test_helper'
 
 class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
 
   setup do
     @scripttags = [
       {event: 'onload', src: 'https://example-app.com/fancy.js'},
-      {event: 'onload', src: 'https://example-app.com/foobar.js'}
+      {event: 'onload', src: 'https://example-app.com/foobar.js'},
+      {event: 'onload', src: ->(domain) { "https://example-app.com/#{domain}-123.js" } }
     ]
 
-    @manager = ShopifyApp::ScripttagsManager.new(@scripttags)
+    @manager = ShopifyApp::ScripttagsManager.new(@scripttags, 'example-app.com')
   end
 
   test "#create_scripttags makes calls to create scripttags" do
@@ -16,7 +18,18 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
 
     expect_scripttag_creation('onload', 'https://example-app.com/fancy.js')
     expect_scripttag_creation('onload', 'https://example-app.com/foobar.js')
+    expect_scripttag_creation('onload', "https://example-app.com/example-app.com-123.js")
     @manager.create_scripttags
+  end
+
+  test "#create_scripttags when creating a dynamic src, does overwrite the src with its result" do
+    ShopifyAPI::ScriptTag.stubs(all: [])
+
+    stub_scripttag = stub(persisted?: true)
+    ShopifyAPI::ScriptTag.expects(:create).returns(stub_scripttag).times(3)
+
+    @manager.create_scripttags
+    assert_respond_to @manager.required_scripttags.last[:src], :call
   end
 
   test "#create_scripttags when creating a scripttag fails, raises an error" do
@@ -29,6 +42,17 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     end
 
     assert_equal 'Source needs to be https', e.message
+  end
+
+  test "#create_scripttags when a script src raises an exception, it's propagated" do
+    ShopifyAPI::ScriptTag.stubs(:all).returns(all_mock_scripttags[0..1])
+    @manager.required_scripttags.last[:src] = -> (domain) { raise 'oops!' }
+
+    e = assert_raise do
+      @manager.create_scripttags
+    end
+
+    assert_equal 'oops!', e.message
   end
 
   test "#recreate_scripttags! destroys all scripttags and recreates" do
@@ -45,11 +69,38 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     @manager.destroy_scripttags
   end
 
+  test "#destroy_scripttags makes calls to destroy scripttags with a dynamic src" do
+    ShopifyAPI::ScriptTag.stubs(:all).returns(Array.wrap(all_mock_scripttags.last))
+    ShopifyAPI::ScriptTag.expects(:delete).with(all_mock_scripttags.last.id)
+
+    @manager.destroy_scripttags
+  end
+
+  test "#destroy_scripttags when deleting a dynamic src, does overwrite the src with its result" do
+    ShopifyAPI::ScriptTag.stubs(all: Array.wrap(all_mock_scripttags.last))
+    ShopifyAPI::ScriptTag.expects(:delete).with(all_mock_scripttags.last.id)
+
+    @manager.destroy_scripttags
+    assert_respond_to @manager.required_scripttags.last[:src], :call
+  end
+
   test "#destroy_scripttags does not destroy scripttags that do not have a matching address" do
     ShopifyAPI::ScriptTag.stubs(:all).returns([stub(src: 'http://something-or-the-other.com/badscript.js', id: 7214109)])
     ShopifyAPI::ScriptTag.expects(:delete).never
 
     @manager.destroy_scripttags
+  end
+
+  test ".queue enqueues a ScripttagsManagerJob" do
+    args = {
+      shop_domain: 'example-app.com',
+      shop_token: 'token',
+      scripttags: [event: 'onload', src: 'https://example-app.com/example-app.com-123.js']
+    }
+
+    assert_enqueued_with(job: ShopifyApp::ScripttagsManagerJob, args: [args]) do
+      ShopifyApp::ScripttagsManager.queue(args[:shop_domain], args[:shop_token], @scripttags[-1,1])
+    end
   end
 
   private
@@ -67,6 +118,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
     [
       stub(id: 1, src: "https://example-app.com/fancy.js", event: 'onload'),
       stub(id: 2, src: "https://example-app.com/foobar.js", event: 'onload'),
+      stub(id: 3, src: "https://example-app.com/example-app.com-123.js", event: 'onload'),
     ]
   end
 end


### PR DESCRIPTION
Should probably add a test to make sure src returned by `#call` is not cached in the global list. 

Somewhat related question: under what circumstances [does this get called](https://github.com/Shopify/shopify_app/blob/076a2966823cfa2d74179cda675ff942de707c7a/lib/shopify_app/scripttags_manager.rb#L49) as if the API cannot create a resource an exception is raised. 