### PR TITLE
Update shopify_api dependency version

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.2.3'
+  VERSION = '7.2.4'
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_runtime_dependency('rails', '>= 4.2.6')
-  s.add_runtime_dependency('shopify_api', '>= 4.2.2')
+  s.add_runtime_dependency('shopify_api', '>= 4.3.3')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
To get apps to Rails 5, `shopify_api` and through it `activeresource` have to be updated.

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    shopify_app (~> 7.2.3) was resolved to 7.2.3, which depends on
      shopify_api (>= 4.2.2) was resolved to 4.2.2, which depends on
        activeresource was resolved to 2.0.1, which depends on
          activesupport (= 2.0.1)
```

@Hammadk @kevinhughes27 