### PR TITLE
Pass shop param to omniauth strategy

### DIFF
--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -61,7 +61,7 @@ module ShopifyApp
 
     def authenticate_in_context
       clear_top_level_oauth_cookie
-      redirect_to "#{main_app.root_path}auth/shopify"
+      redirect_to URI::Generic.build(path: "#{main_app.root_path}auth/shopify", query: {shop: params[:shop]}.to_param).to_s
     end
 
     def authenticate_at_top_level

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -42,21 +42,21 @@ module ShopifyApp
     test '#new redirects to the auth page if top_level param' do
       session.delete('shopify.cookies_persist')
       get :new, params: { shop: 'my-shop', top_level: true }
-      assert_redirected_to '/auth/shopify'
+      assert_redirected_to '/auth/shopify?shop=my-shop'
     end
 
     test "#new should authenticate the shop if a valid shop param exists non embedded" do
       session.delete('shopify.cookies_persist')
       ShopifyApp.configuration.embedded_app = false
       get :new, params: { shop: 'my-shop' }
-      assert_redirected_to '/auth/shopify'
+      assert_redirected_to '/auth/shopify?shop=my-shop'
       assert_equal session['shopify.omniauth_params'][:shop], 'my-shop.myshopify.com'
     end
 
     test '#new authenticates the shop if we\'ve just returned from top-level login flow' do
       session['shopify.top_level_oauth'] = true
       get :new, params: { shop: 'my-shop' }
-      assert_redirected_to '/auth/shopify'
+      assert_redirected_to '/auth/shopify?shop=my-shop'
       assert_equal session['shopify.omniauth_params'][:shop], 'my-shop.myshopify.com'
     end
 


### PR DESCRIPTION
In doing some local testing with shopify_app I discovered that the shop param isn't being passed to the oauth path properly, which makes the app unable to authenticate.