### PR TITLE
Restore the original root_url to fix a leaky test.

### DIFF
--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -25,11 +25,17 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "can set root_url which affects login_url" do
-    ShopifyApp.configure do |config|
-      config.root_url = "/nested"
-    end
+    begin
+      original_root = ShopifyApp.configuration.root_url
 
-    assert_equal "/nested/login", ShopifyApp.configuration.login_url
+      ShopifyApp.configure do |config|
+        config.root_url = "/nested"
+      end
+
+      assert_equal "/nested/login", ShopifyApp.configuration.login_url
+    ensure
+      ShopifyApp.configuration.root_url = original_root
+    end
   end
 
   test "defaults to myshopify_domain" do


### PR DESCRIPTION
Recently I observed these test failures: https://travis-ci.org/Shopify/shopify_app/jobs/509660290

The failures can be reproduced locally with `SEED=6112 bundle exec rake test`.

They occur because a test modifies the `root_url` configuration option and fails to reset it at the end of the test.