### PR TITLE
Update configuration languages in translations.yml

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -1,5 +1,5 @@
 source_language: en
-target_languages: [de, es, fr, it, ja, pt-BR]
+target_languages: [de, es, fr, it, ja, nl, pt-BR, zh-CN, zh-TW]
 components:
   - name: 'merchant'
     paths:


### PR DESCRIPTION
We are now translating Shopify into [nl](https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?iso_639_1=nl), [zh-CN](https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?iso_639_1=zh), [zh-TW](https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?iso_639_1=zh).
Unless you have a specific reason not to, simply merge this mandatory change to your `translation.yml` file.
For any questions, contact [#intl-services](https://shopify.slack.com/messages/C7TJQLVC7/).

**Owners:** @Shopify/platform-dev-tools-education
