### PR TITLE
Update LoginProtection#fullpage_redirect_to to get shopify domain from session

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -86,7 +86,7 @@ module ShopifyApp
                   message: 'Shopify.API.remoteRedirect',
                   data: { location: normalizedLink.href }
                 });
-                window.parent.postMessage(data, "https://#{sanitized_shop_name}");
+                window.parent.postMessage(data, "https://#{current_shopify_domain}");
               }
 
             </script>
@@ -95,6 +95,10 @@ module ShopifyApp
           </body>
         </html>
       )
+    end
+
+    def current_shopify_domain
+      sanitized_shop_name || session[:shopify_domain]
     end
 
     def sanitized_shop_name

--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -2,6 +2,8 @@ module ShopifyApp
   module LoginProtection
     extend ActiveSupport::Concern
 
+    class ShopifyDomainNotFound < StandardError; end
+
     included do
       rescue_from ActiveResource::UnauthorizedAccess, :with => :close_session
     end
@@ -98,7 +100,10 @@ module ShopifyApp
     end
 
     def current_shopify_domain
-      sanitized_shop_name || session[:shopify_domain]
+      shopify_domain = sanitized_shop_name || session[:shopify_domain]
+      return shopify_domain if shopify_domain.present?
+
+      raise ShopifyDomainNotFound
     end
 
     def sanitized_shop_name

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -11,6 +11,10 @@ module ShopifyApp
       I18n.locale = :en
     end
 
+    teardown do
+      ShopifyApp.configuration.embedded_app = true
+    end
+
     test "#new should authenticate the shop if a valid shop param exists" do
       ShopifyApp.configuration.embedded_app = true
       shopify_domain = 'my-shop.myshopify.com'

--- a/test/generators/home_controller_generator_test.rb
+++ b/test/generators/home_controller_generator_test.rb
@@ -29,11 +29,12 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates the home index view with embedded false" do
-    stub_embedded_false
+    ShopifyApp.configuration.embedded_app = false
     run_generator
     assert_file "app/views/home/index.html.erb" do |index|
       refute_match "ShopifyApp.ready", index
     end
+    ShopifyApp.configuration.embedded_app = true
   end
 
   test "adds home route to routes" do
@@ -42,9 +43,5 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
       assert_match "mount ShopifyApp::Engine, at: '/'", routes
       assert_match "root :to => 'home#index'", routes
     end
-  end
-
-  def stub_embedded_false
-    ShopifyApp.configuration.embedded_app = false
   end
 end

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -118,6 +118,15 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
+  test '#fullpage_redirect_to raises an exception when no Shopify domains are available' do
+    with_application_test_routes do
+      session[:shopify_domain] = nil
+      assert_raise ShopifyApp::LoginProtection::ShopifyDomainNotFound do
+        get :redirect
+      end
+    end
+  end
+
   private
 
   def assert_fullpage_redirected(shop_domain, response)

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -128,6 +128,17 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
+  test '#fullpage_redirect_to, when not an embedded app, does a regular redirect' do
+    ShopifyApp.configuration.embedded_app = false
+
+    with_application_test_routes do
+      get :redirect
+      assert_redirected_to 'https://example.com'
+    end
+
+    ShopifyApp.configuration.embedded_app = true
+  end
+
   private
 
   def assert_fullpage_redirected(shop_domain, response)

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -31,6 +31,7 @@ class LoginProtectionTest < ActionController::TestCase
 
   setup do
     ShopifyApp::SessionRepository.storage = InMemorySessionStore
+    ShopifyApp.configuration.embedded_app = true
   end
 
   test "#shop_session returns nil when session is nil" do


### PR DESCRIPTION
In https://github.com/Shopify/shopify_app/issues/398 we found that `fullpage_redirect_to` cannot be used when the `:shop` param is not present and the shop is already logged in. This PR solves this problem by grabbing the domain from the session.

At this point I am not sure if there is a better method of grabbing the domain. Another option is to`ShopifyApp::SessionRepository.retrieve(session[:shopify]).shopify_domain`

Sidenote: Our setup for `LoginProtectionTests` is pretty weird. I'd like to unit test `fullpage_redirect_to` but that's not straight forward.