### PR TITLE
Remove support for rails 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ sudo: false
 
 rvm:
   - 2.3.1
-
-gemfile:
-  - Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ rvm:
   - 2.3.1
 
 gemfile:
-  - Gemfile.rails40
-  - Gemfile.rails50
+  - Gemfile

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'rails', '>=4.2.6', '<5.0.0'

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-gemspec
-
-gem 'rails', '5.0.2'
-gem 'activeresource', github: 'rails/activeresource'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of Contents
 * [**Quickstart**](#quickstart)
 * [**Becoming a Shopify App Developer**](#becoming-a-shopify-app-developer)
 * [**Installation**](#installation)
-  * [Rails 5](#rails-5)
+  * [Rails Compatibility](#rails-compatibility)
 * [**Generators**](#generators)
  * [Default Generator](#default-generator)
  * [Install Generator](#install-generator)
@@ -94,14 +94,9 @@ $ bundle install
 Now we are ready to run any of the shopify_app generators. The following section explains the generators and what they can do.
 
 
-#### Rails 5
+#### Rails Compatibility
 
-shopify_app is compatible with Rails 5 but since the latest ActiveResource release (4.1) is locked on Rails 4.x, you'll need to use the unreleased master version:
-
-```ruby
-gem 'shopify_app'
-gem 'activeresource', github: 'rails/activeresource'
-```
+The lastest version of shopify_app is compatible with Rails `>= 5`. Use version `<= v7.2.8` if you need to work with Rails 4.
 
 
 Generators

--- a/lib/shopify_app/app_proxy_verification.rb
+++ b/lib/shopify_app/app_proxy_verification.rb
@@ -3,12 +3,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      if Rails.version >= '5.0'
-        skip_before_action :verify_authenticity_token, raise: false
-      else
-        skip_before_action :verify_authenticity_token
-      end
-
+      skip_before_action :verify_authenticity_token, raise: false
       before_action :verify_proxy_request
     end
 

--- a/lib/shopify_app/webhook_verification.rb
+++ b/lib/shopify_app/webhook_verification.rb
@@ -3,12 +3,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      if Rails.version >= '5.0'
-        skip_before_action :verify_authenticity_token, raise: false
-      else
-        skip_before_action :verify_authenticity_token
-      end
-
+      skip_before_action :verify_authenticity_token, raise: false
       before_action :verify_request
     end
 

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_runtime_dependency('rails', '>= 4.2.6')
+  s.add_runtime_dependency('rails', '>= 5.0.0')
   s.add_runtime_dependency('shopify_api', '>= 4.3.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.1.11')
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -19,14 +19,14 @@ module ShopifyApp
     test "#new should authenticate the shop if a valid shop param exists" do
       ShopifyApp.configuration.embedded_app = true
       shopify_domain = 'my-shop.myshopify.com'
-      get :new, shop: 'my-shop'
+      get :new, params: { shop: 'my-shop' }
       assert_redirected_to_authentication(shopify_domain, response)
     end
 
     test "#new should authenticate the shop if a valid shop param exists non embedded" do
       ShopifyApp.configuration.embedded_app = false
       auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
-      get :new, shop: 'my-shop'
+      get :new, params: { shop: 'my-shop' }
       assert_redirected_to auth_url
     end
 
@@ -35,7 +35,7 @@ module ShopifyApp
       previously_logged_in_shop_id = 1
       session[:shopify] = previously_logged_in_shop_id
       new_shop_domain = "new-shop.myshopify.com"
-      get :new, shop: new_shop_domain
+      get :new, params: { shop: new_shop_domain }
       assert_redirected_to_authentication(new_shop_domain, response)
     end
 
@@ -47,7 +47,7 @@ module ShopifyApp
 
     test "#new should render a full-page if the shop param value is not a shop" do
       non_shop_address = "example.com"
-      get :new, shop: non_shop_address
+      get :new, params: { shop: non_shop_address }
       assert_response :ok
       assert_match %r{Shopify App — Installation}, response.body
     end
@@ -56,7 +56,7 @@ module ShopifyApp
       test "#create should authenticate the shop for the URL (#{good_url})" do
         ShopifyApp.configuration.embedded_app = true
         shopify_domain = 'my-shop.myshopify.com'
-        post :create, shop: good_url
+        post :create, params: { shop: good_url }
         assert_redirected_to_authentication(shopify_domain, response)
       end
     end
@@ -66,14 +66,14 @@ module ShopifyApp
         ShopifyApp.configuration.embedded_app = true
         ShopifyApp.configuration.myshopify_domain = 'myshopify.io'
         shopify_domain = 'my-shop.myshopify.io'
-        post :create, shop: good_url
+        post :create, params: { shop: good_url }
         assert_redirected_to_authentication(shopify_domain, response)
       end
     end
 
     ['myshop.com', 'myshopify.com', 'shopify.com', 'two words', 'store.myshopify.com.evil.com', '/foo/bar'].each do |bad_url|
       test "#create should return an error for a non-myshopify URL (#{bad_url})" do
-        post :create, shop: bad_url
+        post :create, params: { shop: bad_url }
         assert_response :redirect
         assert_redirected_to '/'
       end
@@ -87,7 +87,7 @@ module ShopifyApp
     test '#callback should have a success flash message' do
       mock_shopify_omniauth
 
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
       assert_equal flash[:notice], 'Logged In'
     end
 
@@ -95,25 +95,25 @@ module ShopifyApp
       I18n.locale = :es
       mock_shopify_omniauth
 
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
       assert_equal flash[:notice], 'Has iniciado sesión'
     end
 
     test '#callback should flash error when omniauth is not present' do
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
       assert_equal flash[:error], 'Could not log in to Shopify store'
     end
 
     test '#callback should flash error in Spanish' do
       I18n.locale = :es
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
       assert_equal flash[:error], 'No se pudo iniciar sesión en tu tienda de Shopify'
     end
 
     test "#callback should setup a shopify session" do
       mock_shopify_omniauth
 
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
       assert_not_nil session[:shopify]
       assert_equal 'shop.myshopify.com', session[:shopify_domain]
     end
@@ -126,7 +126,7 @@ module ShopifyApp
       ShopifyApp::WebhooksManager.expects(:queue)
 
       mock_shopify_omniauth
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
     end
 
     test "#callback doesn't run the WebhooksManager if no webhooks are configured" do
@@ -137,7 +137,7 @@ module ShopifyApp
       ShopifyApp::WebhooksManager.expects(:queue).never
 
       mock_shopify_omniauth
-      get :callback, shop: 'shop'
+      get :callback, params: { shop: 'shop' }
     end
 
     test "#destroy should clear shopify from session and redirect to login with notice" do

--- a/test/integration/webhooks_controller_test.rb
+++ b/test/integration/webhooks_controller_test.rb
@@ -37,7 +37,7 @@ module ShopifyApp
     private
 
     def send_webhook(name, data)
-      post shopify_app.webhooks_path(name), data, {'HTTP_X_SHOPIFY_SHOP_DOMAIN' => 'test.myshopify.com'}
+      post shopify_app.webhooks_path(name), params: data, headers: {'HTTP_X_SHOPIFY_SHOP_DOMAIN' => 'test.myshopify.com'}
     end
   end
 end

--- a/test/shopify_app/app_proxy_verification_test.rb
+++ b/test/shopify_app/app_proxy_verification_test.rb
@@ -35,17 +35,29 @@ class AppProxyVerificationTest < ActionController::TestCase
     assert query_string_valid? 'shop=some-random-store.myshopify.com&path_prefix=%2Fapps%2Fmy-app&timestamp=1466106083&foo=bar&baz[1]&baz[2]=b&baz[c[0]]=whatup&baz[c[1]]=notmuch&signature=bbf3aa60e098f08919a2ea4c64a388414f164e6a117a63b03479ac7aa9464b4f'
   end
 
-  test 'request_should_fail' do
+  test 'request with invalid signature should fail' do
     with_test_routes do
-      get(:basic, shop: 'some-random-store.myshopify.com', path_prefix: '/apps/my-app', timestamp: '1466106083', signature: 'wrong233558b1c50102a6f33c0b63ad1e1072a2fc126cb58d4500f75223cefcd')
-      assert_response(:unauthorized)
+      invalid_params = {
+        shop: 'some-random-store.myshopify.com',
+        path_prefix: '/apps/my-app',
+        timestamp: '1466106083',
+        signature: 'wrong233558b1c50102a6f33c0b63ad1e1072a2fc126cb58d4500f75223cefcd'
+      }
+      get :basic, params: invalid_params
+      assert_response :unauthorized
     end
   end
 
-  test 'request_should_pass' do
+  test 'request with a valid signature should pass' do
     with_test_routes do
-      get(:basic, shop: 'some-random-store.myshopify.com', path_prefix: '/apps/my-app', timestamp: '1466106083', signature: 'f5cd7233558b1c50102a6f33c0b63ad1e1072a2fc126cb58d4500f75223cefcd')
-      assert_response(:ok)
+      valid_params = {
+        shop: 'some-random-store.myshopify.com',
+        path_prefix: '/apps/my-app',
+        timestamp: '1466106083',
+        signature: 'f5cd7233558b1c50102a6f33c0b63ad1e1072a2fc126cb58d4500f75223cefcd'
+      }
+      get :basic, params: valid_params
+      assert_response :ok
     end
   end
 

--- a/test/shopify_app/localization_test.rb
+++ b/test/shopify_app/localization_test.rb
@@ -8,39 +8,39 @@ class LocalizationController < ActionController::Base
   before_action :set_locale
 
   def index
-    render text: I18n.locale
+    head :ok
   end
 end
 
 class LocalizationTest < ActionController::TestCase
   tests LocalizationController
 
-  test "falls back to I18n.default if locale param is not present" do
+  setup do
     I18n.available_locales = [:en, :de, :es, :ja, :fr]
+  end
+
+  test "falls back to I18n.default if locale param is not present" do
     I18n.default_locale = :ja
 
     with_test_routes do
       get :index
-      assert 'ja', response.body
+      assert_equal :ja, I18n.locale
     end
   end
 
   test "set I18n.locale to passed locale param" do
-    I18n.available_locales = [:en, :de, :es, :ja, :fr]
-
     with_test_routes do
-      get :index, locale: 'de'
-      assert 'de', response.body
+      get :index, params: { locale: 'de' }
+      assert_equal :de, I18n.locale
     end
   end
 
   test "falls back to I18n.default if locale is not supported" do
-    I18n.available_locales = [:en, :de, :es, :ja, :fr]
     I18n.default_locale = :en
 
     with_test_routes do
-      get :index, locale: 'cu'
-      assert 'en', response.body
+      get :index, params: { locale: 'invalid_locale' }
+      assert_equal :en, I18n.locale
     end
   end
 

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -67,7 +67,7 @@ class LoginProtectionTest < ActionController::TestCase
       session[:shopify_domain] = "foobar"
       sess = stub(url: 'https://foobar.myshopify.com')
       ShopifyApp::SessionRepository.expects(:retrieve).returns(sess).once
-      get :second_login, shop: 'other_shop'
+      get :second_login, params: { shop: 'other_shop' }
       assert_redirected_to @controller.send(:main_or_engine_login_url, shop: 'other_shop')
       assert_nil session[:shopify]
       assert_nil session[:shopify_domain]
@@ -76,28 +76,28 @@ class LoginProtectionTest < ActionController::TestCase
 
   test '#shopify_session with no Shopify session, redirects to the login url' do
     with_application_test_routes do
-      get :index, shop: 'foobar'
+      get :index, params: { shop: 'foobar' }
       assert_redirected_to @controller.send(:main_or_engine_login_url, shop: 'foobar')
     end
   end
 
   test '#shopify_session with no Shopify session, sets session[:return_to]' do
     with_application_test_routes do
-      get :index, shop: 'foobar'
+      get :index, params: { shop: 'foobar' }
       assert_equal '/?shop=foobar', session[:return_to]
     end
   end
 
   test '#shopify_session with no Shopify session, when the request is an XHR, returns an HTTP 401' do
     with_application_test_routes do
-      xhr :get, :index, shop: 'foobar'
+      get :index, params: { shop: 'foobar' }, xhr: true
       assert_equal 401, response.status
     end
   end
 
   test '#shopify_session when rescuing from unauthorized access, redirects to the login url' do
     with_application_test_routes do
-      get :raise_unauthorized, shop: 'foobar'
+      get :raise_unauthorized, params: { shop: 'foobar' }
       assert_redirected_to @controller.send(:main_or_engine_login_url, shop: 'foobar')
     end
   end
@@ -105,7 +105,7 @@ class LoginProtectionTest < ActionController::TestCase
   test '#fullpage_redirect_to sends a post message to that shop in the shop param' do
     with_application_test_routes do
       example_shop = 'shop.myshopify.com'
-      get :redirect, shop: example_shop
+      get :redirect, params: { shop: example_shop }
       assert_fullpage_redirected(example_shop, response)
     end
   end

--- a/test/shopify_app/webhooks_manager_test.rb
+++ b/test/shopify_app/webhooks_manager_test.rb
@@ -38,9 +38,7 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
     ShopifyAPI::Webhook.stubs(all: all_mock_webhooks)
     @manager.expects(:create_webhook).never
 
-    assert_nothing_raised ShopifyApp::WebhooksManager::CreationFailed do
-      @manager.create_webhooks
-    end
+    assert_nothing_raised { @manager.create_webhooks }
   end
 
   test "#recreate_webhooks! destroys all webhooks and recreates" do


### PR DESCRIPTION
We need to remove support for Rails 4 because changes to the testing syntax In Rails 5 are not compatible with this version.

This PR makes the following changes:
* Update Travis CI to only test Rails 5
* Update test syntax to match Rails 5
* Clean up tests