### PR TITLE
add /callback for oauth callback

### DIFF
--- a/lib/generators/shopify_app/routes/templates/routes.rb
+++ b/lib/generators/shopify_app/routes/templates/routes.rb
@@ -3,6 +3,7 @@
     get 'login' => :new, :as => :login
     post 'login' => :create, :as => :authenticate
     get 'auth/shopify/callback' => :callback
+    get 'callback' => :callback
     get 'logout' => :destroy, :as => :logout
   end
 


### PR DESCRIPTION
A lot of tutorials use the /callback endpoint for oAuth requests, so I thought it would be a useful addition.