### PR TITLE
Fix outdated "Questions or probems" links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,6 @@ Tunneling is also useful for working the the embedded app sdk to solve mixed con
 
 Questions or problems?
 ----------------------
-http://api.shopify.com <= Read up on the possible API calls!
 
-http://ecommerce.shopify.com/c/shopify-apis-and-technology <= Ask questions!
-
-http://docs.shopify.com/api/the-basics/getting-started <= Read the docs!
+- [Ask questions!](https://ecommerce.shopify.com/c/shopify-apis-and-technology)
+- [Read the docs!](https://help.shopify.com/api/guides)


### PR DESCRIPTION
- http://api.shopify.com does not give me anything to read. The "Read the docs" link covers the API anyway. So remove the link to api.shopify.com
- Use current URLs
- Prettify