### PR TITLE
Use fixed-size `secure_compare` in `WebhookVerification#hmac_valid?`

### DIFF
--- a/lib/shopify_app/webhook_verification.rb
+++ b/lib/shopify_app/webhook_verification.rb
@@ -22,7 +22,7 @@ module ShopifyApp
     def hmac_valid?(data)
       secret = ShopifyApp.configuration.secret
       digest = OpenSSL::Digest.new('sha256')
-      ActiveSupport::SecurityUtils.variable_size_secure_compare(
+      ActiveSupport::SecurityUtils.secure_compare(
         shopify_hmac,
         Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
       )


### PR DESCRIPTION
`variable_size_secure_compare` exists to protect against timing attacks that could reveal the length of the inputs. Since the inputs are SHA256 hmacs, their length is already known and nothing is gained from using `variable_size_secure_compare`. Switching to `secure_compare`, which short circuits if the inputs' lengths are not the equal.