### PR TITLE
[WIP] Full page redirect if cookie can't be set

### DIFF
--- a/app/assets/javascripts/shopify_app/redirect.js
+++ b/app/assets/javascripts/shopify_app/redirect.js
@@ -2,7 +2,7 @@ document.addEventListener("DOMContentLoaded", function() {
   var redirectTargetElement = document.getElementById("redirection-target");
   var targetInfo = JSON.parse(redirectTargetElement.dataset.target)
 
-  if (window.top == window.self) {
+  if (window.top == window.self && canSetThirdPartyCookie()) {
     // If the current window is the 'parent', change the URL by setting location.href
     window.top.location.href = targetInfo.url;
   } else {
@@ -17,3 +17,9 @@ document.addEventListener("DOMContentLoaded", function() {
     window.parent.postMessage(data, targetInfo.myshopifyUrl);
   }
 });
+
+function canSetThirdPartyCookie() {
+  var cookie = "third_party_cookie_check=1"
+  document.cookie = cookie
+  return document.cookie.includes(cookie)
+};

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -39,6 +39,8 @@ module ShopifyApp
     def redirect_to_login
       if request.xhr?
         head :unauthorized
+      elsif params[:shop].present?
+        fullpage_redirect_to login_url
       else
         session[:return_to] = request.fullpath if request.get?
         redirect_to login_url


### PR DESCRIPTION
Any browsers that disable third party cookies will need a full page redirect for login. This will check whether we can set a cookie before trying to do an app redirect.