### PR TITLE
Use postMessage to redirect to Shopify during authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+7.2.2
+-----
+* Use postMessage to redirect parent iframe during authentication
+  https://github.com/Shopify/shopify_app/pull/366
+
 7.2.1
 -----
 * Add support for dynamically generating scripttag URLs

--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -69,13 +69,23 @@ module ShopifyApp
         <html lang="en">
           <head>
             <meta charset="utf-8" />
+            <base target="_top">
             <title>Redirecting…</title>
             <script type="text/javascript">
-              data = JSON.stringify({
-                message: 'Shopify.API.remoteRedirect',
-                data: { location: window.location.origin + #{url.to_json} }
-              });
-              window.parent.postMessage(data, "https://#{sanitized_shop_name}");
+
+              // If the current window is the 'parent', change the URL by setting location.href
+              if (window.top == window.self) {
+                window.top.location.href = #{url.to_json};
+
+              // If the current window is the 'child', change the parent's URL with postMessage
+              } else {
+                data = JSON.stringify({
+                  message: 'Shopify.API.remoteRedirect',
+                  data: { location: window.location.origin + #{url.to_json} }
+                });
+                window.parent.postMessage(data, "https://#{sanitized_shop_name}");
+              }
+
             </script>
           </head>
           <body>

--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -97,5 +97,15 @@ module ShopifyApp
         redirect_to_with_fallback url
       end
     end
+
+    def sanitized_shop_name
+      @sanitized_shop_name ||= sanitize_shop_param(params)
+    end
+
+    def sanitize_shop_param(params)
+      return unless params[:shop].present?
+      ShopifyApp::Utils.sanitize_shop_domain(params[:shop])
+    end
+
   end
 end

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -22,10 +22,10 @@ module ShopifyApp
         install_scripttags
 
         flash[:notice] = I18n.t('.logged_in')
-        redirect_to_with_fallback return_address
+        redirect_to return_address
       else
         flash[:error] = I18n.t('could_not_log_in')
-        redirect_to_with_fallback login_url
+        redirect_to login_url
       end
     end
 
@@ -33,7 +33,7 @@ module ShopifyApp
       session[:shopify] = nil
       session[:shopify_domain] = nil
       flash[:notice] = I18n.t('.logged_out')
-      redirect_to_with_fallback login_url
+      redirect_to login_url
     end
 
     protected
@@ -42,7 +42,7 @@ module ShopifyApp
       if sanitized_shop_name.present?
         fullpage_redirect_to "#{main_app.root_path}auth/shopify?shop=#{sanitized_shop_name}"
       else
-        redirect_to_with_fallback return_address
+        redirect_to return_address
       end
     end
 

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -39,8 +39,8 @@ module ShopifyApp
     protected
 
     def authenticate
-      if shop_name = sanitize_shop_param(params)
-        fullpage_redirect_to "#{main_app.root_path}auth/shopify?shop=#{shop_name}"
+      if sanitized_shop_name.present?
+        fullpage_redirect_to "#{main_app.root_path}auth/shopify?shop=#{sanitized_shop_name}"
       else
         redirect_to_with_fallback return_address
       end
@@ -86,15 +86,6 @@ module ShopifyApp
 
     def return_address
       session.delete(:return_to) || main_app.root_url
-    end
-
-    def sanitized_shop_name
-      @sanitized_shop_name ||= sanitize_shop_param(params)
-    end
-
-    def sanitize_shop_param(params)
-      return unless params[:shop].present?
-      ShopifyApp::Utils.sanitize_shop_domain(params[:shop])
     end
 
   end

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.2.0'
+  VERSION = '7.2.2'
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -20,9 +20,9 @@ module ShopifyApp
 
     test "#new should authenticate the shop if the shop param exists non embedded" do
       ShopifyApp.configuration.embedded_app = false
-      shopify_domain = 'my-shop.myshopify.com'
+      auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
       get :new, shop: 'my-shop'
-      assert_redirected_to_authentication(shopify_domain, response)
+      assert_redirected_to auth_url
     end
 
     test "#new should trust the shop param over the current session" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -13,16 +13,16 @@ module ShopifyApp
 
     test "#new should authenticate the shop if the shop param exists" do
       ShopifyApp.configuration.embedded_app = true
-      auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
+      shopify_domain = 'my-shop.myshopify.com'
       get :new, shop: 'my-shop'
-      assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
+      assert_redirected_to_authentication(shopify_domain, response)
     end
 
     test "#new should authenticate the shop if the shop param exists non embedded" do
       ShopifyApp.configuration.embedded_app = false
-      auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
+      shopify_domain = 'my-shop.myshopify.com'
       get :new, shop: 'my-shop'
-      assert_match /window\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
+      assert_redirected_to_authentication(shopify_domain, response)
     end
 
     test "#new should trust the shop param over the current session" do
@@ -30,9 +30,8 @@ module ShopifyApp
       previously_logged_in_shop_id = 1
       session[:shopify] = previously_logged_in_shop_id
       new_shop_domain = "new-shop.myshopify.com"
-      auth_url = "/auth/shopify?shop=#{new_shop_domain}"
       get :new, shop: new_shop_domain
-      assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
+      assert_redirected_to_authentication(new_shop_domain, response)
     end
 
     test "#new should render a full-page if the shop param doesn't exist" do
@@ -44,9 +43,9 @@ module ShopifyApp
     ['my-shop', 'my-shop.myshopify.com', 'https://my-shop.myshopify.com', 'http://my-shop.myshopify.com'].each do |good_url|
       test "#create should authenticate the shop for the URL (#{good_url})" do
         ShopifyApp.configuration.embedded_app = true
-        auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
+        shopify_domain = 'my-shop.myshopify.com'
         post :create, shop: good_url
-        assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
+        assert_redirected_to_authentication(shopify_domain, response)
       end
     end
 
@@ -54,9 +53,9 @@ module ShopifyApp
       test "#create should authenticate the shop for the URL (#{good_url}) with custom myshopify_domain" do
         ShopifyApp.configuration.embedded_app = true
         ShopifyApp.configuration.myshopify_domain = 'myshopify.io'
-        auth_url = '/auth/shopify?shop=my-shop.myshopify.io'
+        shopify_domain = 'my-shop.myshopify.io'
         post :create, shop: good_url
-        assert_match /window\.top\.location\.href = "#{Regexp.escape(auth_url)}"/, response.body
+        assert_redirected_to_authentication(shopify_domain, response)
       end
     end
 
@@ -70,7 +69,6 @@ module ShopifyApp
 
     test "#create should render the login page if the shop param doesn't exist" do
       post :create
-      assert_response :redirect
       assert_redirected_to '/'
     end
 
@@ -161,5 +159,19 @@ module ShopifyApp
       request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:shopify] if request
       request.env['omniauth.params'] = { shop: 'shop.myshopify.com' } if request
     end
+
+    def assert_redirected_to_authentication(shop_domain, response)
+      auth_url = "/auth/shopify?shop=#{shop_domain}".to_json
+      target_origin = "https://#{shop_domain}".to_json
+
+      post_message_handle = "message: 'Shopify.API.remoteRedirect'"
+      post_message_data = "data: { location: window.location.origin + #{auth_url} }"
+      post_message_call = "window.parent.postMessage(data, #{target_origin});"
+
+      assert_includes response.body, post_message_handle
+      assert_includes response.body, post_message_data
+      assert_includes response.body, post_message_call
+    end
+
   end
 end

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -29,7 +29,7 @@ class LoginProtectionTest < ActionController::TestCase
     ShopifyApp::SessionRepository.storage = InMemorySessionStore
   end
 
-  test "calling shop session returns nil when session is nil" do
+  test "#shop_session returns nil when session is nil" do
     with_application_test_routes do
       session[:shopify] = nil
       get :index
@@ -37,7 +37,7 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
-  test "calling shop session retreives session from storage" do
+  test "#shop_session retreives the session from storage" do
     with_application_test_routes do
       session[:shopify] = "foobar"
       get :index
@@ -46,7 +46,7 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
-  test "shop session is memoized and does not retreive session twice" do
+  test "#shop_session is memoized and does not retreive session twice" do
     with_application_test_routes do
       session[:shopify] = "foobar"
       get :index
@@ -56,7 +56,7 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
-  test "login_again_if_different_shop removes current session and redirects to login url" do
+  test "#login_again_if_different_shop removes current session and redirects to login url" do
     with_application_test_routes do
       session[:shopify] = "foobar"
       session[:shopify_domain] = "foobar"


### PR DESCRIPTION
A recent change was proposed in [Chrome Canary 57.0.2933.0](https://github.com/WICG/interventions/issues/16) that will break embedded app authentication. 

### Proposed solution:
* Instead of using `window.location.origin` to redirect to the authentication URL, we should use ` window.parent.postMessage` (this logic is in `#fullpage_redirect_to`).

This PR won't be merged until extensively tested

Related refactor:
* This PR also replaces `#redirect_to_with_fallback` with the Rails method: `redirect_to`. `#redirect_to_with_fallback` doesn't work like we think it does. The status and location headers take priority over the inline response. The fallback only happens if the browser ignores the status and location headers -- which doesn't happen on any modern browser.
 
* This PR moves `#sanitized_shop_name` and `#sanitize_shop_param(params)` from `SessionsConcern` to `LoginProtection`. LoginProtection is already included `SessionController`.

Please see the following issue for reference: https://github.com/Shopify/shopify/issues/93680

@nwtn @peterjm @kevinhughes27 Please review 