### PR TITLE
Use .com domains in tests, fix flakey test

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -13,6 +13,7 @@ module ShopifyApp
 
     teardown do
       ShopifyApp.configuration.embedded_app = true
+      ShopifyApp.configuration.myshopify_domain = 'myshopify.com'
     end
 
     test "#new should authenticate the shop if a valid shop param exists" do

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -3,4 +3,5 @@ ShopifyApp.configure do |config|
   config.secret = "secret"
   config.scope = 'read_orders, read_products'
   config.embedded_app = true
+  config.myshopify_domain = 'myshopify.com'
 end

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -8,6 +8,7 @@ class ConfigurationTest < ActiveSupport::TestCase
 
   teardown do
     Rails.application.config.active_job.queue_name = nil
+    ShopifyApp.configuration.myshopify_domain = 'myshopify.com'
   end
 
   test "configure" do

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -6,6 +6,10 @@ class UtilsTest < ActiveSupport::TestCase
     ShopifyApp.configuration = nil
   end
 
+  teardown do
+    ShopifyApp.configuration.myshopify_domain = 'myshopify.com'
+  end
+
   ['my-shop', 'my-shop.myshopify.com', 'https://my-shop.myshopify.com', 'http://my-shop.myshopify.com'].each do |good_url|
     test "sanitize_shop_domain for (#{good_url})" do
       ShopifyApp.configuration.embedded_app = true


### PR DESCRIPTION
This PR fixes a flakey test that fails when another test sets `ShopifyApp.configuration.myshopify_domain = myshopify.io`. I am rushing this PR so we can get 7.2.6 out the door. I'll follow up and help refactor these tests.