### PR TITLE
Allow absolute URLs in ShopifyApp::LoginProtection.redirection_javascript

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -79,9 +79,12 @@ module ShopifyApp
 
               // If the current window is the 'child', change the parent's URL with postMessage
               } else {
+                normalizedLink = document.createElement('a');
+                normalizedLink.href = #{url.to_json};
+
                 data = JSON.stringify({
                   message: 'Shopify.API.remoteRedirect',
-                  data: { location: window.location.origin + #{url.to_json} }
+                  data: { location: normalizedLink.href }
                 });
                 window.parent.postMessage(data, "https://#{sanitized_shop_name}");
               }

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -172,10 +172,12 @@ module ShopifyApp
       target_origin = "https://#{shop_domain}".to_json
 
       post_message_handle = "message: 'Shopify.API.remoteRedirect'"
-      post_message_data = "data: { location: window.location.origin + #{auth_url} }"
+      post_message_link = "normalizedLink.href = #{auth_url}"
+      post_message_data = "data: { location: normalizedLink.href }"
       post_message_call = "window.parent.postMessage(data, #{target_origin});"
 
       assert_includes response.body, post_message_handle
+      assert_includes response.body, post_message_link
       assert_includes response.body, post_message_data
       assert_includes response.body, post_message_call
     end


### PR DESCRIPTION
The current [`ShopifyApp::LoginProtection.redirection_javascript`](https://github.com/Shopify/shopify_app/blob/e38a0e2892269f804a3768a3dc9181d34ec3eb48/lib/shopify_app/login_protection.rb#L82-L86) only allows you to pass in a relative URL (`/login`). This is because we always set the location in `#postMessage` to:
``` javascript
data: { location: window.location.origin + #{url.to_json} }
```

Instead, we need to allow absolute URLs as well (`https//SHOP.myshopify.com/admin/charges`). We create a normalized link to do this:
``` javascript
normalizedLink = document.createElement('a');
normalizedLink.href = #{url.to_json};
data: { location: normalizedLink.href }
```

Tested in the following browsers:
- [x] Canary Chrome  58
- [x] Firefox 43.0.4
- [x] Safari 10.0.3
- [x] Chrome 56
- [x] IE11 on Windows 7

Fixes https://github.com/Shopify/shopify_app/issues/387