### PR TITLE
Clean up omniauth setup

### DIFF
--- a/example/config/initializers/omniauth.rb
+++ b/example/config/initializers/omniauth.rb
@@ -1,18 +1,8 @@
+# frozen_string_literal: true
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :shopify,
     ShopifyApp.configuration.api_key,
     ShopifyApp.configuration.secret,
-    scope: ShopifyApp.configuration.scope,
-    setup: lambda { |env|
-      strategy = env['omniauth.strategy']
-
-      shopify_auth_params = strategy.session['shopify.omniauth_params']&.with_indifferent_access
-      shop = if shopify_auth_params.present?
-        "https://#{shopify_auth_params[:shop]}"
-      else
-        ''
-      end
-
-      strategy.options[:client_options][:site] = shop
-    }
+    scope: ShopifyApp.configuration.scope
 end

--- a/example/db/schema.rb
+++ b/example/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,12 +13,11 @@
 ActiveRecord::Schema.define(version: 20160212213112) do
 
   create_table "shops", force: :cascade do |t|
-    t.string   "shopify_domain", null: false
-    t.string   "shopify_token",  null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string   "shopify_domain", limit: 255, null: false
+    t.string   "shopify_token",  limit: 255, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.index ["shopify_domain"], name: "index_shops_on_shopify_domain", unique: true
   end
-
-  add_index "shops", ["shopify_domain"], name: "index_shops_on_shopify_domain", unique: true
 
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.0')
   s.add_runtime_dependency('rails', '>= 5.0.0')
   s.add_runtime_dependency('shopify_api', '>= 4.3.5')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 1.2.0')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.0.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')


### PR DESCRIPTION
In investigating some reports of the example app in this repo not working correctly I discovered that `shopify_auth_params` here is `nil`. After a bit of a goose chase I [fixed the inconsistency](https://github.com/Shopify/omniauth-shopify-oauth2/pull/71) between pulling `shop` from session/param in the omniauth library.

Now developers can use this gem without having to set a custom `setup` key in the initializer so I'm removing it from the examples.

Reports:
#354 
#598
https://github.com/Shopify/shopify_app/issues/467#issuecomment-402637019
https://github.com/Shopify/omniauth-shopify-oauth2/issues/61
https://github.com/Shopify/omniauth-shopify-oauth2/issues/64

## :tophat: instructions

Copy some API keys into a `.env` file in the `example/` directory.

```
cd example/
bundle install && bundle exec rake db:migrate
bundle exec rails server
```
Step through the auth process and you shouldn't see any `invalid_site` or CSRF errors.