### PR TITLE
Abstract support to secrets rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test/tmp/*
 # ignore sprockets cache
 /test/dummy/tmp/*
 /node_modules/
+.byebug_history
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_from:
+  - https://shopify.github.io/ruby-style-guide/rubocop.yml
+
 LineLength:
   Exclude:
     - test/**/*

--- a/README.md
+++ b/README.md
@@ -364,6 +364,32 @@ We've also provided a generator which creates a skeleton job and updates the ini
 bin/rails g shopify_app:add_after_authenticate_job
 ```
 
+RotateShopifyTokenJob
+---------------------
+
+If your Shopify secret key is leaked, you can use the RotateShopifyTokenJob to perform [API Credential Rotation](https://help.shopify.com/en/api/getting-started/authentication/oauth/api-credential-rotation).
+
+Before running the job, you'll need to generate a new secret key from your Shopify Partner dashboard, and update the `/config/initializers/shopify_app.rb` to hold your new and old secret keys:
+
+```ruby
+config.secret = Rails.application.secrets.shopify_secret
+config.old_secret = Rails.application.secrets.old_shopify_secret
+```
+
+We've provided a generator which creates the job and an example rake task:
+
+```sh
+bin/rails g shopify_app:rotate_shopify_token_job
+```
+
+The generated rake task will be found at `lib/tasks/shopify/rotate_shopify_token.rake` and is provided strictly for example purposes. It might not work with your application out of the box without some configuration.
+
+⚠️ Note: if you are updating `shopify_app` from a version prior to 8.4.2 (and do not wish to run the default/install generator again), you will need to add [the following line](https://github.com/Shopify/shopify_app/blob/4f7e6cca2a472d8f7af44b938bd0fcafe4d8e88a/lib/generators/shopify_app/install/templates/shopify_provider.rb#L18) to `config/intializers/omniauth.rb`:
+
+```ruby
+strategy.options[:old_client_secret] = ShopifyApp.configuration.old_secret
+```
+
 ShopifyApp::SessionRepository
 -----------------------------
 

--- a/lib/generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator.rb
+++ b/lib/generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator.rb
@@ -12,7 +12,9 @@ module ShopifyApp
       def init_after_authenticate_config
         initializer = load_initializer
 
-       after_authenticate_job_config = "  config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: false }\n"
+        after_authenticate_job_config =
+          "  config.after_authenticate_job = "\
+          "{ job: Shopify::AfterAuthenticateJob, inline: false }\n"
 
         inject_into_file(
           'config/initializers/shopify_app.rb',

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -9,6 +9,7 @@ module ShopifyApp
       class_option :application_name, type: :array, default: ['My', 'Shopify', 'App']
       class_option :api_key, type: :string, default: '<api_key>'
       class_option :secret, type: :string, default: '<secret>'
+      class_option :old_secret, type: :string, default: '<old_secret>'
       class_option :scope, type: :array, default: ['read_products']
       class_option :embedded, type: :string, default: 'true'
 
@@ -16,6 +17,7 @@ module ShopifyApp
         @application_name = format_array_argument(options['application_name'])
         @api_key = options['api_key']
         @secret = options['secret']
+        @old_secret = options['old_secret']
         @scope = format_array_argument(options['scope'])
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -2,6 +2,7 @@ ShopifyApp.configure do |config|
   config.application_name = "<%= @application_name %>"
   config.api_key = "<%= @api_key %>"
   config.secret = "<%= @secret %>"
+  config.old_secret = "<%= @old_secret %>"
   config.scope = "<%= @scope %>" # Consult this page for more scope options:
                                  # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
   config.embedded_app = <%= embedded_app? %>

--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb
@@ -1,16 +1,19 @@
-  provider :shopify,
-           ShopifyApp.configuration.api_key,
-           ShopifyApp.configuration.secret,
-           scope: ShopifyApp.configuration.scope,
-           setup: lambda { |env|
-             strategy = env['omniauth.strategy']
+# frozen_string_literal: true
 
-             shopify_auth_params = strategy.session['shopify.omniauth_params']&.with_indifferent_access
-             shop = if shopify_auth_params.present?
-               "https://#{shopify_auth_params[:shop]}"
-             else
-               ''
-             end
+provider :shopify,
+  ShopifyApp.configuration.api_key,
+  ShopifyApp.configuration.secret,
+  scope: ShopifyApp.configuration.scope,
+  setup: lambda { |env|
+    strategy = env['omniauth.strategy']
 
-             strategy.options[:client_options][:site] = shop
-           }
+    shopify_auth_params = strategy.session['shopify.omniauth_params']&.with_indifferent_access
+    shop = if shopify_auth_params.present?
+      "https://#{shopify_auth_params[:shop]}"
+    else
+      ''
+    end
+
+    strategy.options[:client_options][:site] = shop
+    strategy.options[:old_client_secret] = ShopifyApp.configuration.old_secret
+  }

--- a/lib/generators/shopify_app/rotate_shopify_token_job/rotate_shopify_token_job_generator.rb
+++ b/lib/generators/shopify_app/rotate_shopify_token_job/rotate_shopify_token_job_generator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails/generators/base'
+
+module ShopifyApp
+  module Generators
+    class RotateShopifyTokenJobGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+
+      def add_rotate_shopify_token_job
+        copy_file('rotate_shopify_token_job.rb', "app/jobs/shopify/rotate_shopify_token_job.rb")
+        copy_file('rotate_shopify_token.rake', "lib/tasks/shopify/rotate_shopify_token.rake")
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/rotate_shopify_token_job/templates/rotate_shopify_token.rake
+++ b/lib/generators/shopify_app/rotate_shopify_token_job/templates/rotate_shopify_token.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+namespace :shopify do
+  desc "Rotate shopify tokens for all active shops"
+  task :rotate_shopify_tokens, [:refresh_token] => :environment do |_t, args|
+    all_active_shops.find_each do |shop|
+      Shopify::RotateShopifyTokenJob.perform_later(
+        shop_domain: shop.shopify_domain,
+        refresh_token: args[:refresh_token]
+      )
+    end
+  end
+
+  # Its implementation will depend on the app configuration. Change accordingly.
+  def all_active_shops
+    Shop.all
+  end
+end

--- a/lib/generators/shopify_app/rotate_shopify_token_job/templates/rotate_shopify_token_job.rb
+++ b/lib/generators/shopify_app/rotate_shopify_token_job/templates/rotate_shopify_token_job.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Shopify
+  class RotateShopifyTokenJob < ActiveJob::Base
+    def perform(params)
+      @shop = Shop.find_by(shopify_domain: params[:shop_domain])
+      return unless @shop
+
+      config = ShopifyApp.configuration
+      uri = URI("https://#{@shop.shopify_domain}/admin/oauth/access_token")
+      post_data = {
+        client_id: config.api_key,
+        client_secret: config.secret,
+        refresh_token: params[:refresh_token],
+        access_token: @shop.shopify_token,
+      }
+
+      @response = Net::HTTP.post_form(uri, post_data)
+      return log_error(response_expcetion_error_message) unless @response.is_a?(Net::HTTPSuccess)
+
+      access_token = JSON.parse(@response.body)['access_token']
+      return log_error(no_access_token_error_message) unless access_token
+
+      @shop.update(shopify_token: access_token)
+    end
+
+    private
+
+    def log_error(message)
+      Rails.logger.error(message)
+    end
+
+    def no_access_token_error_message
+      "RotateShopifyTokenJob response returned no access token for shop: #{@shop.shopify_domain}"
+    end
+
+    def response_exception_error_message
+      "RotateShopifyTokenJob failed for shop: #{@shop.shopify_domain}." \
+        "Response returned status: #{@response.code}. Error message: #{@response.message}. "
+    end
+  end
+end

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -7,6 +7,7 @@ module ShopifyApp
     attr_accessor :application_name
     attr_accessor :api_key
     attr_accessor :secret
+    attr_accessor :old_secret
     attr_accessor :scope
     attr_accessor :embedded_app
     alias_method  :embedded_app?, :embedded_app

--- a/lib/shopify_app/controller_concerns/webhook_verification.rb
+++ b/lib/shopify_app/controller_concerns/webhook_verification.rb
@@ -15,12 +15,16 @@ module ShopifyApp
     end
 
     def hmac_valid?(data)
-      secret = ShopifyApp.configuration.secret
-      digest = OpenSSL::Digest.new('sha256')
-      ActiveSupport::SecurityUtils.secure_compare(
-        shopify_hmac,
-        Base64.encode64(OpenSSL::HMAC.digest(digest, secret, data)).strip
-      )
+      secrets = [ShopifyApp.configuration.secret, ShopifyApp.configuration.old_secret].reject(&:blank?)
+
+      secrets.any? do |secret|
+        digest = OpenSSL::Digest.new('sha256')
+
+        ActiveSupport::SecurityUtils.secure_compare(
+          shopify_hmac,
+          Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, data))
+        )
+      end
     end
 
     def shop_domain

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.0')
   s.add_runtime_dependency('rails', '>= 5.0.0')
   s.add_runtime_dependency('shopify_api', '>= 4.3.5')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.0.0')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.1.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -18,6 +18,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match 'config.application_name = "My Shopify App"', shopify_app
       assert_match 'config.api_key = "<api_key>"', shopify_app
       assert_match 'config.secret = "<secret>"', shopify_app
+      assert_match 'config.old_secret = "<old_secret>"', shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match "config.after_authenticate_job = false", shopify_app

--- a/test/generators/rotate_shopify_token_job_generator_test.rb
+++ b/test/generators/rotate_shopify_token_job_generator_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'generators/shopify_app/rotate_shopify_token_job/rotate_shopify_token_job_generator'
+
+class RotateShopifyTokenJobGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::RotateShopifyTokenJobGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+
+  setup do
+    prepare_destination
+    run_generator
+  end
+
+  test "adds the rotate_shopify_token job" do
+    assert_directory "app/jobs/shopify"
+    assert_file "app/jobs/shopify/rotate_shopify_token_job.rb"
+  end
+
+  test "adds the rotate_shopify_token rake task" do
+    assert_directory "lib/tasks/shopify"
+    assert_file "lib/tasks/shopify/rotate_shopify_token.rake"
+  end
+end


### PR DESCRIPTION
Relates to https://github.com/Shopify/buy-button/issues/2739

- Extend the hmac validation to support both previous and new token when a secret rotation is happening. 
- Add a job generator, to make requests to all `shops` to update their `shopify_token` with the use of a `refresh_token`. This should work for any consumer that has `shopify_token` and `shopify_domain` in their `shops` table.

PR by @jamiemtdwyer and @jmignac 