### PR TITLE
Remove X-Frame-Options header on login route

### DIFF
--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -2,6 +2,9 @@ module ShopifyApp
   class SessionsController < ActionController::Base
     include ShopifyApp::LoginProtection
     layout false, only: :new
+    after_action only: :new do |controller|
+      controller.response.headers.except!('X-Frame-Options')
+    end
 
     def new
       authenticate if sanitized_shop_name.present?


### PR DESCRIPTION
This prevents a browser error where the login route is called from the embedded app iframe.