### PR TITLE
basic setup for per-user authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.0.1 (unreleased)
 ------------------
 * Add support for per_user_authentication
+* Pass the shop param in the sesssion for authentication instead of a url param (prevents csrf)
 
 8.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+8.0.1 (unreleased)
+------------------
+* Add support for per_user_authentication
+
 8.0.0
 -----
 * Removed the `shopify_session_repository` initializer. The SessionRepository is now configured through the main ShopifyApp configuration object and the generated initializer

--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ provider :shopify,
   callback_path: '/nested/auth/shopify/callback'
 ```
 
+Per User Authentication
+-----------------------
+To enable per user authentication you need to update the `omniauth.rb` initializer:
+
+```ruby
+provider :shopify,
+  ShopifyApp.configuration.api_key,
+  ShopifyApp.configuration.secret,
+  scope: ShopifyApp.configuration.scope,
+  per_user_permissions: true
+```
+
+The current Shopify user will be stored in the rails session at `session[:shopify_user]`
+
+This will change the type of token that Shopify returns and it will only be valid for a short time. Read more about `Online access` [here](https://help.shopify.com/api/getting-started/authentication/oauth). Note that this means you won't be able to use this token to respond to Webhooks.
+
 Managing Api Keys
 -----------------
 

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -26,8 +26,7 @@ module ShopifyApp
     end
 
     def destroy
-      session[:shopify] = nil
-      session[:shopify_domain] = nil
+      reset_session
       flash[:notice] = I18n.t('.logged_out')
       redirect_to login_url
     end
@@ -46,6 +45,7 @@ module ShopifyApp
       sess = ShopifyAPI::Session.new(shop_name, token)
       session[:shopify] = ShopifyApp::SessionRepository.store(sess)
       session[:shopify_domain] = shop_name
+      session[:shopify_user] = associated_user if associated_user.present?
     end
 
     def auth_hash
@@ -54,6 +54,11 @@ module ShopifyApp
 
     def shop_name
       auth_hash.uid
+    end
+
+    def associated_user
+      return unless auth_hash['extra'].present?
+      auth_hash['extra']['associated_user']
     end
 
     def token

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -35,7 +35,8 @@ module ShopifyApp
 
     def authenticate
       if sanitized_shop_name.present?
-        fullpage_redirect_to "#{main_app.root_path}auth/shopify?shop=#{sanitized_shop_name}"
+        session['shopify.omniauth_params'] = { shop: sanitized_shop_name }
+        fullpage_redirect_to "#{main_app.root_path}auth/shopify"
       else
         redirect_to return_address
       end

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -44,6 +44,10 @@ module ShopifyApp
 
     def login_shop
       sess = ShopifyAPI::Session.new(shop_name, token)
+
+      request.session_options[:renew] = true
+      session.delete(:_csrf_token)
+
       session[:shopify] = ShopifyApp::SessionRepository.store(sess)
       session[:shopify_domain] = shop_name
       session[:shopify_user] = associated_user if associated_user.present?

--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -2,3 +2,15 @@
            ShopifyApp.configuration.api_key,
            ShopifyApp.configuration.secret,
            scope: ShopifyApp.configuration.scope
+           setup: lambda { |env|
+             strategy = env['omniauth.strategy']
+
+             shopify_auth_params = strategy.session['shopify.omniauth_params']&.with_indifferent_access
+             shop = if shopify_auth_params.present?
+               "https://#{shopify_auth_params[:shop]}"
+             else
+               ''
+             end
+
+             strategy.options[:client_options][:site] = shop
+           }

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_runtime_dependency('rails', '>= 5.0.0')
-  s.add_runtime_dependency('shopify_api', '>= 4.3.2')
+  s.add_runtime_dependency('shopify_api', '>= 4.3.5')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.2.0')
 
   s.add_development_dependency('rake')

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -100,6 +100,15 @@ module ShopifyApp
       assert_equal 'shop.myshopify.com', session[:shopify_domain]
     end
 
+    test "#callback should setup a shopify session with a user for online mode" do
+      mock_shopify_user_omniauth
+
+      get :callback, params: { shop: 'shop' }
+      assert_not_nil session[:shopify]
+      assert_equal 'shop.myshopify.com', session[:shopify_domain]
+      assert_equal 'user_object', session[:shopify_user]
+    end
+
     test "#callback should start the WebhooksManager if webhooks are configured" do
       ShopifyApp.configure do |config|
         config.webhooks = [{topic: 'carts/update', address: 'example-app.com/webhooks'}]
@@ -194,6 +203,17 @@ module ShopifyApp
 
     def mock_shopify_omniauth
       OmniAuth.config.add_mock(:shopify, provider: :shopify, uid: 'shop.myshopify.com', credentials: {token: '1234'})
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:shopify] if request
+      request.env['omniauth.params'] = { shop: 'shop.myshopify.com' } if request
+    end
+
+    def mock_shopify_user_omniauth
+      OmniAuth.config.add_mock(:shopify,
+        provider: :shopify,
+        uid: 'shop.myshopify.com',
+        credentials: {token: '1234'},
+        extra: {associated_user: 'user_object'}
+      )
       request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:shopify] if request
       request.env['omniauth.params'] = { shop: 'shop.myshopify.com' } if request
     end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -25,9 +25,9 @@ module ShopifyApp
 
     test "#new should authenticate the shop if a valid shop param exists non embedded" do
       ShopifyApp.configuration.embedded_app = false
-      auth_url = '/auth/shopify?shop=my-shop.myshopify.com'
       get :new, params: { shop: 'my-shop' }
-      assert_redirected_to auth_url
+      assert_redirected_to '/auth/shopify'
+      assert_equal session['shopify.omniauth_params'][:shop], 'my-shop.myshopify.com'
     end
 
     test "#new should trust the shop param over the current session" do
@@ -219,8 +219,10 @@ module ShopifyApp
     end
 
     def assert_redirected_to_authentication(shop_domain, response)
-      auth_url = "/auth/shopify?shop=#{shop_domain}".to_json
+      auth_url = "/auth/shopify".to_json
       target_origin = "https://#{shop_domain}".to_json
+
+      session_shop = session['shopify.omniauth_params'][:shop]
 
       post_message_handle = "message: 'Shopify.API.remoteRedirect'"
       post_message_link = "normalizedLink.href = #{auth_url}"
@@ -231,6 +233,7 @@ module ShopifyApp
       assert_includes response.body, post_message_link
       assert_includes response.body, post_message_data
       assert_includes response.body, post_message_call
+      assert_equal session_shop, shop_domain
     end
 
   end


### PR DESCRIPTION
related to #385

This PR adds some inner workings to store the current user if ShopifyApp is configured to use per user permissions. It doesn't add everything that we could possibly support for Online mode but its a start.

For review:
@Hammadk @EiNSTeiN- 