### PR TITLE
Remove 'Logged in' flash message

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,3 @@
 de:
-  logged_in: 'Eingeloggt'
   logged_out: 'Erfolgreich ausgelogt'
   could_not_log_in: 'Shopify Store Login fehlgeschlagen'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,3 @@
 en:
-  logged_in: 'Logged In'
   logged_out: 'Successfully logged out'
   could_not_log_in: 'Could not log in to Shopify store'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,3 @@
 es:
-  logged_in: 'Has iniciado sesión'
   logged_out: 'Cerrar sesión'
   could_not_log_in: 'No se pudo iniciar sesión en tu tienda de Shopify'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,3 @@
 fr:
-  logged_in: 'Vous êtes connecté(e)'
   logged_out: 'Vous êtes déconnecté(e)'
   could_not_log_in: 'Impossible de se connecter à la boutique Shopify'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,3 @@
 ja:
-  logged_in: 'ログイン'
   logged_out: 'ログインに成功しました'
   could_not_log_in: 'Shopifyストアにログインできませんでした'

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -21,7 +21,6 @@ module ShopifyApp
         install_webhooks
         install_scripttags
 
-        flash[:notice] = I18n.t('.logged_in')
         redirect_to return_address
       else
         flash[:error] = I18n.t('could_not_log_in')

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -84,21 +84,6 @@ module ShopifyApp
       assert_redirected_to '/'
     end
 
-    test '#callback should have a success flash message' do
-      mock_shopify_omniauth
-
-      get :callback, params: { shop: 'shop' }
-      assert_equal flash[:notice], 'Logged In'
-    end
-
-    test '#callback should have a success flash message in Spanish' do
-      I18n.locale = :es
-      mock_shopify_omniauth
-
-      get :callback, params: { shop: 'shop' }
-      assert_equal flash[:notice], 'Has iniciado sesión'
-    end
-
     test '#callback should flash error when omniauth is not present' do
       get :callback, params: { shop: 'shop' }
       assert_equal flash[:error], 'Could not log in to Shopify store'


### PR DESCRIPTION
This PR removes the `Logged in` message. Please see this issue for reference: https://github.com/Shopify/shopify_app/issues/424