### PR TITLE
Fix infinite loop when third-party cookies are disabled

### DIFF
--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -33,9 +33,14 @@
   }
 
   StorageAccessHelper.prototype.grantedStorageAccess = function() {
-    sessionStorage.setItem('shopify.granted_storage_access', true);
-    document.cookie = 'shopify.granted_storage_access=true';
-    this.redirectToAppHome();
+    try {
+      sessionStorage.setItem('shopify.granted_storage_access', true);
+      document.cookie = 'shopify.granted_storage_access=true';
+      this.redirectToAppHome();
+    } catch (error) {
+      console.warn('Third party cookies may be blocked.', error);
+      this.redirectToAppTLD(ACCESS_DENIED_STATUS);
+    }
   }
 
   StorageAccessHelper.prototype.handleRequestStorageAccess = function() {

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')
-  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('sqlite3', '~> 1.3.6')
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')
 


### PR DESCRIPTION
Fixes #677.

I’m not that familiar with our ITP solution, so I’m looking for feedback on the direction here.

We already have a check on the number of install redirects; this try/catch block just makes sure that this is the path we go down if users have explicitly turned off third-party cookies.

![chrome-storage-demo](https://user-images.githubusercontent.com/786799/52302808-4bfb4800-295c-11e9-9bc4-9f08ca473d33.gif)
