### PR TITLE
Clear stale shopify_user sessions

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -54,7 +54,7 @@ module ShopifyApp
 
       session[:shopify] = ShopifyApp::SessionRepository.store(session_store)
       session[:shopify_domain] = shop_name
-      session[:shopify_user] = associated_user if associated_user.present?
+      session[:shopify_user] = associated_user
     end
 
     def install_webhooks

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -40,6 +40,15 @@ module ShopifyApp
       assert_equal 'shop.myshopify.com', session[:shopify_domain]
     end
 
+    test '#callback clears a stale shopify_user session if none is provided in latest callback' do
+      session[:shopify_user] = 'user_object'
+      mock_shopify_omniauth
+
+      get :callback, params: { shop: 'shop' }
+      assert_not_nil session[:shopify]
+      assert_nil session[:shopify_user]
+    end
+
     test '#callback sets up a shopify session with a user for online mode' do
       mock_shopify_user_omniauth
 


### PR DESCRIPTION
### Problem

If an individual logs into `Shop1` as `User1` and installs an app on `Shop1` both a `session[:shopify]` and `session[:shopify_user]` are created.

If the individual then logs into `Shop2` as `User2` and installs the same app `session[:shopify]` will now properly refer to `shop2.myshopify.com` but the `session[:shopify_user]` will still refer to `User1`.

### Solution

If no `associated_user` is present in the callback we should clear the stale `session[:shopify_user]` since it isn't relevant anymore.