### PR TITLE
Update scripttags_manager_job.rb

### DIFF
--- a/lib/shopify_app/scripttags_manager_job.rb
+++ b/lib/shopify_app/scripttags_manager_job.rb
@@ -2,7 +2,7 @@ module ShopifyApp
   class ScripttagsManagerJob < ActiveJob::Base
 
     queue_as do
-      ShopifyApp.configuration.webhooks_manager_queue_name
+      ShopifyApp.configuration.scripttags_manager_queue_name
     end
 
     def perform(shop_domain:, shop_token:, scripttags:)


### PR DESCRIPTION
Related to : https://github.com/Shopify/shopify_app/pull/298

I've implemented that a while ago and during the review process I realised I could just use `config.active_jobs.queue_name` in `application.rb` which I did (https://github.com/Shopify/shopify_app/pull/298#issuecomment-233640773)

I now have to separate webhooks and scripttag jobs into two different queues and I just realised that I did a mistake when implementing this so here is a small fix.



