### PR TITLE
Packaging for release 11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+11.0.0
+-----
+
+* Rename `login_url` method to `login_url_with_optional_shop` to avoid ambiguity with Rails' route helper method of the
+  same name (see [#585](https://github.com/Shopify/shopify_app/pull/585)).
+
 10.0.0
 -----
 

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '10.0.0'.freeze
+  VERSION = '11.0.0'.freeze
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
Ships changes from https://github.com/Shopify/shopify_app/pull/585 into gem v11.0.0.