### PR TITLE
Handle Webhook.all raturning `nil` and raising on `index_by`

### DIFF
--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -55,7 +55,7 @@ module ShopifyApp
     end
 
     def current_webhooks
-      @current_webhooks ||= ShopifyAPI::Webhook.all.index_by(&:topic)
+      @current_webhooks ||= ShopifyAPI::Webhook.all.to_a.index_by(&:topic)
     end
   end
 end

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -22,6 +22,16 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
     @manager.create_webhooks
   end
 
+  test "#create_webhooks handles no webhooks present as nil" do
+    ShopifyAPI::Webhook.stubs(all: nil)
+
+    expect_webhook_creation('app/uninstalled', "https://example-app.com/webhooks/app_uninstalled")
+    expect_webhook_creation('orders/create', "https://example-app.com/webhooks/order_create")
+    expect_webhook_creation('orders/updated', "https://example-app.com/webhooks/order_updated")
+
+    @manager.create_webhooks
+  end
+
   test "#create_webhooks when creating a webhook fails, raises an error" do
     ShopifyAPI::Webhook.stubs(all: [])
     webhook = stub(persisted?: false, errors: stub(full_messages: ['topic already taken']))


### PR DESCRIPTION
## Problem

Described in #700, it is possible for `.all` on an ActiveResource object to return `nil` and not just an empty array.

This causes the `WebhooksManager` to raise calling `nil#index_by` in this case. 


## Solution

Coerce `nil.to_a` to force `[]`. It's done a few lines above in the same file in the same way.