### PR TITLE
Fix link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,4 +498,4 @@ is changed to
 
 ### ShopifyAPI changes
 
-You will need to also follow the ShopifyAPI [upgrade guide](https://github.com/shopify/shopify_api/README.md#-breaking-change-notice-for-version-700-) to ensure your app is ready to work with api versioning.
+You will need to also follow the ShopifyAPI [upgrade guide](https://github.com/Shopify/shopify_api/blob/master/README.md#-breaking-change-notice-for-version-700-) to ensure your app is ready to work with api versioning.


### PR DESCRIPTION
This link was a 404, now it is not.

https://github.com/Shopify/shopify_api/blob/master/README.md#-breaking-change-notice-for-version-700-