### PR TITLE
Allow #after_authenticate_job to accept a string class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,9 +347,11 @@ If your app needs to perform specific actions after the user is authenticated su
 
 ```ruby
 ShopifyApp.configure do |config|
-  config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob }
+  config.after_authenticate_job = { job: "Shopify::AfterAuthenticateJob" }
 end
 ```
+
+The job can be configured as either a class or a class name string.
 
 If you need the job to run synchronously add the `inline` flag:
 

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -86,10 +86,13 @@ module ShopifyApp
 
       return unless config && config[:job].present?
 
+      job = config[:job]
+      job = job.constantize if job.is_a?(String)
+
       if config[:inline] == true
-        config[:job].perform_now(shop_domain: session[:shopify_domain])
+        job.perform_now(shop_domain: session[:shopify_domain])
       else
-        config[:job].perform_later(shop_domain: session[:shopify_domain])
+        job.perform_later(shop_domain: session[:shopify_domain])
       end
     end
   end

--- a/lib/generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator.rb
+++ b/lib/generators/shopify_app/add_after_authenticate_job/add_after_authenticate_job_generator.rb
@@ -14,7 +14,7 @@ module ShopifyApp
 
         after_authenticate_job_config =
           "  config.after_authenticate_job = "\
-          "{ job: Shopify::AfterAuthenticateJob, inline: false }\n"
+          "{ job: \"Shopify::AfterAuthenticateJob\", inline: false }\n"
 
         inject_into_file(
           'config/initializers/shopify_app.rb',

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -124,6 +124,29 @@ module ShopifyApp
       get :callback, params: { shop: 'shop' }
     end
 
+    test "#callback calls #perform_after_authenticate_job constantizes from a string to a class" do
+      ShopifyApp.configure do |config|
+        config.after_authenticate_job = { job: "Shopify::AfterAuthenticateJob", inline: false }
+      end
+
+      Shopify::AfterAuthenticateJob.expects(:perform_later)
+
+      mock_shopify_omniauth
+      get :callback, params: { shop: 'shop' }
+    end
+
+    test "#callback calls #perform_after_authenticate_job raises if the string is not a valid job class" do
+      ShopifyApp.configure do |config|
+        config.after_authenticate_job = { job: "InvalidJobClassThatDoesNotExist", inline: false }
+      end
+
+      mock_shopify_omniauth
+
+      assert_raise NameError do
+        get :callback, params: { shop: 'shop' }
+      end
+    end
+
     private
 
     def mock_shopify_omniauth

--- a/test/generators/add_after_authenticate_job_generator_test.rb
+++ b/test/generators/add_after_authenticate_job_generator_test.rb
@@ -15,7 +15,7 @@ class AddAfterAuthenticateJobGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "config/initializers/shopify_app.rb" do |config|
-      assert_match 'config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: false }', config
+      assert_match 'config.after_authenticate_job = { job: "Shopify::AfterAuthenticateJob", inline: false }', config
     end
   end
 


### PR DESCRIPTION
## Problem

We are encountering the "removed from the module tree but still active" errors in development:

<img width="1202" alt="Slack_-_Shopify" src="https://user-images.githubusercontent.com/84159/57304130-c008d180-70ac-11e9-86f1-682ad0deebe7.png">

This is being caused by referencing the job as a class name. Then when autoload triggers in some changes, it causes that job to be reloaded. But since the `ShopifyApp.configure` block is not done in a `to_prepare` and is only done once, the reference is held and the two versions of the class conflict.


## Solution

Allow for the job to be passed in as a string and constantized. That way the class is looked up by name on each use. This is _slightly_ slower but not consequentially so.

Going forward the generator will output a string, but the literal class is still valid. I have done this approach so that there's no backwards compatiblity problems, and no behaviour difference on existing apps. We simply support both class and string now, with string being preferred.