### PR TITLE
Add a concern ShopifyApp::Authenticated so apps don't have to inherit from AuthenticatedController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+8.6.0
+-----
+
+* Added an `Authenticated` concern to allow gem users to inherit from a custom `AuthenticatedController` instead of
+  `ShopifyApp::AuthenticatedController`
+
 8.5.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Table of Contents
 * [**ScripttagsManager**](#scripttagsmanager)
 * [**AfterAuthenticate Job**](#afterauthenticate-job)
 * [**ShopifyApp::SessionRepository**](#shopifyappsessionrepository)
-* [**AuthenticatedController**](#authenticatedcontroller)
+* [**Authenticated**](#authenticated)
 * [**AppProxyVerification**](#appproxyverification)
  * [Recommended Usage](#recommended-usage)
 * [**Troubleshooting**](#troubleshooting)
@@ -397,10 +397,12 @@ ShopifyApp::SessionRepository
 
 If you only run the install generator then by default you will have an in memory store but it **won't work** on multi-server environments including Heroku. If you ran all the generators including the shop_model generator then the `Shop` model itself will be the `SessionRepository`. If you look at the implementation of the generated shop model you'll see that this gem provides a concern for the `SessionRepository`. You can use this concern on any model that responds to `shopify_domain` and `shopify_token`.
 
-AuthenticatedController
------------------------
+Authenticated
+-------------
 
-The engine includes a controller called `ShopifyApp::AuthenticatedController` which inherits from `ActionController::Base`. It adds some before_filters which ensure the user is authenticated and will redirect to the login page if not. It is best practice to have all controllers that belong to the Shopify part of your app inherit from this controller. The HomeController that is generated already inherits from AuthenticatedController.
+The engine provides a `ShopifyApp::Authenticated` concern which should be included in any controller that is intended to be behind Shopify OAuth. It adds `before_action`s to ensure that the user is authenticated and will redirect to the Shopify login page if not. It is best practice to include this concern in a base controller inheriting from your `ApplicationController`, from which all controllers that require Shopify authentication inherit.
+
+For backwards compatibility, the engine still provides a controller called `ShopifyApp::AuthenticatedController` which includes the `ShopifyApp::Authenticated` concern. Note that it inherits directly from `ActionController::Base`, so you will not be able to share functionality between it and your application's `ApplicationController`.
 
 AppProxyVerification
 --------------------

--- a/app/controllers/concerns/shopify_app/authenticated.rb
+++ b/app/controllers/concerns/shopify_app/authenticated.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module Authenticated
+    extend ActiveSupport::Concern
+
+    included do
+      include ShopifyApp::Localization
+      include ShopifyApp::LoginProtection
+      include ShopifyApp::EmbeddedApp
+      before_action :login_again_if_different_shop
+      around_action :shopify_session
+    end
+  end
+end

--- a/app/controllers/shopify_app/authenticated_controller.rb
+++ b/app/controllers/shopify_app/authenticated_controller.rb
@@ -1,11 +1,7 @@
 module ShopifyApp
   class AuthenticatedController < ActionController::Base
-    include ShopifyApp::Localization
-    include ShopifyApp::LoginProtection
-    include ShopifyApp::EmbeddedApp
+    include ShopifyApp::Authenticated
 
     protect_from_forgery with: :exception
-    before_action :login_again_if_different_shop
-    around_action :shopify_session
   end
 end

--- a/example/app/controllers/authenticated_controller.rb
+++ b/example/app/controllers/authenticated_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AuthenticatedController < ApplicationController
+  include ShopifyApp::Authenticated
+end

--- a/example/app/controllers/home_controller.rb
+++ b/example/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
-class HomeController < ShopifyApp::AuthenticatedController
+# frozen_string_literal: true
+
+class HomeController < AuthenticatedController
   def index
   end
 

--- a/lib/generators/shopify_app/authenticated_controller/authenticated_controller_generator.rb
+++ b/lib/generators/shopify_app/authenticated_controller/authenticated_controller_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails/generators/base'
+
+module ShopifyApp
+  module Generators
+    class AuthenticatedControllerGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+
+      def create_home_controller
+        template('authenticated_controller.rb', 'app/controllers/authenticated_controller.rb')
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/authenticated_controller/templates/authenticated_controller.rb
+++ b/lib/generators/shopify_app/authenticated_controller/templates/authenticated_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AuthenticatedController < ApplicationController
+  include ShopifyApp::Authenticated
+end

--- a/lib/generators/shopify_app/home_controller/templates/home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/home_controller.rb
@@ -1,4 +1,6 @@
-class HomeController < ShopifyApp::AuthenticatedController
+# frozen_string_literal: true
+
+class HomeController < AuthenticatedController
   def index
     @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
     @webhooks = ShopifyAPI::Webhook.find(:all)

--- a/lib/generators/shopify_app/shopify_app_generator.rb
+++ b/lib/generators/shopify_app/shopify_app_generator.rb
@@ -9,6 +9,7 @@ module ShopifyApp
       def run_all_generators
         generate "shopify_app:install #{@opts.join(' ')}"
         generate "shopify_app:shop_model"
+        generate("shopify_app:authenticated_controller")
         generate "shopify_app:home_controller"
       end
     end

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '8.5.1'.freeze
+  VERSION = '8.6.0'.freeze
 end

--- a/test/controllers/concerns/authenticated_test.rb
+++ b/test/controllers/concerns/authenticated_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AuthenticatedTest < ActionController::TestCase
+  class AuthenticatedTestController < ActionController::Base
+    include ShopifyApp::Authenticated
+
+    def index
+    end
+  end
+
+  tests AuthenticatedTestController
+
+  test "includes all the needed concerns" do
+    AuthenticatedTestController.include?(ShopifyApp::Localization)
+    AuthenticatedTestController.include?(ShopifyApp::LoginProtection)
+    AuthenticatedTestController.include?(ShopifyApp::EmbeddedApp)
+  end
+end


### PR DESCRIPTION
Currently, any app that uses `shopify_app` needs to inherit from `ShopifyApp::AuthenticatedController` so those parts of their app receive Shopify authentication. This has the unfortunate consequence that controllers cannot inherit from the application's actually `ApplicationController` and leads to a situation where there's no place for shared functionality of both authenticated and unauthenticated controllers can go.

This PR adds a `Authenticated` concern, which can simply be included in an `AuthenticatedController` defined by the app, which can then inherit from `ApplicationController` and benefit from any shared functionality therein. 