### PR TITLE
add webhooks to example home controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Changed engine controllers to subclass ActionController::Base to avoid any possible conflict with the parent application
 * Removed the `ShopifyApp::Shop` concern and added its methods to `ShopifyApp::SessionStorage`. To update for this change just remove this concern anywhere it is being used in your application.
 * Add `ShopifyApp::EmbeddedApp` controller concern which handles setting the required headers for the ESDK. Previously this was done by injecting configuration into applicaton.rb which affects the entire app.
+* Add webhooks to generated home controller. This should help new users debug issues.
 
 7.4.0
 -----

--- a/lib/generators/shopify_app/home_controller/templates/home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ShopifyApp::AuthenticatedController
   def index
     @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
+    @webhooks = ShopifyAPI::Webhook.find(:all)
   end
 end

--- a/lib/generators/shopify_app/home_controller/templates/index.html.erb
+++ b/lib/generators/shopify_app/home_controller/templates/index.html.erb
@@ -5,3 +5,17 @@
     <li><%= link_to product.title, "https://#{@shop_session.url}/admin/products/#{product.id}", target: "_top" %></li>
   <% end %>
 </ul>
+
+<hr>
+
+<h2>Webhooks</h2>
+
+<% if @webhooks.present? %>
+  <ul>
+    <% @webhooks.each do |webhook| %>
+      <li><%= webhook.topic %> : <%= webhook.address %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>This app has not created any webhooks for this Shop. Add webhooks to your ShopifyApp initializer if you need webhooks</p>
+<% end %>


### PR DESCRIPTION
This PR adds Webhooks to the generated HomeController. This is useful since it shows users how to view the webhooks per shop. Its pretty common for people to get confused and check the webhooks list in the admin which only shows the Shop's webhooks not the App's. I am hoping this change will help alleviate this confusion.

New generated home view:
![image](https://user-images.githubusercontent.com/1965489/28594410-db249724-715d-11e7-9038-848365ffe5bd.png)

@jamiemtdwyer @alanhill 