### PR TITLE
Patch install_generator to allow whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.2.1
 -----
 * Add support for dynamically generating scripttag URLs
+* Bug-fix: `--application_name` and `--scope` generates proper Configuration even when options supplied to them contain whitespaces.
 
 7.2.0
 -----

--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ $ rails generate shopify_app:install --api_key <your_api_key> --secret <your_app
 ```
 
 Other options include:
-* `application_name` - the name of your app
-* `scope` - the Oauth access scope required for your app, eg 'read_products, write_orders'. For more information read the [docs](http://docs.shopify.com/api/tutorials/oauth)
+* `application_name` - the name of your app, it can be supplied with or without double-quotes if a whitespace is present. (e.g. `--application_name Example App` or `--application_name "Example App"`)  
+* `scope` - the Oauth access scope required for your app, eg **read_products, write_orders**. *Multiple options* need to be delimited by a comma-space, and can be supplied with or without double-quotes  
+(e.g. `--scope read_products, write_orders, write_products` or `--scope "read_products, write_orders, write_products"`)  
+For more information, refer the [docs](http://docs.shopify.com/api/tutorials/oauth).
 * `embedded` - the default is to generate an [embedded app](http://docs.shopify.com/embedded-app-sdk), if you want a legacy non-embedded app then set this to false, `--embedded false`
 
 You can update any of these settings later on easily, the arguments are simply for convenience.

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -7,17 +7,20 @@ module ShopifyApp
       include Rails::Generators::Migration
       source_root File.expand_path('../templates', __FILE__)
 
-      class_option :application_name, type: :string
+      class_option :application_name, type: :array
       class_option :api_key, type: :string, default: '<api_key>'
       class_option :secret, type: :string, default: '<secret>'
-      class_option :scope, type: :string, default: 'read_orders, read_products'
+      class_option :scope, type: :array, default: ['read_orders,', 'read_products']
       class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer
-        @application_name = options['application_name']
+        #
+        # enable users to provide options containing whitespace and strip them off 'double-quotes', if present.
+        #
+        @application_name = options['application_name'].join(' ').tr('"', '') if options['application_name']
         @api_key = options['api_key']
         @secret = options['secret']
-        @scope = options['scope']
+        @scope = options['scope'].join(' ').tr('"', '')
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'
       end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -7,17 +7,14 @@ module ShopifyApp
       include Rails::Generators::Migration
       source_root File.expand_path('../templates', __FILE__)
 
-      class_option :application_name, type: :array
+      class_option :application_name, type: :array, default: ['My', 'Shopify', 'App']
       class_option :api_key, type: :string, default: '<api_key>'
       class_option :secret, type: :string, default: '<secret>'
       class_option :scope, type: :array, default: ['read_orders,', 'read_products']
       class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer
-        #
-        # enable users to provide options containing whitespace and strip them off 'double-quotes', if present.
-        #
-        @application_name = options['application_name'].join(' ').tr('"', '') if options['application_name']
+        @application_name = options['application_name'].join(' ').tr('"', '')
         @api_key = options['api_key']
         @secret = options['secret']
         @scope = options['scope'].join(' ').tr('"', '')

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -14,10 +14,10 @@ module ShopifyApp
       class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer
-        @application_name = options['application_name'].join(' ').tr('"', '')
+        @application_name = format_array_argument(options['application_name'])
         @api_key = options['api_key']
         @secret = options['secret']
-        @scope = options['scope'].join(' ').tr('"', '')
+        @scope = format_array_argument(options['scope'])
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'
       end
@@ -60,6 +60,10 @@ module ShopifyApp
 
       def embedded_app?
         options['embedded'] == 'true'
+      end
+
+      def format_array_argument(array)
+        array.join(' ').tr('"', '')
       end
     end
   end

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <% application_name = ShopifyApp.configuration.application_name %>
-    <title><%= application_name.presence || 'Embedded Shopify App Example' %></title>
+    <title><%= application_name %></title>
     <%= stylesheet_link_tag 'application' %>
     <%= javascript_include_tag 'application', "data-turbolinks-track" => true %>
     <%= csrf_meta_tags %>

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -1,7 +1,5 @@
 ShopifyApp.configure do |config|
-<% if @application_name.present? %>
   config.application_name = "<%= @application_name %>"
-<% end %>
   config.api_key = "<%= @api_key %>"
   config.secret = "<%= @secret %>"
   config.scope = "<%= @scope %>"

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -15,6 +15,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "creates the ShopifyApp initializer" do
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
+      assert_match 'config.application_name = "My Shopify App"', shopify_app
       assert_match 'config.api_key = "<api_key>"', shopify_app
       assert_match 'config.secret = "<secret>"', shopify_app
       assert_match 'config.scope = "read_orders, read_products"', shopify_app

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -23,12 +23,23 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates the ShopifyApp initializer with args" do
-    run_generator %w(--application_name name --api_key key --secret shhhhh --scope read_orders,write_products)
+    run_generator %w(--application_name Test Name --api_key key --secret shhhhh --scope read_orders, write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
-      assert_match 'config.application_name = "name"', shopify_app
+      assert_match 'config.application_name = "Test Name"', shopify_app
       assert_match 'config.api_key = "key"', shopify_app
       assert_match 'config.secret = "shhhhh"', shopify_app
-      assert_match 'config.scope = "read_orders,write_products"', shopify_app
+      assert_match 'config.scope = "read_orders, write_products"', shopify_app
+      assert_match "config.embedded_app = true", shopify_app
+    end
+  end
+
+  test "creates the ShopifyApp initializer with double-quoted args" do
+    run_generator %w(--application_name "Test Name" --api_key key --secret shhhhh --scope "read_orders, write_products")
+    assert_file "config/initializers/shopify_app.rb" do |shopify_app|
+      assert_match 'config.application_name = "Test Name"', shopify_app
+      assert_match 'config.api_key = "key"', shopify_app
+      assert_match 'config.secret = "shhhhh"', shopify_app
+      assert_match 'config.scope = "read_orders, write_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
     end
   end


### PR DESCRIPTION
A patch to address #356.

- [x] Update documentation informing users that they are able to optionally pass double-quoted options for `--application_name` but `--scope` takes a comma-space-delimitted array..