### PR TITLE
change how the X-Frame-Options header is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+8.2.2
+-----
+* Changes how the ESDK concern allows iframes. Fixes an issue with the first request for some people
+
 8.2.1
 -----
 * Bugfix: Don't logout shops from `login_again_if_different_shop` when Rails

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -13,7 +13,7 @@ module ShopifyApp
 
     def set_esdk_headers
       response.set_header('P3P', 'CP="Not used"')
-      response.default_headers.delete('X-Frame-Options')
+      response.headers.except!('X-Frame-Options')
     end
   end
 end


### PR DESCRIPTION
fixes #468

@resistorsoftware / @meulmees lets try this fix suggested [here](https://stackoverflow.com/questions/18445782/how-to-override-x-frame-options-for-a-controller-or-action-in-rails-4) 