### PR TITLE
don't require 'rails/generators/active_record' in install generator

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -1,5 +1,4 @@
 require 'rails/generators/base'
-require 'rails/generators/active_record'
 
 module ShopifyApp
   module Generators


### PR DESCRIPTION
The `install` generator doesn't do anything involving ActiveRecord, so this `require` is unnecessary here