### PR TITLE
Rails 5: ActionDispatch::Reloader#to_prepare is deprecated

### DIFF
--- a/example/config/initializers/shopify_session_repository.rb
+++ b/example/config/initializers/shopify_session_repository.rb
@@ -1,7 +1,9 @@
 if Rails.configuration.cache_classes
   ShopifyApp::SessionRepository.storage = Shop
 else
-  ActionDispatch::Reloader.to_prepare do
+  reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
+
+  reloader.to_prepare do
     ShopifyApp::SessionRepository.storage = Shop
   end
 end

--- a/lib/generators/shopify_app/shop_model/templates/shopify_session_repository.rb
+++ b/lib/generators/shopify_app/shop_model/templates/shopify_session_repository.rb
@@ -1,7 +1,9 @@
 if Rails.configuration.cache_classes
   ShopifyApp::SessionRepository.storage = Shop
 else
-  ActionDispatch::Reloader.to_prepare do
+  reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
+
+  reloader.to_prepare do
     ShopifyApp::SessionRepository.storage = Shop
   end
 end


### PR DESCRIPTION
When Rails 5.1 comes out, the use of `ActionDispatch::Reloader#to_prepare` here will cause the session initializer to break.

This fixes the following deprecation warning, while maintaining support for Rails 4 and below:

> DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1 (use ActiveSupport::Reloader.to_prepare instead)