### PR TITLE
 remove “third-party” from ITP copy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
   enable_cookies_footer: 'Cookies let the app authenticate you by temporarily storing your preferences and personal information. They expire after 30 days.'
   enable_cookies_action: 'Enable cookies'
   top_level_interaction_heading: "Your browser needs to authenticate %{app}"
-  top_level_interaction_body: "Your browser requires third-party apps like %{app} to ask you for access to cookies before Shopify can open it for you."
+  top_level_interaction_body: "Your browser requires apps like %{app} to ask you for access to cookies before Shopify can open it for you."
   top_level_interaction_action: 'Continue'
   request_storage_access_heading: "%{app} needs access to cookies"
   request_storage_access_body: "This lets the app authenticate you by temporarily storing your personal information. Click continue and allow cookies to use the app."


### PR DESCRIPTION
This is an MVP fix, English-only, for the copy in the ITP flow.

~(the updated yarn lock is unrelated, but should be committed)~