### PR TITLE
Ignore non-String shop params in login_again_if_different_shop

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -27,7 +27,7 @@ module ShopifyApp
     end
 
     def login_again_if_different_shop
-      if shop_session && params[:shop] && (shop_session.url != params[:shop])
+      if shop_session && params[:shop] && params[:shop].is_a?(String) && shop_session.url != params[:shop]
         session[:shopify] = nil
         session[:shopify_domain] = nil
         redirect_to_login

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -27,7 +27,7 @@ module ShopifyApp
     end
 
     def login_again_if_different_shop
-      if shop_session && params[:shop] && params[:shop].is_a?(String) && shop_session.url != params[:shop]
+      if shop_session && params[:shop] && params[:shop].is_a?(String) && (shop_session.url != params[:shop])
         session[:shopify] = nil
         session[:shopify_domain] = nil
         redirect_to_login

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -10,11 +10,11 @@ class LoginProtectionController < ActionController::Base
   before_action :login_again_if_different_shop, only: [:second_login]
 
   def index
-    render nothing: true
+    render plain: "OK"
   end
 
   def second_login
-    render nothing: true
+    render plain: "OK"
   end
 
   def redirect
@@ -70,6 +70,18 @@ class LoginProtectionTest < ActionController::TestCase
       assert_redirected_to '/login?shop=other_shop'
       assert_nil session[:shopify]
       assert_nil session[:shopify_domain]
+    end
+  end
+
+  test "#login_again_if_different_shop ignores non-String shop params so that Rails params for Shop model can be accepted" do
+    with_application_test_routes do
+      session[:shopify] = "foobar"
+      session[:shopify_domain] = "foobar"
+      sess = stub(url: 'https://foobar.myshopify.com')
+      ShopifyApp::SessionRepository.expects(:retrieve).returns(sess).once
+
+      get :second_login, params: { shop: { id: 123, disabled: true } }
+      assert_response :ok
     end
   end
 


### PR DESCRIPTION
Reverts Shopify/shopify_app#430, and adds a test to prevent regression.

In Shopify/shopify_app#430, I removed the `params[:shop].is_a?(String)` check from `LoginProtection:: login_again_if_different_shop` because we didn't think it was needed.

While working on another project I found out that this check is needed. Consider the case where someone has a `Shop` model in Rails. When they use form_for in a controller, Rails passes along the params under the `shop` hash, so:
``` ruby
shop : {
  id: 123,
  foo: bar
}
```

If this hash is passed to `login_again_if_different_shop`, the following check is always true: `shop_session.url != params[:shop]`. Of course, using the non-default param gets around this.