### PR TITLE
EmbeddedApp Concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove ShopifySession concern. This module made the code internal to this engine harder to follow and we want do discourage over-writing the auth code now that we have generic hooks for all extra tasks during install.
 * Changed engine controllers to subclass ActionController::Base to avoid any possible conflict with the parent application
 * Removed the `ShopifyApp::Shop` concern and added its methods to `ShopifyApp::SessionStorage`. To update for this change just remove this concern anywhere it is being used in your application.
+* Add `ShopifyApp::EmbeddedApp` controller concern which handles setting the required headers for the ESDK. Previously this was done by injecting configuration into applicaton.rb which affects the entire app.
 
 7.4.0
 -----

--- a/app/controllers/shopify_app/authenticated_controller.rb
+++ b/app/controllers/shopify_app/authenticated_controller.rb
@@ -2,11 +2,9 @@ module ShopifyApp
   class AuthenticatedController < ActionController::Base
     include ShopifyApp::Localization
     include ShopifyApp::LoginProtection
+    include ShopifyApp::EmbeddedApp
 
-    before_action :set_locale
     before_action :login_again_if_different_shop
     around_action :shopify_session
-
-    layout ShopifyApp.configuration.embedded_app? ? 'embedded_app' : 'application'
   end
 end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -34,13 +34,6 @@ module ShopifyApp
         )
       end
 
-      def inject_embedded_app_options_to_application
-        if embedded_app?
-          application "config.action_dispatch.default_headers.delete('X-Frame-Options')"
-          application "config.action_dispatch.default_headers['P3P'] = 'CP=\"Not used\"'"
-        end
-      end
-
       def create_embedded_app_layout
         if embedded_app?
           copy_file 'embedded_app.html.erb', 'app/views/layouts/embedded_app.html.erb'

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -16,6 +16,7 @@ require 'shopify_app/utils'
 # controller concerns
 require 'shopify_app/controller_concerns/localization'
 require 'shopify_app/controller_concerns/login_protection'
+require 'shopify_app/controller_concerns/embedded_app'
 require 'shopify_app/controller_concerns/webhook_verification'
 require 'shopify_app/controller_concerns/app_proxy_verification'
 

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -1,0 +1,19 @@
+module ShopifyApp
+  module EmbeddedApp
+    extend ActiveSupport::Concern
+
+    included do
+      if ShopifyApp.configuration.embedded_app?
+        after_action :set_esdk_headers
+        layout 'embedded_app'
+      end
+    end
+
+    private
+
+    def set_esdk_headers
+      response.set_header('P3P', 'CP="Not used"')
+      response.default_headers.delete('X-Frame-Options')
+    end
+  end
+end

--- a/lib/shopify_app/controller_concerns/localization.rb
+++ b/lib/shopify_app/controller_concerns/localization.rb
@@ -2,6 +2,12 @@ module ShopifyApp
   module Localization
     extend ActiveSupport::Concern
 
+    included do
+      before_action :set_locale
+    end
+
+    private
+
     def set_locale
       if params[:locale]
         session[:locale] = params[:locale]

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -62,22 +62,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "adds the embedded app options to application.rb" do
-    run_generator
-    assert_file "config/application.rb" do |application|
-      assert_match "config.action_dispatch.default_headers.delete('X-Frame-Options')", application
-      assert_match "config.action_dispatch.default_headers['P3P'] = 'CP=\"Not used\"'", application
-    end
-  end
-
-  test "doesn't add embedd options if -embedded false" do
-    run_generator %w(--embedded false)
-    assert_file "config/application.rb" do |application|
-      refute_match "config.action_dispatch.default_headers.delete('X-Frame-Options')", application
-      refute_match "config.action_dispatch.default_headers['P3P'] = 'CP=\"Not used\"'", application
-    end
-  end
-
   test "creates the embedded_app layout" do
     run_generator
     assert_file "app/views/layouts/embedded_app.html.erb"


### PR DESCRIPTION
One thing I didn't like when I went to use this engine on a project where the embedded app is a small thing compared to the whole app was how we still configured headers for the ESDK globally. I looked into how to avoid this because I didn't want to add these headers for my whole application. I found it was pretty easy to do locally in newer versions of rails (this may have been hard in the past I am not sure).

I also updated the Localization concern to fully abstract itself while I was nearby.

@swalkinshaw @Hammadk 