### PR TITLE
Sanitizes the shop param to only call authenticate on valid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.2.4
+-----
+* Fix redirect issue by sanitizing shop name on sessions#new
+
 7.2.3
 -----
 * Use postMessage to redirect parent iframe during authentication [[#366]](https://github.com/Shopify/shopify_app/pull/366)

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -8,7 +8,7 @@ module ShopifyApp
     end
 
     def new
-      authenticate if params[:shop].present?
+      authenticate if sanitized_shop_name.present?
     end
 
     def create

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -11,14 +11,14 @@ module ShopifyApp
       I18n.locale = :en
     end
 
-    test "#new should authenticate the shop if the shop param exists" do
+    test "#new should authenticate the shop if a valid shop param exists" do
       ShopifyApp.configuration.embedded_app = true
       shopify_domain = 'my-shop.myshopify.com'
       get :new, shop: 'my-shop'
       assert_redirected_to_authentication(shopify_domain, response)
     end
 
-    test "#new should authenticate the shop if the shop param exists non embedded" do
+    test "#new should authenticate the shop if a valid shop param exists non embedded" do
       ShopifyApp.configuration.embedded_app = false
       auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
       get :new, shop: 'my-shop'
@@ -36,6 +36,13 @@ module ShopifyApp
 
     test "#new should render a full-page if the shop param doesn't exist" do
       get :new
+      assert_response :ok
+      assert_match %r{Shopify App — Installation}, response.body
+    end
+
+    test "#new should render a full-page if the shop param value is not a shop" do
+      non_shop_address = "example.com"
+      get :new, shop: non_shop_address
       assert_response :ok
       assert_match %r{Shopify App — Installation}, response.body
     end


### PR DESCRIPTION
This changes sessions#new to check if the shop parameter received is valid before calling authenticate. Currently we just check if `params[:shop].present?`, but this causes some strange redirect behaviour on unexpected shop values. 

If we call an app with an invalid shop value (ex. `shop=example.com`), it will pass that to authenticate. Since `sanitized_shop_name.present?` would be false in this case, it redirects to `return_address`. If the `return_address` calls sessions#new again, this results in circular redirects.

@kevinhughes27 @gauravmc 

