### PR TITLE
Adds the ability to configure the login_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ provider :shopify,
   callback_path: '/nested/auth/shopify/callback'
 ```
 
+### Custom login URL
+
+While you can customize the login view by creating a `/app/views/shopify_app/sessions/new.html.erb` file, you may also want to customize the URL entirely. You can modify your `shopify_app.rb` initializer to provide a custom `login_url` e.g.:
+
+```ruby
+ShopifyApp.configure do |config|
+  config.login_url = 'https://my.domain.com/nested/login'
+end
+```
+
 Per User Authentication
 -----------------------
 To enable per user authentication you need to update the `omniauth.rb` initializer:

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -17,6 +17,7 @@ module ShopifyApp
 
     # customise urls
     attr_accessor :root_url
+    attr_accessor :login_url
 
     # customise ActiveJob queue names
     attr_accessor :scripttags_manager_queue_name
@@ -36,7 +37,7 @@ module ShopifyApp
     end
 
     def login_url
-      File.join(@root_url, 'login')
+      @login_url || File.join(@root_url, 'login')
     end
 
     def session_repository=(klass)


### PR DESCRIPTION
### Problem

While working on our embedded app we ran into a requirement where we want to redirect users to a separate landing page in order to go through the login flow.

Currently the `shopify_app` gem redirects to `login_url` but that's hard coded to be essentially `"#{root_url}/login"`


### Solution

This PR adds a `login_url` `attr_accessor` so that clients can configure the login URL. It defaults to the old behaviour until you've customized the URL.

ex:

```ruby
ShopifyApp.configure do |config|
  config.login_url = 'https://my.domain.com/some/route/login
end
```