### PR TITLE
Move policial under the ci hide to ignore for release.

### DIFF
--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,3 +1,4 @@
 # using the default shipit config
- hide:
-  - code-review/policial
+ci:
+  hide:
+    - code-review/policial


### PR DESCRIPTION
Ship-it documentation points that the hide needs to be under the `ci:` configuration space.  
https://github.com/Shopify/shipit-engine#ci