### PR TITLE
Prevent flash script from running on Turbolinks preview

### DIFF
--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <% content_for :javascript do %>
-<script type="text/javascript">
+<script type="text/javascript" data-turbolinks-eval="false">
   var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
 
   document.addEventListener(eventName, function flash() {

--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,17 +1,20 @@
 <% content_for :javascript do %>
-<script type="text/javascript" data-turbolinks-eval="false">
-  var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
+  <script type="text/javascript">
+      var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
 
-  document.addEventListener(eventName, function flash() {
-    <% if flash[:notice] %>
-      ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
-    <% end %>
+      if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
+          document.addEventListener(eventName, function flash() {
+              <% if flash[:notice] %>
+              ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
+              <% end %>
 
-    <% if flash[:error] %>
-      ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
-    <% end %>
-                             
-    document.removeEventListener(eventName, flash)
-  });
-</script>
+              <% if flash[:error] %>
+              ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
+              <% end %>
+
+              document.removeEventListener(eventName, flash)
+          });
+      }
+  </script>
 <% end %>
+

--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,20 +1,20 @@
 <% content_for :javascript do %>
   <script type="text/javascript">
-      var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
+    var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
 
-      if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
-          document.addEventListener(eventName, function flash() {
-              <% if flash[:notice] %>
-              ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
-              <% end %>
+    if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
+      document.addEventListener(eventName, function flash() {
+        <% if flash[:notice] %>
+          ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
+        <% end %>
 
-              <% if flash[:error] %>
-              ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
-              <% end %>
+        <% if flash[:error] %>
+          ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
+        <% end %>
 
-              document.removeEventListener(eventName, flash)
-          });
-      }
+        document.removeEventListener(eventName, flash)
+      });
+    }
   </script>
 <% end %>
 


### PR DESCRIPTION
Adds a data attribute to prevent the flash code from running when Turbolinks is displaying a preview of the page. Otherwise, the flash code will run again during that short instant of the preview.

The same can be achieve by wrapping the flash code in a conditional to check if:
`document.documentElement.hasAttribute("data-turbolinks-preview")`

Just annotating with an attribute seems cleaner, though not so clear. 

