### PR TITLE
Allow specifying namespace for webhooks jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Upcoming
+-----
+* Add `webhook_jobs_namespace` config option. [[#463]](https://github.com/Shopify/shopify_app/pull/463)
+
 8.1.0
 -----
 * Add support for per_user_authentication

--- a/README.md
+++ b/README.md
@@ -182,14 +182,15 @@ Mounting the Engine will provide the basic routes to authenticating a shop with 
 |GET     |'/logout'                      |Logout                        |
 |POST    |'/webhooks/:type'              |Webhook Callback              |
 
+### Nested Routes
 
-If required the engine can be mounted at a nested route, eg:
+The engine may also be mounted at a nested route, for example:
 
 ```ruby
 mount ShopifyApp::Engine, at: '/nested'
 ```
 
-This will create the Shopify engine routes under the specified subpath. You'll also need to make some updates to your `shopify_app.rb` and `omniauth.rb` initializers. First update the shopify_app initializer to include a custom `root_url` e.g:
+This will create the Shopify engine routes under the specified subpath. You'll also need to make some updates to your `shopify_app.rb` and `omniauth.rb` initializers. First update the shopify_app initializer to include a custom `root_url` e.g.:
 
 ```ruby
 ShopifyApp.configure do |config|
@@ -197,7 +198,7 @@ ShopifyApp.configure do |config|
 end
 ```
 
-then update the omniauth initializer to include a custom `callback_path` e.g:
+then update the omniauth initializer to include a custom `callback_path` e.g.:
 
 ```ruby
 provider :shopify,
@@ -242,7 +243,7 @@ end
 WebhooksManager
 ---------------
 
-ShopifyApp can manage your app's webhooks for you by setting which webhooks you require in the initializer:
+ShopifyApp can manage your app's webhooks for you if you set which webhooks you require in the initializer:
 
 ```ruby
 ShopifyApp.configure do |config|
@@ -254,7 +255,15 @@ end
 
 When the oauth callback is completed successfully ShopifyApp will queue a background job which will ensure all the specified webhooks exist for that shop. Because this runs on every oauth callback it means your app will always have the webhooks it needs even if the user uninstalls and re-installs the app.
 
-ShopifyApp also provides a WebhooksController that receives webhooks and queues a job based on the webhook url. For example if you register the webhook from above then all you need to do is create a job called `CartsUpdateJob`. The job will be queued with 2 params `shop_domain` and `webhook` which is the webhook body.
+ShopifyApp also provides a WebhooksController that receives webhooks and queues a job based on the received topic. For example if you register the webhook from above then all you need to do is create a job called `CartsUpdateJob`. The job will be queued with 2 params: `shop_domain` and `webhook` (which is the webhook body).
+
+If you would like to namespace your jobs you may set `webhook_jobs_namespace` in the config. For example if your app handles webhooks from other ecommerce applications as well, and you want Shopify cart update webhooks to be processed by a job living in `jobs/shopify/webhooks/carts_update_job.rb` rather than `jobs/carts_update_job.rb`):
+
+```ruby
+ShopifyApp.configure do |config|
+  config.webhook_jobs_namespace = 'shopify/webhooks'
+end
+```
 
 If you are only interested in particular fields, you can optionally filter the data sent by Shopify by specifying the `fields` parameter in `config/webhooks`. Note that you will still receive a webhook request from Shopify every time the resource is updated, but only the specified fields will be sent.
 

--- a/app/controllers/shopify_app/webhooks_controller.rb
+++ b/app/controllers/shopify_app/webhooks_controller.rb
@@ -18,11 +18,19 @@ module ShopifyApp
     end
 
     def webhook_job_klass
-      "#{webhook_type.classify}Job".safe_constantize or raise ShopifyApp::MissingWebhookJobError
+      webhook_job_klass_name.safe_constantize or raise ShopifyApp::MissingWebhookJobError
+    end
+
+    def webhook_job_klass_name(type = webhook_type)
+      [webhook_namespace, "#{type}_job"].compact.join('/').classify
     end
 
     def webhook_type
       params[:type]
+    end
+
+    def webhook_namespace
+      ShopifyApp.configuration.webhook_jobs_namespace
     end
   end
 end

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -25,6 +25,9 @@ module ShopifyApp
     # configure myshopify domain for local shopify development
     attr_accessor :myshopify_domain
 
+    # allow namespacing webhook jobs
+    attr_accessor :webhook_jobs_namespace
+
     def initialize
       @root_url = '/'
       @myshopify_domain = 'myshopify.com'

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -91,4 +91,24 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal :'my-custom-worker-2', ShopifyApp.configuration.scripttags_manager_queue_name
   end
 
+  test "webhook_jobs_namespace handles default" do
+    assert_equal "TestJob", ShopifyApp::WebhooksController.new.send(:webhook_job_klass_name, 'test')
+  end
+
+  test "webhook_jobs_namespace handles single plural value" do
+    ShopifyApp.configure do |config|
+      config.webhook_jobs_namespace = 'webhooks'
+    end
+
+    assert_equal "Webhooks::TestJob", ShopifyApp::WebhooksController.new.send(:webhook_job_klass_name, 'test')
+  end
+
+  test "webhook_jobs_namespace handles nested values" do
+    ShopifyApp.configure do |config|
+      config.webhook_jobs_namespace = 'shopify/webhooks'
+    end
+
+    assert_equal "Shopify::Webhooks::TestJob", ShopifyApp::WebhooksController.new.send(:webhook_job_klass_name, 'test')
+  end
+
 end


### PR DESCRIPTION
This tweak allow specifying a namespace for the webhook jobs.

Rationale: I'm trying to build a generic ecommerce app, keeping in mind that I may expand to support non-Shopify stores in the future. With that in mind, I've namespaced my ShopifyApp webhook jobs under `jobs/shopify/xxx_job.rb`, but despite mounting ShopifyApp under '/shopify', the webhook controller was always raising ShopifyApp::MissingWebhookJobError because it was hardcoded to assume the webhook job names were in the top-level namespace. 