### PR TITLE
clear shopify_user in session

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+LineLength:
+  Exclude:
+    - test/**/*
+
+Metrics/ClassLength:
+  Exclude:
+    - test/**/*

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -28,8 +28,7 @@ module ShopifyApp
 
     def login_again_if_different_shop
       if shop_session && params[:shop] && params[:shop].is_a?(String) && (shop_session.url != params[:shop])
-        session[:shopify] = nil
-        session[:shopify_domain] = nil
+        clear_shop_session
         redirect_to_login
       end
     end
@@ -48,9 +47,14 @@ module ShopifyApp
     end
 
     def close_session
+      clear_shop_session
+      redirect_to login_url
+    end
+
+    def clear_shop_session
       session[:shopify] = nil
       session[:shopify_domain] = nil
-      redirect_to login_url
+      session[:shopify_user] = nil
     end
 
     def login_url

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -136,11 +136,13 @@ module ShopifyApp
       shop_id = 1
       session[:shopify] = shop_id
       session[:shopify_domain] = 'shop1.myshopify.com'
+      session[:shopify_user] = { 'id' => 1, 'email' => 'foo@example.com' }
 
       get :destroy
 
       assert_nil session[:shopify]
       assert_nil session[:shopify_domain]
+      assert_nil session[:shopify_user]
       assert_redirected_to login_path
       assert_equal 'Successfully logged out', flash[:notice]
     end


### PR DESCRIPTION
https://github.com/Shopify/shopify_app/pull/459 introduced shopify_user in session, and it's cleared out here: https://github.com/Shopify/shopify_app/blob/master/app/controllers/shopify_app/sessions_controller.rb#L32

However, we should clear it out as well in login_protection