### PR TITLE
Fixes issue with ITP circumvention and redirecting to requested URL

### DIFF
--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -103,7 +103,7 @@
 
   /* ITP 2.0 solution: handles cookie partitioning */
   StorageAccessHelper.prototype.setUpHelper = function() {
-    return new ITPHelper({redirectUrl: window.shopOrigin + "/admin/apps/" + window.apiKey});
+    return new ITPHelper({redirectUrl: window.shopOrigin + "/admin/apps/" + window.apiKey + window.returnTo});
   }
 
   StorageAccessHelper.prototype.setCookieAndRedirect = function() {

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -54,6 +54,8 @@ module ShopifyApp
       return render_invalid_shop_error unless sanitized_shop_name.present?
       session['shopify.omniauth_params'] = { shop: sanitized_shop_name }
 
+      session[:return_to] = params[:return_to] if params[:return_to]
+
       if user_agent_can_partition_cookies
         authenticate_with_partitioning
       else
@@ -77,7 +79,7 @@ module ShopifyApp
         authenticate_in_context
       else
         set_top_level_oauth_cookie
-        fullpage_redirect_to enable_cookies_path(shop: sanitized_shop_name)
+        enable_cookie_access
       end
     end
 
@@ -94,6 +96,13 @@ module ShopifyApp
     def render_invalid_shop_error
       flash[:error] = I18n.t('invalid_shop_url')
       redirect_to return_address
+    end
+
+    def enable_cookie_access
+      fullpage_redirect_to(enable_cookies_path(
+        shop: sanitized_shop_name,
+        return_to: session[:return_to]
+      ))
     end
 
     def authenticate_in_context

--- a/app/views/shopify_app/sessions/enable_cookies.html.erb
+++ b/app/views/shopify_app/sessions/enable_cookies.html.erb
@@ -17,6 +17,7 @@
   <script>
     window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
     window.shopOrigin = "https://<%= @shop %>";
+    window.returnTo = "<%= params[:return_to] %>"
   </script>
 
   <%= javascript_include_tag('shopify_app/enable_cookies', crossorigin: 'anonymous', integrity: true) %>

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -75,6 +75,10 @@ module ShopifyApp
       query_params = {}
       query_params[:shop] = sanitized_params[:shop] if params[:shop].present?
 
+      if session[:return_to] && return_to_param_required?
+        query_params[:return_to] = session[:return_to]
+      end
+
       has_referer_shop_name = referer_sanitized_shop_name.present?
 
       if has_referer_shop_name
@@ -83,6 +87,11 @@ module ShopifyApp
 
       query_params[:top_level] = true if top_level
       query_params
+    end
+
+    def return_to_param_required?
+      native_params = %i[shop hmac timestamp locale protocol return_to]
+      request.path != '/' || sanitized_params.except(*native_params).any?
     end
 
     def fullpage_redirect_to(url)

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -89,7 +89,7 @@ class LoginProtectionTest < ActionController::TestCase
       sess = stub(domain: 'https://foobar.myshopify.com')
       ShopifyApp::SessionRepository.expects(:retrieve).returns(sess).once
       get :second_login, params: { shop: 'other-shop' }
-      assert_redirected_to '/login?shop=other-shop.myshopify.com'
+      assert_redirected_to '/login?return_to=%2Fsecond_login%3Fshop%3Dother-shop.myshopify.com&shop=other-shop.myshopify.com'
       assert_nil session[:shopify]
       assert_nil session[:shopify_domain]
       assert_nil session[:shopify_user]


### PR DESCRIPTION
I realize that the ITP issues and workarounds are a larger ongoing discussion; however, the problems this PR addresses required us to move our app onto a fork of the gem. I'd like to be able to switch back to the official release as soon as this issue is resolved.

The issue is that in user agents which are subject to the ITP workarounds (Safari 12, Safari WebView in the Shopify POS), the `session[:redirect_to]` value in `ShopifyApp::LoginProtection` is saved prior to the user agent allowing cookies to be set. Once the `fullpage_redirect_to enable_cookies_path` happens at the top level, the original `session[:return_to]` URL is lost. This means that if an unauthenticated user follows a deep link into the app (like from a `More Actions` link or from a POS integration link), then after authentication is successful they are returned to the root path of the app and **not** to the path they requested. This is a significant issue for us.

The changes in this PR ensure that the originally requested URL is saved throughout the redirection process, and the user is eventually taken to the appropriate content that was requested. If there's a simpler way of solving this, I'd love to hear it. If not, the changes below do solve the problem.