### PR TITLE
Make compatible with Turbolinks >= 5.0.0

### DIFF
--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,8 +1,8 @@
 <% content_for :javascript do %>
 <script type="text/javascript">
-  var eventName = typeof(Turbolinks) !== 'undefined' ? 'page:change' : 'DOMContentLoaded';
+  var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
 
-  document.addEventListener(eventName, function() {
+  document.addEventListener(eventName, function flash() {
     <% if flash[:notice] %>
       ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
     <% end %>
@@ -10,6 +10,8 @@
     <% if flash[:error] %>
       ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
     <% end %>
+                             
+    document.removeEventListener(eventName, flash)
   });
 </script>
 <% end %>


### PR DESCRIPTION
Update event name to trigger the handler on newer Turbolinks versions. Explicitly remove the event listener after the flash notice (or error) is triggered once.