### PR TITLE
Add expiry to cookies to allow persisted cookies in example

### DIFF
--- a/example/config/initializers/session_store.rb
+++ b/example/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_example_session'
+Rails.application.config.session_store(:cookie_store, key: '_example_session', expire_after: 14.days)


### PR DESCRIPTION
See https://github.com/Shopify/merchant-experience-of-apps/issues/196

In order to optimize performance of apps on mobile, subsequent load time can be reduced if the app uses persisted cookies. This updates the example to include this suggestion.