### PR TITLE
Improve tests: reset ShopifyApp configuration before each test

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -11,13 +11,7 @@ module ShopifyApp
       I18n.locale = :en
     end
 
-    teardown do
-      ShopifyApp.configuration.embedded_app = true
-      ShopifyApp.configuration.myshopify_domain = 'myshopify.com'
-    end
-
     test "#new should authenticate the shop if a valid shop param exists" do
-      ShopifyApp.configuration.embedded_app = true
       shopify_domain = 'my-shop.myshopify.com'
       get :new, params: { shop: 'my-shop' }
       assert_redirected_to_authentication(shopify_domain, response)
@@ -31,7 +25,6 @@ module ShopifyApp
     end
 
     test "#new should trust the shop param over the current session" do
-      ShopifyApp.configuration.embedded_app = true
       previously_logged_in_shop_id = 1
       session[:shopify] = previously_logged_in_shop_id
       new_shop_domain = "new-shop.myshopify.com"
@@ -54,7 +47,6 @@ module ShopifyApp
 
     ['my-shop', 'my-shop.myshopify.com', 'https://my-shop.myshopify.com', 'http://my-shop.myshopify.com'].each do |good_url|
       test "#create should authenticate the shop for the URL (#{good_url})" do
-        ShopifyApp.configuration.embedded_app = true
         shopify_domain = 'my-shop.myshopify.com'
         post :create, params: { shop: good_url }
         assert_redirected_to_authentication(shopify_domain, response)
@@ -63,7 +55,6 @@ module ShopifyApp
 
     ['my-shop', 'my-shop.myshopify.io', 'https://my-shop.myshopify.io', 'http://my-shop.myshopify.io'].each do |good_url|
       test "#create should authenticate the shop for the URL (#{good_url}) with custom myshopify_domain" do
-        ShopifyApp.configuration.embedded_app = true
         ShopifyApp.configuration.myshopify_domain = 'myshopify.io'
         shopify_domain = 'my-shop.myshopify.io'
         post :create, params: { shop: good_url }

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -1,7 +1,13 @@
-ShopifyApp.configure do |config|
-  config.api_key = "key"
-  config.secret = "secret"
-  config.scope = 'read_orders, read_products'
-  config.embedded_app = true
-  config.myshopify_domain = 'myshopify.com'
+class ShopifyAppConfigurer
+  def self.call
+    ShopifyApp.configure do |config|
+      config.api_key = "key"
+      config.secret = "secret"
+      config.scope = 'read_orders, read_products'
+      config.embedded_app = true
+      config.myshopify_domain = 'myshopify.com'
+    end
+  end
 end
+
+ShopifyAppConfigurer.call

--- a/test/generators/home_controller_generator_test.rb
+++ b/test/generators/home_controller_generator_test.rb
@@ -34,7 +34,6 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/home/index.html.erb" do |index|
       refute_match "ShopifyApp.ready", index
     end
-    ShopifyApp.configuration.embedded_app = true
   end
 
   test "adds home route to routes" do

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -8,7 +8,6 @@ class ConfigurationTest < ActiveSupport::TestCase
 
   teardown do
     Rails.application.config.active_job.queue_name = nil
-    ShopifyApp.configuration.myshopify_domain = 'myshopify.com'
   end
 
   test "configure" do

--- a/test/shopify_app/login_protection_test.rb
+++ b/test/shopify_app/login_protection_test.rb
@@ -31,7 +31,6 @@ class LoginProtectionTest < ActionController::TestCase
 
   setup do
     ShopifyApp::SessionRepository.storage = InMemorySessionStore
-    ShopifyApp.configuration.embedded_app = true
   end
 
   test "#shop_session returns nil when session is nil" do
@@ -135,8 +134,6 @@ class LoginProtectionTest < ActionController::TestCase
       get :redirect
       assert_redirected_to 'https://example.com'
     end
-
-    ShopifyApp.configuration.embedded_app = true
   end
 
   private

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -6,20 +6,14 @@ class UtilsTest < ActiveSupport::TestCase
     ShopifyApp.configuration = nil
   end
 
-  teardown do
-    ShopifyApp.configuration.myshopify_domain = 'myshopify.com'
-  end
-
   ['my-shop', 'my-shop.myshopify.com', 'https://my-shop.myshopify.com', 'http://my-shop.myshopify.com'].each do |good_url|
     test "sanitize_shop_domain for (#{good_url})" do
-      ShopifyApp.configuration.embedded_app = true
       assert ShopifyApp::Utils.sanitize_shop_domain(good_url)
     end
   end
 
   ['my-shop', 'my-shop.myshopify.io', 'https://my-shop.myshopify.io', 'http://my-shop.myshopify.io'].each do |good_url|
     test "sanitize_shop_domain URL (#{good_url}) with custom myshopify_domain" do
-      ShopifyApp.configuration.embedded_app = true
       ShopifyApp.configuration.myshopify_domain = 'myshopify.io'
       assert ShopifyApp::Utils.sanitize_shop_domain(good_url)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,4 +14,9 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 class ActiveSupport::TestCase
   include GeneratorTestHelpers
+
+  def before_setup
+    super
+    ShopifyAppConfigurer.call
+  end
 end


### PR DESCRIPTION
### Problem

Tests have to reset the default `ShopifyApp.configuration` to prevent leaky tests. This means that more context is required when writing tests, and more boilerplate code.

### Suggested Solution
Set the default configuration with `ShopifyAppConfigurer.call` before each test.