### PR TITLE
Fix instructions for preventing forceRedirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ see [TROUBLESHOOTING.md](https://github.com/Shopify/shopify_app/blob/master/docs
 Testing an embedded app outside the Shopify admin
 -------------------------------------------------
 
-By default, loading your embedded app will redirect to the Shopify admin, with the app view loaded in an `iframe`. If you need to load your app outside of the Shopify admin (e.g., for performance testing), you can change `forceRedirect: false` to `true` in `ShopifyApp.init` block in the `embedded_app` view. To keep the redirect on in production but off in your `development` and `test` environments, you can use:
+By default, loading your embedded app will redirect to the Shopify admin, with the app view loaded in an `iframe`. If you need to load your app outside of the Shopify admin (e.g., for performance testing), you can change `forceRedirect: true` to `false` in `ShopifyApp.init` block in the `embedded_app` view. To keep the redirect on in production but off in your `development` and `test` environments, you can use:
 
 ```javascript
 forceRedirect: <%= Rails.env.development? || Rails.env.test? ? 'false' : 'true' %>


### PR DESCRIPTION
It seems to me like the `true` and `false` should change place in order for the sentence makes sense.
After this change the sentence will read:

>If you need to load your app outside of the Shopify admin -- you can change `forceRedirect: true` to `false`