### PR TITLE
Show an error message when entering an invalid url

### DIFF
--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -41,6 +41,7 @@ module ShopifyApp
         session['shopify.omniauth_params'] = { shop: sanitized_shop_name }
         fullpage_redirect_to "#{main_app.root_path}auth/shopify"
       else
+        flash[:error] = I18n.t('invalid_shop_url')
         redirect_to return_address
       end
     end

--- a/app/views/shopify_app/sessions/new.html.erb
+++ b/app/views/shopify_app/sessions/new.html.erb
@@ -48,6 +48,12 @@
       line-height: 2em;
     }
 
+    .error {
+      line-height: 1em;
+      padding: 0.5em;
+      color: red;
+    }
+
     input.marketing-input {
       width: 100%;
       height: 52px;
@@ -104,7 +110,10 @@
       <label for="shop">Enter your shop domain to log in or install this app.</label>
     </p>
 
-    <form method="GET" action="login">
+    <form method="POST" action="login">
+      <% if flash[:error] %>
+        <div class=error><%= flash[:error] %></div>
+      <% end %>
       <input id="shop" name="shop" type="text" autofocus="autofocus" placeholder="example.myshopify.com" class="marketing-input">
       <button type="submit" class="marketing-button">Install</button>
     </form>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   logged_out: 'Successfully logged out'
   could_not_log_in: 'Could not log in to Shopify store'
+  invalid_shop_url: 'Invalid shop domain'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,3 +1,4 @@
 fr:
   logged_out: 'Vous êtes déconnecté(e)'
   could_not_log_in: 'Impossible de se connecter à la boutique Shopify'
+  invalid_shop_url: 'Url invalide'

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -73,6 +73,7 @@ module ShopifyApp
         post :create, params: { shop: bad_url }
         assert_response :redirect
         assert_redirected_to '/'
+        assert_equal I18n.t('invalid_shop_url'), flash[:error]
       end
     end
 


### PR DESCRIPTION
# Why
Right now when an invalid url is entered (one that is from an invalid host) nothing is displayed to the user to let them know something is wrong. This PR adds a simple error message

# What
<img width="598" alt="screen shot 2017-11-30 at 2 02 27 pm" src="https://user-images.githubusercontent.com/311279/33449607-49948e5c-d5d7-11e7-9f51-62333288368a.png">
(only .com is supported by default)
