### PR TITLE
Fix infinite loop when Edge has third-party cookies blocked.

### DIFF
--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -36,6 +36,9 @@
     try {
       sessionStorage.setItem('shopify.granted_storage_access', true);
       document.cookie = 'shopify.granted_storage_access=true';
+      if (!document.cookie) {
+        throw 'Cannot set third-party cookie.'
+      }
       this.redirectToAppHome();
     } catch (error) {
       console.warn('Third party cookies may be blocked.', error);


### PR DESCRIPTION
@nwtn, @sergey-alekseev

Another fix on top of #684. I only now had the chance to test how 8.4.2 works on MS Edge (v44), when third-party cookies are blocked, and it still results in an infinite loop. 

Edge does't throw an error when we try to set session storage or cookies, even if third-party cookies are blocked. My solution is to manually check and throw the error if cookies are empty, after we just attempted to set one. 