### PR TITLE
Moving the inline js to a js asset file

### DIFF
--- a/example/app/assets/javascripts/flash_messages.js
+++ b/example/app/assets/javascripts/flash_messages.js
@@ -1,0 +1,17 @@
+var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
+
+if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
+  document.addEventListener(eventName, function flash() {
+    var flash = JSON.parse(document.getElementById('flash').dataset.flash);
+
+    if (flash.notice) {
+      ShopifyApp.flashNotice(flash.notice);
+    }
+
+    if (flash.error) {
+      ShopifyApp.flashError(flash.error);
+    }
+
+    document.removeEventListener(eventName, flash)
+  });
+}

--- a/example/app/assets/javascripts/flash_messages.js
+++ b/example/app/assets/javascripts/flash_messages.js
@@ -2,7 +2,7 @@ var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMCon
 
 if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
   document.addEventListener(eventName, function flash() {
-    var flash = JSON.parse(document.getElementById('flash').dataset.flash);
+    var flash = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
 
     if (flash.notice) {
       ShopifyApp.flashNotice(flash.notice);

--- a/example/app/assets/javascripts/shopify_app.js
+++ b/example/app/assets/javascripts/shopify_app.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  var data = document.getElementById('shopify-app-init').dataset;
+  ShopifyApp.init({
+    apiKey: data.apiKey,
+    shopOrigin: data.shopOrigin,
+    debug: data.debug,
+    forceRedirect: true
+  });
+});

--- a/example/app/assets/javascripts/shopify_app.js
+++ b/example/app/assets/javascripts/shopify_app.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ShopifyApp.init({
     apiKey: data.apiKey,
     shopOrigin: data.shopOrigin,
-    debug: data.debug,
+    debug: data.debug === 'true',
     forceRedirect: true
   });
 });

--- a/example/app/views/layouts/_flash_messages.html.erb
+++ b/example/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,3 @@
 <% content_for :javascript do %>
-  <%= content_tag(:div, nil, id: 'flash', data: { flash: { notice: flash[:notice], error: flash[:error] } }) %>
+  <%= content_tag(:div, nil, id: 'shopify-app-flash', data: { flash: { notice: flash[:notice], error: flash[:error] } }) %>
 <% end %>

--- a/example/app/views/layouts/_flash_messages.html.erb
+++ b/example/app/views/layouts/_flash_messages.html.erb
@@ -1,15 +1,3 @@
 <% content_for :javascript do %>
-  <script type="text/javascript">
-    var eventName = typeof(Turbolinks) !== 'undefined' ? 'page:change' : 'DOMContentLoaded';
-
-    document.addEventListener(eventName, function() {
-      <% if flash[:notice] %>
-        ShopifyApp.flashNotice(<%== flash[:notice].to_json %>);
-      <% end %>
-
-      <% if flash[:error] %>
-        ShopifyApp.flashError(<%== flash[:error].to_json %>);
-      <% end %>
-    });
-  </script>
+  <%= content_tag(:div, nil, id: 'flash', data: { flash: { notice: flash[:notice], error: flash[:error] } }) %>
 <% end %>

--- a/example/app/views/layouts/embedded_app.html.erb
+++ b/example/app/views/layouts/embedded_app.html.erb
@@ -28,6 +28,11 @@
         forceRedirect: true
       });
     </script>
+    <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
+      api_key: ShopifyApp.configuration.api_key,
+      shop_origin: ("https://#{ @shop_session.url }" if @shop_session),
+      debug: (Rails.env.development? ? 'true' : 'false')
+    } ) %>
 
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 

--- a/example/app/views/layouts/embedded_app.html.erb
+++ b/example/app/views/layouts/embedded_app.html.erb
@@ -20,18 +20,10 @@
 
     <script src="https://cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
 
-    <script type="text/javascript">
-      ShopifyApp.init({
-        apiKey: "<%= ShopifyApp.configuration.api_key %>",
-        shopOrigin: "<%= "https://#{ @shop_session.domain }" if @shop_session %>",
-        debug: false,
-        forceRedirect: true
-      });
-    </script>
     <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
       api_key: ShopifyApp.configuration.api_key,
       shop_origin: ("https://#{ @shop_session.url }" if @shop_session),
-      debug: (Rails.env.development? ? 'true' : 'false')
+      debug: Rails.env.development?
     } ) %>
 
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -44,7 +44,10 @@ module ShopifyApp
       def create_embedded_app_layout
         if embedded_app?
           copy_file 'embedded_app.html.erb', 'app/views/layouts/embedded_app.html.erb'
+          copy_file 'shopify_app.js', 'app/assets/javascripts/shopify_app.js'
           copy_file '_flash_messages.html.erb', 'app/views/layouts/_flash_messages.html.erb'
+          copy_file 'flash_messages.js',
+                    'app/assets/javascripts/flash_messages.js'
         end
       end
 

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -44,10 +44,10 @@ module ShopifyApp
       def create_embedded_app_layout
         if embedded_app?
           copy_file 'embedded_app.html.erb', 'app/views/layouts/embedded_app.html.erb'
-          copy_file 'shopify_app.js', 'app/assets/javascripts/shopify_app.js'
+          copy_file('shopify_app.js', 'app/assets/javascripts/shopify_app.js')
           copy_file '_flash_messages.html.erb', 'app/views/layouts/_flash_messages.html.erb'
-          copy_file 'flash_messages.js',
-                    'app/assets/javascripts/flash_messages.js'
+          copy_file('flash_messages.js',
+            'app/assets/javascripts/flash_messages.js')
         end
       end
 

--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,3 +1,3 @@
 <% content_for :javascript do %>
-  <%= content_tag(:div, nil, id: 'flash', data: { flash: { notice: flash[:notice], error: flash[:error] } }) %>
+  <%= content_tag(:div, nil, id: 'shopify-app-flash', data: { flash: { notice: flash[:notice], error: flash[:error] } }) %>
 <% end %>

--- a/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
+++ b/lib/generators/shopify_app/install/templates/_flash_messages.html.erb
@@ -1,19 +1,3 @@
 <% content_for :javascript do %>
-<script type="text/javascript">
-  var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
-
-  if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
-    document.addEventListener(eventName, function flash() {
-      <% if flash[:notice] %>
-        ShopifyApp.flashNotice(<%== flash[:notice].to_json %>);
-      <% end %>
-
-      <% if flash[:error] %>
-        ShopifyApp.flashError(<%== flash[:error].to_json %>);
-      <% end %>
-                             
-      document.removeEventListener(eventName, flash)
-    });
-  }
-</script>
+  <%= content_tag(:div, nil, id: 'flash', data: { flash: { notice: flash[:notice], error: flash[:error] } }) %>
 <% end %>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -30,6 +30,11 @@
         forceRedirect: true
       });
     </script>
+    <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
+      api_key: ShopifyApp.configuration.api_key,
+      shop_origin: ("https://#{ @shop_session.url }" if @shop_session),
+      debug: (Rails.env.development? ? 'true' : 'false')
+    } ) %>
 
     <% if content_for?(:javascript) %>
       <div id="ContentForJavascript" data-turbolinks-temporary>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -22,18 +22,10 @@
 
     <script src="https://cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
 
-    <script type="text/javascript">
-      ShopifyApp.init({
-        apiKey: "<%= ShopifyApp.configuration.api_key %>",
-        shopOrigin: "<%= "https://#{ @shop_session.domain }" if @shop_session %>",
-        debug: <%= Rails.env.development? ? 'true' : 'false' %>,
-        forceRedirect: true
-      });
-    </script>
     <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
       api_key: ShopifyApp.configuration.api_key,
       shop_origin: ("https://#{ @shop_session.url }" if @shop_session),
-      debug: (Rails.env.development? ? 'true' : 'false')
+      debug: Rails.env.development?
     } ) %>
 
     <% if content_for?(:javascript) %>

--- a/lib/generators/shopify_app/install/templates/flash_messages.js
+++ b/lib/generators/shopify_app/install/templates/flash_messages.js
@@ -1,0 +1,17 @@
+var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMContentLoaded';
+
+if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
+  document.addEventListener(eventName, function flash() {
+    var flash = JSON.parse(document.getElementById('flash').dataset.flash);
+
+    if (flash.notice) {
+      ShopifyApp.flashNotice(flash.notice);
+    }
+
+    if (flash.error) {
+      ShopifyApp.flashError(flash.error);
+    }
+
+    document.removeEventListener(eventName, flash)
+  });
+}

--- a/lib/generators/shopify_app/install/templates/flash_messages.js
+++ b/lib/generators/shopify_app/install/templates/flash_messages.js
@@ -2,7 +2,7 @@ var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMCon
 
 if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
   document.addEventListener(eventName, function flash() {
-    var flash = JSON.parse(document.getElementById('flash').dataset.flash);
+    var flash = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
 
     if (flash.notice) {
       ShopifyApp.flashNotice(flash.notice);

--- a/lib/generators/shopify_app/install/templates/shopify_app.js
+++ b/lib/generators/shopify_app/install/templates/shopify_app.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  var data = document.getElementById('shopify-app-init').dataset;
+  ShopifyApp.init({
+    apiKey: data.apiKey,
+    shopOrigin: data.shopOrigin,
+    debug: data.debug,
+    forceRedirect: true
+  });
+});

--- a/lib/generators/shopify_app/install/templates/shopify_app.js
+++ b/lib/generators/shopify_app/install/templates/shopify_app.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ShopifyApp.init({
     apiKey: data.apiKey,
     shopOrigin: data.shopOrigin,
-    debug: data.debug,
+    debug: data.debug === 'true',
     forceRedirect: true
   });
 });


### PR DESCRIPTION
## What is the problem you are trying to solve?

[Content Security Policy(CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is an additional layer of security that helps detecting and migrating from Cross-site Scripting (XSS). When generate a new Shopify app through the gem, it's generate few files and one of the files is `app/views/layouts/embedded_app.html.erb` and `app/views/layouts/_flash_messages.html.erb`. This file `lib/generators/shopify_app/install/install_generator.rb` copies the following files to your app.
- `lib/generators/shopify_app/install/templates/embedded_app.html.erb`
- `lib/generators/shopify_app/install/templates/_flash_messages.html.erb` 

The `embedded_app.html.erb` and `_flash_messages.html.erb` contains an inline script tag and it's doesn't play well with CSP, where the first option is to replace the `<script>` tag with a `<%= nonced_javascript_tag %>` if you are using [secure_headers](https://github.com/twitter/secure_headers) or `<%= javascript_tag nonce: true %>` if you are using Rails 5.2 CSP. The second option is to allow `'unsafe-inline'` which is definitely not recommend because it defeats the purpose of CSP detecting and migrating from XSS.

## What are you trying to accomplish with this PR?
Move inline javascript into a `.js` asset and pass the ERB variables through a data attribute in a div so it plays nicely with CSP.

## How to 🎩 this PR?

The :tophat:ing for this PR is divide into 3 parts. Part 1 will be making sure the shopify app loads and doesn't throw any errors. Part 2 will be checking the files that the shopify app generates and finally part 3 will be making sure that flashes works.

### Setting up Shopify_app

1. First clone the repo

2. Create a new Ruby on Rails project
  ```bash
  rails new test-project
  ```

3. Add the shopify_app gem into your Gemfile and make it point to the local shopify_app
  ```ruby
  gem 'shopify_app', path: 'THE GEM LOCAL PATH'
  ```

4. Install the gem by running:
  ```bash
  bundle install
  ```

5. Generate a shopify_app using rails generator
  ```
  rails generate shopify_app --api_key <YOUR API KEY>  --secret <YOUR SECRET>
  ```

6. Run the application
  ```
  rails s
  ```

### Part 1 (Shopify app init)

1. Install the application on your development store

2. Go to the main page and check that there is no errors in the console. You should see warnings but no errors. Check the following :point_down:  screenshot for reference.

<img width="1867" alt="test0x04___discountify___shopify" src="https://user-images.githubusercontent.com/13983801/53367706-d78d4680-3914-11e9-80d4-76cd82c66cda.png">

### Part 2

1. open the file `app/views/layouts/embedded_app.html.erb` and make sure that the file doesn't have the following script tag.

https://github.com/Shopify/shopify_app/blob/b7fd181c73378b3956dbce95dab90b06e12b9244/lib/generators/shopify_app/install/templates/embedded_app.html.erb#L25-L32

But it has a `content_tag(:div....)`

https://github.com/Shopify/shopify_app/blob/d19a02835c95917c625072b0007d34d4c05059c2/lib/generators/shopify_app/install/templates/embedded_app.html.erb#L25-L29

2. make sure that the gem generate a JavaScript file in the assets folder `app/assets/javascripts/shopify_app.js` and it matches the following file.

https://github.com/Shopify/shopify_app/blob/d19a02835c95917c625072b0007d34d4c05059c2/lib/generators/shopify_app/install/templates/shopify_app.js#L1-L9


### Part 3 (Flashes)

To make sure that application displays the flash messages, we have to pass them to the view. The easiest way would be to pass the flashes through a get parameter and than take that parameter and pass it to flash

#### Setup

In `app/controllers/home_controllers.rb` modify the index action to be like the following:

```ruby
  def index
    @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
    @webhooks = ShopifyAPI::Webhook.find(:all)
    flash[:error] = params[:error] if params[:error]
    flash[:notice] = params[:notice] if params[:notice]
  end
```

#### Testing

To view the flashes goto https://<YOURR DEVELOPMENT STORE>.myshopify.com/admin/apps/<YOUR APPLICATION>/?error=This+is+an+error. You should see an error flash message with `This is an error` and in the console you should see `ShopifyApp client sent {"message":"Shopify.API.flash.error","data":{"message":"This is an error"}} to https://test0x04.myshopify.com`

<img width="1865" alt="test0x04___discountify___shopify" src="https://user-images.githubusercontent.com/13983801/53371866-6b641000-391f-11e9-9651-01da52972497.png">

To view the flashes goto https://<YOURR DEVELOPMENT STORE>.myshopify.com/admin/apps/<YOUR APPLICATION>/?notice=This is a notice. You should see an error flash message with `This is a notice` and in the console you should see `ShopifyApp client sent {"message":"Shopify.API.flash.notice","data":{"message":"This is a notice"}} to https://test0x04.myshopify.com`

<img width="1859" alt="test0x04___discountify___shopify" src="https://user-images.githubusercontent.com/13983801/53372173-2ee4e400-3920-11e9-9ea4-f5c32516747c.png">