### PR TITLE
Added Rails version to create_shops generator template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+7.2.10
+-----
+* Fix an issue with the create_shops generator template
+  [[#423]](https://github.com/Shopify/shopify_app/pull/423)
+
 7.2.9
 -----
 * Remove support for Rails 4

--- a/lib/generators/shopify_app/shop_model/shop_model_generator.rb
+++ b/lib/generators/shopify_app/shop_model/shop_model_generator.rb
@@ -12,7 +12,7 @@ module ShopifyApp
       end
 
       def create_shop_migration
-        copy_migration 'create_shops.rb'
+        migration_template "db/migrate/create_shops.erb", "db/migrate/create_shops.rb"
       end
 
       def create_session_storage_initializer
@@ -25,12 +25,8 @@ module ShopifyApp
 
       private
 
-      def copy_migration(migration_name, config = {})
-        migration_template(
-          "db/migrate/#{migration_name}",
-          "db/migrate/#{migration_name}",
-          config
-        )
+      def rails_migration_version
+        Rails.version.match(/\d\.\d/)[0]
       end
 
       # for generating a timestamp when using `create_migration`

--- a/lib/generators/shopify_app/shop_model/templates/db/migrate/create_shops.erb
+++ b/lib/generators/shopify_app/shop_model/templates/db/migrate/create_shops.erb
@@ -1,4 +1,4 @@
-class CreateShops < ActiveRecord::Migration
+class CreateShops < ActiveRecord::Migration[<%= rails_migration_version %>]
   def self.up
     create_table :shops  do |t|
       t.string :shopify_domain, null: false

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.2.9'
+  VERSION = '7.2.10'
 end


### PR DESCRIPTION
Closes https://github.com/Shopify/shopify_app/issues/415

Rails 5 requires the Rails version in the migration parent class apparently. This PR adds that via an erb template. It has to be in a minor version format `[x.x]`

Do I need to bump a version number somewhere?