### PR TITLE
Rename `login_url` method to `login_url_with_optional_shop` to avoid ambiguity with Rails' route helper method of the same name

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -15,7 +15,7 @@ module ShopifyApp
         redirect_to return_address
       else
         flash[:error] = I18n.t('could_not_log_in')
-        redirect_to login_url_with_optional_shop
+        redirect_to(login_url_with_optional_shop)
       end
     end
 

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -15,7 +15,7 @@ module ShopifyApp
         redirect_to return_address
       else
         flash[:error] = I18n.t('could_not_log_in')
-        redirect_to login_url
+        redirect_to login_url_with_optional_shop
       end
     end
 

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -22,14 +22,14 @@ module ShopifyApp
         does_not_have_storage_access_url: top_level_interaction_path(
           shop: sanitized_shop_name
         ),
-        has_storage_access_url: login_url(top_level: true),
+        has_storage_access_url: login_url_with_optional_shop(top_level: true),
         app_home_url: granted_storage_access_path(shop: sanitized_shop_name),
         current_shopify_domain: current_shopify_domain,
       })
     end
 
     def top_level_interaction
-      @url = login_url(top_level: true)
+      @url = login_url_with_optional_shop(top_level: true)
       validate_shop
     end
 
@@ -45,7 +45,7 @@ module ShopifyApp
     def destroy
       reset_session
       flash[:notice] = I18n.t('.logged_out')
-      redirect_to login_url
+      redirect_to login_url_with_optional_shop
     end
 
     private
@@ -110,7 +110,7 @@ module ShopifyApp
     end
 
     def authenticate_at_top_level
-      fullpage_redirect_to login_url(top_level: true)
+      fullpage_redirect_to login_url_with_optional_shop(top_level: true)
     end
 
     def authenticate_in_context?
@@ -132,7 +132,7 @@ module ShopifyApp
         does_not_have_storage_access_url: top_level_interaction_path(
           shop: sanitized_shop_name
         ),
-        has_storage_access_url: login_url(top_level: true),
+        has_storage_access_url: login_url_with_optional_shop(top_level: true),
         app_home_url: granted_storage_access_path(shop: sanitized_shop_name),
         current_shopify_domain: current_shopify_domain
       }

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -45,7 +45,7 @@ module ShopifyApp
     def destroy
       reset_session
       flash[:notice] = I18n.t('.logged_out')
-      redirect_to login_url_with_optional_shop
+      redirect_to(login_url_with_optional_shop)
     end
 
     private
@@ -110,7 +110,7 @@ module ShopifyApp
     end
 
     def authenticate_at_top_level
-      fullpage_redirect_to login_url_with_optional_shop(top_level: true)
+      fullpage_redirect_to(login_url_with_optional_shop(top_level: true))
     end
 
     def authenticate_in_context?
@@ -128,14 +128,18 @@ module ShopifyApp
     end
 
     def redirect_to_request_storage_access
-      render :request_storage_access, layout: false, locals: {
-        does_not_have_storage_access_url: top_level_interaction_path(
-          shop: sanitized_shop_name
-        ),
-        has_storage_access_url: login_url_with_optional_shop(top_level: true),
-        app_home_url: granted_storage_access_path(shop: sanitized_shop_name),
-        current_shopify_domain: current_shopify_domain
-      }
+      render(
+        :request_storage_access,
+        layout: false,
+        locals: {
+          does_not_have_storage_access_url: top_level_interaction_path(
+            shop: sanitized_shop_name
+          ),
+          has_storage_access_url: login_url_with_optional_shop(top_level: true),
+          app_home_url: granted_storage_access_path(shop: sanitized_shop_name),
+          current_shopify_domain: current_shopify_domain,
+        }
+      )
     end
   end
 end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -47,13 +47,13 @@ module ShopifyApp
         if request.get?
           session[:return_to] = "#{request.path}?#{sanitized_params.to_query}"
         end
-        redirect_to login_url_with_optional_shop
+        redirect_to(login_url_with_optional_shop)
       end
     end
 
     def close_session
       clear_shop_session
-      redirect_to login_url_with_optional_shop
+      redirect_to(login_url_with_optional_shop)
     end
 
     def clear_shop_session

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -47,13 +47,13 @@ module ShopifyApp
         if request.get?
           session[:return_to] = "#{request.path}?#{sanitized_params.to_query}"
         end
-        redirect_to login_url
+        redirect_to login_url_with_optional_shop
       end
     end
 
     def close_session
       clear_shop_session
-      redirect_to login_url
+      redirect_to login_url_with_optional_shop
     end
 
     def clear_shop_session
@@ -62,7 +62,7 @@ module ShopifyApp
       session[:shopify_user] = nil
     end
 
-    def login_url(top_level: false)
+    def login_url_with_optional_shop(top_level: false)
       url = ShopifyApp.configuration.login_url
 
       query_params = login_url_params(top_level: top_level)


### PR DESCRIPTION
`login_url` potentially conflicts with Rails' route helper methods which are auto generated. Since this engine defines a `login` route, `login_url` would be the generated method.

While this doesn't cause problems in normal use cases, if the same route is defined in the main app's route to point to a customized sessions controller (for example), the route helper method `login_url` will take precedence causing redirects to happen *without* the `shop` param.

ie:

```ruby
Rails.application.routes.draw do
  get 'login', to: 'sessions#new', as: :login

  mount ShopifyApp::Engine, at: '/'
end
```

Even though this is guarding against an uncommon edge case, there's no reason to keep the conflicting method name.

This simply renames it to `login_url_with_optional_shop`.

NOTE: I guess this is a potentially breaking change if anyone had overridden `login_url` previously even though it's a protected method.