### PR TITLE
Add ability to enable simultaneous offline & online access modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,25 @@ To enable per user authentication you need to update the `omniauth.rb` initializ
 provider :shopify,
   ShopifyApp.configuration.api_key,
   ShopifyApp.configuration.secret,
+  scope: ShopifyApp.configuration.scope
+
+provider :shopify,
+  ShopifyApp.configuration.api_key,
+  ShopifyApp.configuration.secret,
   scope: ShopifyApp.configuration.scope,
-  per_user_permissions: true
+  per_user_permissions: true,
+  path_prefix: "/online_auth"
+```
+
+You also need to add an additional URL to your whitelisted redirection URLs in the Shopify partner dashboard.
+
+```
+/online_auth/shopify/callback
 ```
 
 The current Shopify user will be stored in the rails session at `session[:shopify_user]`
 
-This will change the type of token that Shopify returns and it will only be valid for a short time. Read more about `Online access` [here](https://help.shopify.com/api/getting-started/authentication/oauth). Note that this means you won't be able to use this token to respond to Webhooks.
+Read more about `Online access` [here](https://help.shopify.com/api/getting-started/authentication/oauth). Note this will cause the login process to take slightly longer due to the additional authentication.
 
 Managing Api Keys
 -----------------

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -8,9 +8,11 @@ module ShopifyApp
     def callback
       if auth_hash
         login_shop
-        install_webhooks
-        install_scripttags
-        perform_after_authenticate_job
+        unless online_access_required?
+          install_webhooks
+          install_scripttags
+          perform_after_authenticate_job
+        end
 
         redirect_to return_address
       else
@@ -56,9 +58,9 @@ module ShopifyApp
         api_version: ShopifyApp.configuration.api_version
       )
 
-      session[:shopify] = ShopifyApp::SessionRepository.store(session_store)
+      session[:shopify] = ShopifyApp::SessionRepository.store(session_store, !associated_user)
       session[:shopify_domain] = shop_name
-      session[:shopify_user] = associated_user
+      session[:shopify_user] = associated_user && associated_user.merge({token: token})
     end
 
     def install_webhooks

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -106,7 +106,7 @@ module ShopifyApp
     end
 
     def authenticate_in_context
-      redirect_to "#{main_app.root_path}auth/shopify"
+      redirect_to "#{main_app.root_path}#{online_access_required? ? 'online_auth' : 'auth'}/shopify"
     end
 
     def authenticate_at_top_level

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -3,17 +3,17 @@ ko:
   logged_out: 성공적으로 로그아웃 되었습니다.
   could_not_log_in: Shopify 스토어에 로그인할 수 없습니다.
   invalid_shop_url: 유효하지 않은 상점 도메인
-  enable_cookies_heading: "%{app} 에서 쿠키를 사용 가능"
+  enable_cookies_heading: "%{app}에서 쿠키를 사용 가능"
   enable_cookies_body: Shopify 내에서 %{app} 을 사용하기 위해 이 브라우저에서 쿠키를 수동으로 사용할 수 있습니다.
-  enable_cookies_footer: 쿠키를 사용하면 개인의 선호나 정보를 임시로 저장하여 app에서 사용자를 인증할 수 있습니다. 쿠키는
-    30일 후에 만료됩니다.
+  enable_cookies_footer: 쿠키를 사용하면 개인의 선호나 정보를 임시로 저장하여 앱에서 사용자를 인증할 수 있습니다. 쿠키는 30일
+    후에 만료됩니다.
   enable_cookies_action: 쿠리 사용 가능
   top_level_interaction_heading: 브라우저에서 %{app} 을 인증해야 합니다.
-  top_level_interaction_body: Shopify를 열기 전 쿠키에 엑세스하려면 %{app} 과 같은 app 들이 브라우저에 설치되어야
+  top_level_interaction_body: Shopify를 열기 전 쿠키에 엑세스하려면 %{app} 과 같은 앱 들이 브라우저에 설치되어야
     합니다.
   top_level_interaction_action: 계속
-  request_storage_access_heading: "%{app} 에서 쿠키에 접근해야 합니다."
-  request_storage_access_body: 이를 통해 개인 정보를 임시로 저장하여 app에서 사용자를 인증할 수 있습니다. 계속 클릭하여
-    쿠키로 app을 사용하세요.
+  request_storage_access_heading: "%{app}에서 쿠키에 접근해야 합니다."
+  request_storage_access_body: 이를 통해 개인 정보를 임시로 저장하여 앱에서 사용자를 인증할 수 있습니다. 계속 클릭하여
+    쿠키로 앱을 사용하세요.
   request_storage_access_footer: 쿠키는 30일 후에 만료됩니다.
   request_storage_access_action: 계속

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,10 +1,10 @@
 ---
 nl:
-  logged_out: U bent afgemeld
+  logged_out: u bent afgemeld
   could_not_log_in: Kon niet aanmelden bij Shopify-winkel
   invalid_shop_url: Ongeldig winkeldomein
   enable_cookies_heading: Schakel cookies in van %{app}
-  enable_cookies_body: U moet cookies in deze browser handmatig inschakelen om %{app}
+  enable_cookies_body: u moet cookies in deze browser handmatig inschakelen om %{app}
     binnen Shopify te gebruiken.
   enable_cookies_footer: Met cookies kan de app u verifiëren door uw voorkeuren en
     persoonlijke informatie tijdelijk op te slaan. Ze vervallen na 30 dagen.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ ShopifyApp::Engine.routes.draw do
 
   controller :callback do
     get 'auth/shopify/callback' => :callback
+    get 'online_auth/shopify/callback' => :callback
   end
 
   namespace :webhooks do

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -16,6 +16,8 @@ module ShopifyApp
     attr_accessor :after_authenticate_job
     attr_accessor :session_repository
     attr_accessor :api_version
+    attr_accessor :online_access
+    alias_method  :online_access?, :online_access
 
     # customise urls
     attr_accessor :root_url

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -28,7 +28,8 @@ module ShopifyApp
 
     def shop_session
       return unless session[:shopify]
-      @shop_session ||= ShopifyApp::SessionRepository.retrieve(session[:shopify])
+      return if online_access_required?
+      @shop_session ||= ShopifyApp::SessionRepository.retrieve(session[:shopify], session[:shopify_user].try(:[], :token))
     end
 
     def login_again_if_different_shop
@@ -139,6 +140,10 @@ module ShopifyApp
 
     def return_address
       session.delete(:return_to) || ShopifyApp.configuration.root_url
+    end
+
+    def online_access_required?
+      ShopifyApp.configuration.online_access? && session[:shopify] && !session[:shopify_user]
     end
   end
 end

--- a/lib/shopify_app/session/in_memory_session_store.rb
+++ b/lib/shopify_app/session/in_memory_session_store.rb
@@ -2,11 +2,11 @@ module ShopifyApp
   class InMemorySessionStore
     class EnvironmentError < StandardError; end
 
-    def self.retrieve(id)
+    def self.retrieve(id, online_access_token = nil)
       repo[id]
     end
 
-    def self.store(session)
+    def self.store(session, persist_token = true)
       id = SecureRandom.uuid
       repo[id] = session
       id

--- a/lib/shopify_app/session/session_repository.rb
+++ b/lib/shopify_app/session/session_repository.rb
@@ -11,12 +11,12 @@ module ShopifyApp
         end
       end
 
-      def retrieve(id)
-        storage.retrieve(id)
+      def retrieve(id, online_access_token = nil)
+        storage.retrieve(id, online_access_token)
       end
 
-      def store(session)
-        storage.store(session)
+      def store(session, persist_token = true)
+        storage.store(session, persist_token)
       end
 
       def storage

--- a/lib/shopify_app/session/session_storage.rb
+++ b/lib/shopify_app/session/session_storage.rb
@@ -18,20 +18,20 @@ module ShopifyApp
     end
 
     class_methods do
-      def store(session)
+      def store(session, persist_token = true)
         shop = find_or_initialize_by(shopify_domain: session.domain)
-        shop.shopify_token = session.token
+        shop.shopify_token = session.token if persist_token
         shop.save!
         shop.id
       end
 
-      def retrieve(id)
+      def retrieve(id, online_access_token = nil)
         return unless id
 
         if shop = self.find_by(id: id)
           ShopifyAPI::Session.new(
             domain: shop.shopify_domain,
-            token: shop.shopify_token,
+            token: online_access_token || shop.shopify_token,
             api_version: shop.api_version
           )
         end

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -55,7 +55,7 @@ module ShopifyApp
       get :callback, params: { shop: 'shop' }
       assert_not_nil session[:shopify]
       assert_equal 'shop.myshopify.com', session[:shopify_domain]
-      assert_equal 'user_object', session[:shopify_user]
+      assert_equal(OmniAuth::AuthHash.new({token: '1234'}), session[:shopify_user])
     end
 
     test '#callback starts the WebhooksManager if webhooks are configured' do
@@ -161,7 +161,7 @@ module ShopifyApp
         provider: :shopify,
         uid: 'shop.myshopify.com',
         credentials: { token: '1234' },
-        extra: { associated_user: 'user_object' }
+        extra: { associated_user: { } }
       )
       request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:shopify] if request
       request.env['omniauth.params'] = { shop: 'shop.myshopify.com' } if request

--- a/test/shopify_app/session/shopify_session_repository_test.rb
+++ b/test/shopify_app/session/shopify_session_repository_test.rb
@@ -7,11 +7,11 @@ class TestSessionStore
     @storage = []
   end
 
-  def retrieve(id)
+  def retrieve(id, online_access_token = nil)
     storage[id]
   end
 
-  def store(session)
+  def store(session, persist_token = true)
     id = storage.length
     storage[id] = session
     id
@@ -19,10 +19,10 @@ class TestSessionStore
 end
 
 class TestSessionStoreClass
-  def self.store(session)
+  def self.store(session, persist_token = true)
   end
 
-  def self.retrieve(id)
+  def self.retrieve(id, online_access_token = nil)
   end
 end
 


### PR DESCRIPTION
We needed online access in our app while still storing and retrieving an offline access token in the database so that webhooks and background processes would continue to work. This PR solves that problem by optionally (based on the `online_access` configuration value) expanding the authentication process to include 2 passes through the Shopify oauth flow. It is inspired by the discussion here: https://github.com/Shopify/shopify_app/issues/618

Would love feedback on the direction of this, and the liklihood of getting it merged. Thanks!

@EiNSTeiN- @nwtn 