### PR TITLE
Add missing quotes around error class in sessions/new

### DIFF
--- a/app/views/shopify_app/sessions/new.html.erb
+++ b/app/views/shopify_app/sessions/new.html.erb
@@ -112,7 +112,7 @@
 
     <%= form_tag login_path do %>
       <% if flash[:error] %>
-        <div class=error><%= flash[:error] %></div>
+        <div class="error"><%= flash[:error] %></div>
       <% end %>
       <input id="shop" name="shop" type="text" autofocus="autofocus" placeholder="example.myshopify.com" class="marketing-input">
       <button type="submit" class="marketing-button">Install</button>


### PR DESCRIPTION
The https://github.com/Shopify/better-html gem raises errors when serving this file because `error` is unquoted.