### PR TITLE
Minor change: Expect params[:shop] to be a string

### DIFF
--- a/lib/shopify_app/login_protection.rb
+++ b/lib/shopify_app/login_protection.rb
@@ -27,7 +27,7 @@ module ShopifyApp
     end
 
     def login_again_if_different_shop
-      if shop_session && params[:shop] && params[:shop].is_a?(String) && shop_session.url != params[:shop]
+      if shop_session && params[:shop] && (shop_session.url != params[:shop])
         session[:shopify] = nil
         session[:shopify_domain] = nil
         redirect_to_login


### PR DESCRIPTION
`LoginProtection#login_again_if_different_shop` is a before action that forces re-login is another shop is already logged in. Currently it only works when `params[:shop].is_a?(String)`. As far as I can tell, there is no good reason to keep that around.