### PR TITLE
subclass from ActionController::Base not Application controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Removed the `shopify_session_repository` initializer. The SessionRepository is now configured through the main ShopifyApp configuration object and the generated initializer
 * Moved InMemorySessionStore into the ShopifyApp namespace
 * Remove ShopifySession concern. This module made the code internal to this engine harder to follow and we want do discourage over-writing the auth code now that we have generic hooks for all extra tasks during install.
+* Changed engine controllers to subclass ActionController::Base to avoid any possible conflict with the parent application
 
 7.3.0
 -----

--- a/app/controllers/shopify_app/authenticated_controller.rb
+++ b/app/controllers/shopify_app/authenticated_controller.rb
@@ -1,5 +1,5 @@
 module ShopifyApp
-  class AuthenticatedController < ApplicationController
+  class AuthenticatedController < ActionController::Base
     include ShopifyApp::Localization
     include ShopifyApp::LoginProtection
 

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -1,5 +1,5 @@
 module ShopifyApp
-  class SessionsController < ApplicationController
+  class SessionsController < ActionController::Base
     include ShopifyApp::LoginProtection
     layout false, only: :new
 

--- a/app/controllers/shopify_app/webhooks_controller.rb
+++ b/app/controllers/shopify_app/webhooks_controller.rb
@@ -1,5 +1,5 @@
 module ShopifyApp
-  class WebhooksController < ApplicationController
+  class WebhooksController < ActionController::Base
     include ShopifyApp::WebhookVerification
 
     class ShopifyApp::MissingWebhookJobError < StandardError; end


### PR DESCRIPTION
I'm working on mounting ShopifyApp in an application where most of the code is not part of the Shopify application. One of things I came across is that our ApplicationController defines a few before_actions which interfere with the engine. I think this change makes sense since we wouldn't want ApplicationController to interfere with anything inside the engine.

review
@Hammadk @alanhill 