### PR TITLE
Hide policial from shipit

### DIFF
--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,3 +1,3 @@
 # using the default shipit config
  hide:
-  - policial
+  - code-review/policial


### PR DESCRIPTION
Policial is doing weird things (trying to analyze the wrong PR) and blocking deploys in Shipit. We don’t want Policial affecting Shipit.