### PR TITLE
Make uniqueness case insensive by default.

### DIFF
--- a/lib/shopify_app/session/session_storage.rb
+++ b/lib/shopify_app/session/session_storage.rb
@@ -3,7 +3,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
-      validates :shopify_domain, presence: true, uniqueness: true
+      validates :shopify_domain, presence: true, uniqueness: { case_sensitive: false }
       validates :shopify_token, presence: true
     end
 


### PR DESCRIPTION
## Description

Following an upgrade to rails 6.0.0beta3 I've received a lot of warning concerning the uniqueness of the `shopify_domain` and the fact that rails 6.1 will no longer enforce case sensitive comparison by default.

More informations at https://github.com/rails/rails/blob/master/guides/source/active_record_validations.md#uniqueness

## Proposition

Let's mark the uniqueness as non-case-sensitive by default cause `MyShop.myshopify.com` should be equal to `myshop.myshopify.com` anyway.

This would limit the noise when running tests on an app that is using `Shopify_app`

Example:
```bash
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :shopify_domain attribute in Shop model, pass `case_sensitive: true` option explicitly to the uniqueness validator. (called from run_callbacks at /Users/mlhamel/.gem/ruby/2.5.3/gems/bugsnag-6.11.1/lib/bugsnag/integrations/rails/active_record_rescue.rb:25)
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :shopify_domain attribute in Shop model, pass `case_sensitive: true` option explicitly to the uniqueness validator. (called from run_callbacks at /Users/mlhamel/.gem/ruby/2.5.3/gems/bugsnag-6.11.1/lib/bugsnag/integrations/rails/active_record_rescue.rb:25)
.I, [2019-04-04T12:10:06.377411 #82913]  INFO -- omniauth: (shopify) Setup endpoint detected, running now.
```