### PR TITLE
Update javascript flash message from html_safe

### DIFF
--- a/example/app/views/layouts/_flash_messages.html.erb
+++ b/example/app/views/layouts/_flash_messages.html.erb
@@ -4,11 +4,11 @@
 
     document.addEventListener(eventName, function() {
       <% if flash[:notice] %>
-        ShopifyApp.flashNotice("<%= escape_javascript flash[:notice].html_safe %>");
+        ShopifyApp.flashNotice(<%== flash[:notice].to_json %>);
       <% end %>
 
       <% if flash[:error] %>
-        ShopifyApp.flashError("<%= escape_javascript flash[:error].html_safe %>");
+        ShopifyApp.flashError(<%== flash[:error].to_json %>);
       <% end %>
     });
   </script>

--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -5,11 +5,11 @@
   if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
     document.addEventListener(eventName, function flash() {
       <% if flash[:notice] %>
-        ShopifyApp.flashNotice("<%= j flash[:notice].html_safe %>");
+        ShopifyApp.flashNotice(<%== flash[:notice].to_json %>);
       <% end %>
 
       <% if flash[:error] %>
-        ShopifyApp.flashError("<%= j flash[:error].html_safe %>");
+        ShopifyApp.flashError(<%== flash[:error].to_json %>);
       <% end %>
                              
       document.removeEventListener(eventName, flash)


### PR DESCRIPTION
The flash messages generated by this app just caused a PR I created that makes use of the `shopify_app` gem to get flagged for review.

See https://github.com/Shopify/payment_gateway_sample_app/pull/1

Just updating the cause at the source.