### PR TITLE
Use form_tag helper to create login form

### DIFF
--- a/app/views/shopify_app/sessions/new.html.erb
+++ b/app/views/shopify_app/sessions/new.html.erb
@@ -110,13 +110,13 @@
       <label for="shop">Enter your shop domain to log in or install this app.</label>
     </p>
 
-    <form method="POST" action="login">
+    <%= form_tag login_path do %>
       <% if flash[:error] %>
         <div class=error><%= flash[:error] %></div>
       <% end %>
       <input id="shop" name="shop" type="text" autofocus="autofocus" placeholder="example.myshopify.com" class="marketing-input">
       <button type="submit" class="marketing-button">Install</button>
-    </form>
+    <% end %>
   </main>
 
 </body>


### PR DESCRIPTION
On #513, the login form method was changed from GET to POST. This causes Rails to raise an invalid token error. Using the form_tag helper, the form automatically gets a hidden input with the token, to protect from CSRF attacks.