### PR TITLE
Add after authenticate job option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+7.4.0
+-----
+* Add an after_authenticate job which will be run once the shop is authenticated. [[#431]](https://github.com/Shopify/shopify_app/pull/432)
+
 7.3.0
 -----
 * Bump required omniauth-shopify-oauth2 version to 1.2.0.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Table of Contents
 * [**Managing Api Keys**](#managing-api-keys)
 * [**WebhooksManager**](#webhooksmanager)
 * [**ScripttagsManager**](#scripttagsmanager)
+* [**AfterAuthenticate Job**](#afterauthenticate-job)
 * [**ShopifyApp::SessionRepository**](#shopifyappsessionrepository)
 * [**AuthenticatedController**](#authenticatedcontroller)
 * [**AppProxyVerification**](#appproxyverification)
@@ -289,6 +290,31 @@ You also need to have write_script_tags permission in the config scope in order 
 Scripttags are created in the same way as the Webhooks, with a background job which will create the required scripttags.
 
 If `src` responds to `call` its return value will be used as the scripttag's source. It will be called on scripttag creation and deletion.
+
+AfterAuthenticate Job
+---------------------
+
+If your app needs to perform specific actions after it is installed ShopifyApp can queue or run a job of your choosing (note that we already provide support for automatically creating Webhooks and Scripttags). To configure the after authenticate job update your initializer as follows:
+
+```ruby
+ShopifyApp.configure do |config|
+  config.add_after_authenticate_job = { job: Shopify::AfterAuthenticateJob }
+end
+```
+
+If you need the job to run synchronously add the `inline` flag:
+
+```ruby
+ShopifyApp.configure do |config|
+  config.add_after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: true }
+end
+```
+
+We've also provided a generator which creates a skeleton job and updates the initializer for you:
+
+```
+bin/rails g shopify_app:add_after_authenticate_job
+```
 
 ShopifyApp::SessionRepository
 -----------------------------

--- a/lib/generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator.rb
+++ b/lib/generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator.rb
@@ -1,0 +1,43 @@
+require 'rails/generators/base'
+
+module ShopifyApp
+  module Generators
+    class AddAfterAuthenticateJobGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+
+      hook_for :test_framework, as: :job, in: :rails do |instance, generator|
+        instance.invoke generator, [ instance.send(:job_file_name) ]
+      end
+
+      def init_after_authenticate_config
+        initializer = load_initializer
+
+       after_authenticate_job_config = "  config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: false }\n"
+
+        inject_into_file(
+          'config/initializers/shopify_app.rb',
+          after_authenticate_job_config,
+          before: 'end'
+        )
+
+        unless initializer.include?(after_authenticate_job_config)
+          shell.say "Error adding after_authneticate_job to config. Add this line manually: #{after_authenticate_job_config}", :red
+        end
+      end
+
+      def add_after_authenticate_job
+        template 'after_authenticate_job.rb', "app/jobs/#{job_file_name}_job.rb"
+      end
+
+      private
+
+      def load_initializer
+        File.read(File.join(destination_root, 'config/initializers/shopify_app.rb'))
+      end
+
+      def job_file_name
+        'shopify/after_authenticate'
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/add_after_authenticate_job/templates/after_authenticate_job.rb
+++ b/lib/generators/shopify_app/add_after_authenticate_job/templates/after_authenticate_job.rb
@@ -1,0 +1,10 @@
+module Shopify
+  class AfterAuthenticateJob < ActiveJob::Base
+    def perform(shop_domain:)
+      shop = Shop.find_by(shopify_domain: shop_domain)
+
+      shop.with_shopify_session do
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -4,4 +4,5 @@ ShopifyApp.configure do |config|
   config.secret = "<%= @secret %>"
   config.scope = "<%= @scope %>"
   config.embedded_app = <%= embedded_app? %>
+  config.after_authenticate_job = false
 end

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -12,6 +12,7 @@ module ShopifyApp
     alias_method  :embedded_app?, :embedded_app
     attr_accessor :webhooks
     attr_accessor :scripttags
+    attr_accessor :after_authenticate_job
 
     # customise ActiveJob queue names
     attr_accessor :scripttags_manager_queue_name

--- a/lib/shopify_app/sessions_concern.rb
+++ b/lib/shopify_app/sessions_concern.rb
@@ -20,6 +20,7 @@ module ShopifyApp
         login_shop
         install_webhooks
         install_scripttags
+        perform_after_authenticate_job
 
         redirect_to return_address
       else
@@ -87,5 +88,16 @@ module ShopifyApp
       session.delete(:return_to) || main_app.root_url
     end
 
+    def perform_after_authenticate_job
+      config = ShopifyApp.configuration.after_authenticate_job
+
+      return unless config && config[:job].present?
+
+      if config[:inline] == true
+        config[:job].perform_now(shop_domain: session[:shopify_domain])
+      else
+        config[:job].perform_later(shop_domain: session[:shopify_domain])
+      end
+    end
   end
 end

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '7.3.0'
+  VERSION = '7.4.0'
 end

--- a/test/generators/add_after_authenticate_job_generator_test.rb
+++ b/test/generators/add_after_authenticate_job_generator_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+require 'generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator'
+
+class AddAfterAuthenticateJobGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::AddAfterAuthenticateJobGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+
+  setup do
+    prepare_destination
+  end
+
+  test 'adds enable_after_authenticate_actions config' do
+    provide_existing_initializer_file
+
+    run_generator
+
+    assert_file "config/initializers/shopify_app.rb" do |config|
+      assert_match 'config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: false }', config
+    end
+  end
+
+  test "adds the after_authenticate job" do
+    provide_existing_initializer_file
+
+    run_generator
+
+    assert_directory "app/jobs/shopify"
+    assert_file "app/jobs/shopify/after_authenticate_job.rb"
+  end
+end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -20,6 +20,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match 'config.secret = "<secret>"', shopify_app
       assert_match 'config.scope = "read_orders, read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
+      assert_match "config.after_authenticate_job = false", shopify_app
     end
   end
 

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -13,9 +13,11 @@ class ConfigurationTest < ActiveSupport::TestCase
   test "configure" do
     ShopifyApp.configure do |config|
       config.embedded_app = true
+      config.after_authenticate_job = false
     end
 
     assert_equal true, ShopifyApp.configuration.embedded_app
+    assert_equal false, ShopifyApp.configuration.after_authenticate_job
   end
 
   test "defaults to myshopify_domain" do


### PR DESCRIPTION
### What

Adds the ability to generate an after authenticate job which can perform async or inline once the shop has authenticated with the app.

Branch renamed from: https://github.com/Shopify/shopify_app/pull/428 to better reflect the changes. 

@Hammadk @kevinhughes27 ready for review again - made the config a hash accepting `job` and `inline`. 