### PR TITLE
Set highest gem version for shopify_api.

### DIFF
--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.0')
   s.add_runtime_dependency('rails', '>= 5.0.0')
-  s.add_runtime_dependency('shopify_api', '>= 4.3.5')
+  s.add_runtime_dependency('shopify_api', '>= 4.3.5', '< 7.0.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.1.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Next major version of shopify_api will have breaking changes and will require a new version for shopify_app.  

This change stops `8.6.x` to  not bump up to the 7.0 version for shopify_api 