### PR TITLE
Retain return_to address after granted_storage_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+9.0.4
+-----
+
+* Fix returning to a deep link after authentication [#746](https://github.com/Shopify/shopify_app/pull/746)
+
 9.0.3
 -----
 

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -39,7 +39,7 @@ module ShopifyApp
       session['shopify.granted_storage_access'] = true
 
       params = { shop: @shop }
-      redirect_to "#{ShopifyApp.configuration.root_url}?#{params.to_query}"
+      redirect_to("#{return_address}?#{params.to_query}")
     end
 
     def destroy

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '9.0.3'.freeze
+  VERSION = '9.0.4'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
If a user accesses a deep link in an app, the user is redirected to the root url of the app after being granted storage access (or bypassed in an agent that doesn't require it). I found the root cause in SessionsController that was always using the configured root_url to redirect, instead I'm using [this method](https://github.com/Shopify/shopify_app/blob/b41fba031e6e7379580994b9b2aae71f6b53dc41/lib/shopify_app/controller_concerns/login_protection.rb#L132) in LoginProtection.