### PR TITLE
Revert "Removing the read_orders scope from list of default scopes provided to a generated app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ ShopifyApp.configure do |config|
   config.application_name = 'Your app name' # Optional
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
-  config.scope = 'read_customers, write_products'
+  config.scope = 'read_customers, read_orders, write_products'
   config.embedded_app = true
 end
 ```

--- a/example/config/initializers/shopify_app.rb
+++ b/example/config/initializers/shopify_app.rb
@@ -2,7 +2,7 @@ ShopifyApp.configure do |config|
   config.application_name = 'Example App'
   config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
   config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
-  config.scope = 'read_customers, write_products'
+  config.scope = 'read_customers, read_orders, write_products'
   config.embedded_app = true
   config.session_repository = Shop
 end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -9,7 +9,7 @@ module ShopifyApp
       class_option :application_name, type: :array, default: ['My', 'Shopify', 'App']
       class_option :api_key, type: :string, default: '<api_key>'
       class_option :secret, type: :string, default: '<secret>'
-      class_option :scope, type: :array, default: ['read_products']
+      class_option :scope, type: :array, default: ['read_orders,', 'read_products']
       class_option :embedded, type: :string, default: 'true'
 
       def create_shopify_app_initializer

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -2,8 +2,7 @@ ShopifyApp.configure do |config|
   config.application_name = "<%= @application_name %>"
   config.api_key = "<%= @api_key %>"
   config.secret = "<%= @secret %>"
-  config.scope = "<%= @scope %>" # Consult this page for more scope options:
-                                 # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
+  config.scope = "<%= @scope %>"
   config.embedded_app = <%= embedded_app? %>
   config.after_authenticate_job = false
   config.session_repository = ShopifyApp::InMemorySessionStore

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -18,7 +18,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match 'config.application_name = "My Shopify App"', shopify_app
       assert_match 'config.api_key = "<api_key>"', shopify_app
       assert_match 'config.secret = "<secret>"', shopify_app
-      assert_match 'config.scope = "read_products"', shopify_app
+      assert_match 'config.scope = "read_orders, read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match "config.after_authenticate_job = false", shopify_app
     end


### PR DESCRIPTION
Reverts Shopify/shopify_app#629