### PR TITLE
add troubleshooting hint about reinstallation problems when session isn't deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ $ bundle exec spring stop
 
 Run shopify_app generator again.
 
+### App installation fails with 'The page you’re looking for could not be found' if the app was installed before
+
+This issue can occur when the session (the model you set as `ShopifyApp::SessionRepository.storage`) isn't deleted when the user uninstalls your app. A possible fix for this is listening to the `app/uninstalled` webhook and deleting the corresponding session in the webhook handler.
+
 Testing an embedded app outside the Shopify admin
 -------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -310,19 +310,7 @@ Create your app proxy url in the [Shopify Partners' Dashboard](https://app.shopi
 Troubleshooting
 ---------------
 
-### Generator shopify_app:install hangs
-
-Rails uses spring by default to speed up development. To run the generator, spring has to be stopped:
-
-```sh
-$ bundle exec spring stop
-```
-
-Run shopify_app generator again.
-
-### App installation fails with 'The page you’re looking for could not be found' if the app was installed before
-
-This issue can occur when the session (the model you set as `ShopifyApp::SessionRepository.storage`) isn't deleted when the user uninstalls your app. A possible fix for this is listening to the `app/uninstalled` webhook and deleting the corresponding session in the webhook handler.
+see [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 
 Testing an embedded app outside the Shopify admin
 -------------------------------------------------

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,16 @@
+Troubleshooting Shopify App
+===========
+
+### Generator shopify_app:install hangs
+
+Rails uses spring by default to speed up development. To run the generator, spring has to be stopped:
+
+```sh
+$ bundle exec spring stop
+```
+
+Run shopify_app generator again.
+
+### App installation fails with 'The page you’re looking for could not be found' if the app was installed before
+
+This issue can occur when the session (the model you set as `ShopifyApp::SessionRepository.storage`) isn't deleted when the user uninstalls your app. A possible fix for this is listening to the `app/uninstalled` webhook and deleting the corresponding session in the webhook handler.


### PR DESCRIPTION
When using the shopify_app gem naively, but according to documentation, the session in the app's session store will not be deleted when the app is uninstalled.

That leads to a situation where a re-installation of the app is not possible because the app still has an outdated session.

You can use the app/uninstalled hook though to delete the session and fix this problem. This PR documents that.