### PR TITLE
Skip layout when doing full page redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ doc/
 *.sqlite3
 test/tmp/*
 .idea
+# ignore sprockets cache
+/test/dummy/tmp/*

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -70,7 +70,7 @@ module ShopifyApp
 
     def fullpage_redirect_to(url)
       if ShopifyApp.configuration.embedded_app?
-        render 'shopify_app/shared/redirect', locals: { url: url, current_shopify_domain: current_shopify_domain }
+        render 'shopify_app/shared/redirect', layout: false, locals: { url: url, current_shopify_domain: current_shopify_domain }
       else
         redirect_to url
       end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 require 'action_controller'
 require 'action_controller/base'
+require 'action_view/testing/resolvers'
 
 class LoginProtectionController < ActionController::Base
+  include ShopifyApp::EmbeddedApp
   include ShopifyApp::LoginProtection
   helper_method :shop_session
 
@@ -170,6 +172,15 @@ class LoginProtectionTest < ActionController::TestCase
       assert_raise ShopifyApp::LoginProtection::ShopifyDomainNotFound do
         get :redirect
       end
+    end
+  end
+
+  test '#fullpage_redirect_to skips rendering layout' do
+    with_application_test_routes do
+      example_shop = 'shop.myshopify.com'
+      get :redirect, params: { shop: example_shop }
+      rendered_templates = @_templates.keys
+      assert_equal(['shopify_app/shared/redirect'], rendered_templates)
     end
   end
 


### PR DESCRIPTION
I needed to do a full page redirect and so I used the one from `LoginProtection` since I'm including that concern in my controller. I noticed the redirect was failing due to some missing instance variables. I realized that `ShopifyApp::LoginProtection`, together with `ShopifyApp::EmbeddedApp` renders the embedded_app layout file and then yields redirect HTML+JS.

`ShopifyApp::AuthenticatedController` mixes in both `ShopifyApp::LoginProtection` and `ShopifyApp::EmbeddedApp`:

```ruby
module ShopifyApp
  class AuthenticatedController < ActionController::Base
    # ...
    include ShopifyApp::LoginProtection
    include ShopifyApp::EmbeddedApp

    # ...
  end
end
```

So, I'd assume that in most cases the rendered redirection page looks like this:

```html
# app/views/layout/embedded_app.html.erb
<!DOCTYPE html>
<html lang="en">
<!-- ... -->

  <body>
    <div class="app-wrapper">
      <div class="app-content">
        <main role="main">
          # app/views/shopify_app/shared/redirect.html.erb
          # <%= yield %>
          <!DOCTYPE html>
          <html lang="en">
          <head>
            <meta charset="utf-8" />
            <base target="_top">
            <title>Redirecting…</title>
            <%= javascript_include_tag('shopify_app/redirect', crossorigin: 'anonymous', integrity: true) %>
          </head>
          <!-- ... -->
          # end <%= yield %>
        </main>
      </div>
    </div>

    <!-- ... -->
  </body>
</html>

```

This PR fixes it by explicitly not rendering a layout.

I hope the spec is good. I spent several hours getting it to green since it's my first TestUnit test I've ever written.