### PR TITLE
Renaming var flash to flashData

### DIFF
--- a/example/app/assets/javascripts/flash_messages.js
+++ b/example/app/assets/javascripts/flash_messages.js
@@ -2,14 +2,14 @@ var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMCon
 
 if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
   document.addEventListener(eventName, function flash() {
-    var flash = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
+    var flashData = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
 
-    if (flash.notice) {
-      ShopifyApp.flashNotice(flash.notice);
+    if (flashData.notice) {
+      ShopifyApp.flashNotice(flashData.notice);
     }
 
-    if (flash.error) {
-      ShopifyApp.flashError(flash.error);
+    if (flashData.error) {
+      ShopifyApp.flashError(flashData.error);
     }
 
     document.removeEventListener(eventName, flash)

--- a/lib/generators/shopify_app/install/templates/flash_messages.js
+++ b/lib/generators/shopify_app/install/templates/flash_messages.js
@@ -2,14 +2,14 @@ var eventName = typeof(Turbolinks) !== 'undefined' ? 'turbolinks:load' : 'DOMCon
 
 if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
   document.addEventListener(eventName, function flash() {
-    var flash = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
+    var flashData = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
 
-    if (flash.notice) {
-      ShopifyApp.flashNotice(flash.notice);
+    if (flashData.notice) {
+      ShopifyApp.flashNotice(flashData.notice);
     }
 
-    if (flash.error) {
-      ShopifyApp.flashError(flash.error);
+    if (flashData.error) {
+      ShopifyApp.flashError(flashData.error);
     }
 
     document.removeEventListener(eventName, flash)


### PR DESCRIPTION
Previously in this PR #695 I moved the flash message script block to a separate file to make it play well with [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy). When I moved them to a separate file I had to pass the data for the flash through data attribute.

https://github.com/Shopify/shopify_app/blob/32af7acf93d343d129f69249e7e384b7337845ac/lib/generators/shopify_app/install/templates/_flash_messages.html.erb#L1-L3

In `flash_message.js` I fetch the data and store them in a variable called `flash`

https://github.com/Shopify/shopify_app/blob/32af7acf93d343d129f69249e7e384b7337845ac/lib/generators/shopify_app/install/templates/flash_messages.js#L5

The issue is that there is already a function called `flash` in the same file
https://github.com/Shopify/shopify_app/blob/32af7acf93d343d129f69249e7e384b7337845ac/lib/generators/shopify_app/install/templates/flash_messages.js#L4

So there is a conflict with the names, and that's what I am trying to accomplish in this PR, which is renaming the variable `flash` to `flashData`.