### PR TITLE
Add CSRF Protection on AuthenticatedController

### DIFF
--- a/app/controllers/shopify_app/authenticated_controller.rb
+++ b/app/controllers/shopify_app/authenticated_controller.rb
@@ -4,6 +4,7 @@ module ShopifyApp
     include ShopifyApp::LoginProtection
     include ShopifyApp::EmbeddedApp
 
+    protect_from_forgery with: :exception
     before_action :login_again_if_different_shop
     around_action :shopify_session
   end


### PR DESCRIPTION
In release 8.0.0 on Aug 14th, CSRF protection was removed from `ShopifyApp::AuthenticatedController`, this PR adds it back.

Once this merges, I'll bump the gem version + update README with the preferred version in a note, and title the PR something eye-catching so that our watchers will know to update.

@kevinhughes27 @yaworsk