### PR TITLE
Include session_store template in the install generator

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
-gem 'sqlite3', '~> 1.3.0'
+gem 'sqlite3'
 
 gem 'dotenv-rails'
 gem 'shopify_app', '~> 8.0.0'

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.0'
 
 gem 'dotenv-rails'
 gem 'shopify_app', '~> 8.0.0'

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -22,6 +22,10 @@ module ShopifyApp
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'
       end
+	  
+      def create_session_store_initializer
+  		  copy_file 'session_store.rb', 'config/initializers/session_store.rb'
+      end
 
       def create_and_inject_into_omniauth_initializer
         unless File.exist? "config/initializers/omniauth.rb"

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -22,9 +22,9 @@ module ShopifyApp
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'
       end
-	  
+
       def create_session_store_initializer
-  		  copy_file 'session_store.rb', 'config/initializers/session_store.rb'
+        copy_file('session_store.rb', 'config/initializers/session_store.rb')
       end
 
       def create_and_inject_into_omniauth_initializer

--- a/lib/generators/shopify_app/install/templates/session_store.rb
+++ b/lib/generators/shopify_app/install/templates/session_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store(:cookie_store, key: '_example_session', expire_after: 14.days)

--- a/lib/generators/shopify_app/install/templates/session_store.rb
+++ b/lib/generators/shopify_app/install/templates/session_store.rb
@@ -1,0 +1,3 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.session_store(:cookie_store, key: '_example_session', expire_after: 14.days)


### PR DESCRIPTION
Addresses https://github.com/Shopify/shopify_app/pull/703#issuecomment-471657509

This includes a template for the generator that configures the `session_store` to include a persisted cookie.