### PR TITLE
Handle empty webhook result sets

### DIFF
--- a/lib/shopify_app/webhooks_manager.rb
+++ b/lib/shopify_app/webhooks_manager.rb
@@ -30,7 +30,7 @@ module ShopifyApp
     end
 
     def destroy_webhooks
-      ShopifyAPI::Webhook.all.each do |webhook|
+      ShopifyAPI::Webhook.all.to_a.each do |webhook|
         ShopifyAPI::Webhook.delete(webhook.id) if is_required_webhook?(webhook)
       end
 

--- a/test/shopify_app/webhooks_manager_test.rb
+++ b/test/shopify_app/webhooks_manager_test.rb
@@ -50,6 +50,12 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
     @manager.recreate_webhooks!
   end
 
+  test "#destroy_webhooks doesnt freak out if there are no webhooks" do
+    ShopifyAPI::Webhook.stubs(:all).returns(nil)
+
+    @manager.destroy_webhooks
+  end
+
   test "#destroy_webhooks makes calls to destroy webhooks" do
     ShopifyAPI::Webhook.stubs(:all).returns(Array.wrap(all_mock_webhooks.first))
     ShopifyAPI::Webhook.expects(:delete).with(all_mock_webhooks.first.id)


### PR DESCRIPTION
sometimes the shopify api can return a nil to us. so lets make sure we dont try to call #each on nil.

@kevinhughes27 