### PR TITLE
add dotenv-rails to generator to fetch credentials from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+11.0.1
+-----
+
+* Add dotenv-rails gem to install generator, so apps fetch credentials from `.env` by default: [#776](https://github.com/Shopify/shopify_app/pull/776)
+
 11.0.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Table of Contents
  * [App Proxy Controller Generator](#app-proxy-controller-generator)
  * [Controllers, Routes and Views](#controllers-routes-and-views)
 * [**Mounting the Engine**](#mounting-the-engine)
-* [**Managing Api Keys**](#managing-api-keys)
 * [**WebhooksManager**](#webhooksmanager)
 * [**ScripttagsManager**](#scripttagsmanager)
 * [**AfterAuthenticate Job**](#afterauthenticate-job)
@@ -104,10 +103,21 @@ Generators
 The default generator will run the `install`, `shop`, and `home_controller` generators. This is the recommended way to start your app.
 
 ```sh
-$ rails generate shopify_app --api_key <your_api_key> --secret <your_app_secret>
+$ rails generate shopify_app
 ```
 
 After running the generator, you will need to run `rake db:migrate` to add tables to your database. You can start your app with `bundle exec rails server` and install your app by visiting localhost.
+
+### API Keys
+
+The default and install generators have been updated to source Shopify API key and secret from a `.env` file, which you will need to create with the following format:
+
+```
+SHOPIFY_API_KEY=your api key
+SHOPIFY_API_SECRET=your api secret
+```
+
+These values can be found on the "App Setup" page in the [Shopify Partners Dashboard][dashboard].
 
 ### Install Generator
 
@@ -116,7 +126,7 @@ $ rails generate shopify_app:install
 
 # or optionally with arguments:
 
-$ rails generate shopify_app:install --api_key <your_api_key> --secret <your_app_secret>
+$ rails generate shopify_app:install
 ```
 
 Other options include:
@@ -243,21 +253,6 @@ provider :shopify,
 The current Shopify user will be stored in the rails session at `session[:shopify_user]`
 
 This will change the type of token that Shopify returns and it will only be valid for a short time. Read more about `Online access` [here](https://help.shopify.com/api/getting-started/authentication/oauth). Note that this means you won't be able to use this token to respond to Webhooks.
-
-Managing Api Keys
------------------
-
-The `install` generator places your Api credentials directly into the shopify_app initializer which is convenient and fine for development but once your app goes into production **your api credentials should not be in source control**. When we develop apps we keep our keys in environment variables so a production shopify_app initializer would look like this:
-
-```ruby
-ShopifyApp.configure do |config|
-  config.application_name = 'Your app name' # Optional
-  config.api_key = ENV['SHOPIFY_CLIENT_API_KEY']
-  config.secret = ENV['SHOPIFY_CLIENT_API_SECRET']
-  config.scope = 'read_customers, write_products'
-  config.embedded_app = true
-end
-```
 
 
 WebhooksManager
@@ -439,7 +434,7 @@ class ReviewsController < ApplicationController
 end
 ```
 
-Create your app proxy url in the [Shopify Partners' Dashboard](https://app.shopify.com/services/partners/api_clients), making sure to point it to `https://your_app_website.com/app_proxy`.
+Create your app proxy url in the [Shopify Partners' Dashboard][dashboard], making sure to point it to `https://your_app_website.com/app_proxy`.
 ![Creating an App Proxy](/images/app-proxy-screenshot.png)
 
 Troubleshooting
@@ -515,3 +510,5 @@ is changed to
 ### ShopifyAPI changes
 
 You will need to also follow the ShopifyAPI [upgrade guide](https://github.com/Shopify/shopify_api/blob/master/README.md#-breaking-change-notice-for-version-700-) to ensure your app is ready to work with api versioning.
+
+[dashboard]:https://partners.shopify.com

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -7,18 +7,16 @@ module ShopifyApp
       source_root File.expand_path('../templates', __FILE__)
 
       class_option :application_name, type: :array, default: ['My', 'Shopify', 'App']
-      class_option :api_key, type: :string, default: '<api_key>'
-      class_option :secret, type: :string, default: '<secret>'
-      class_option :old_secret, type: :string, default: '<old_secret>'
       class_option :scope, type: :array, default: ['read_products']
       class_option :embedded, type: :string, default: 'true'
       class_option :api_version, type: :string, default: ShopifyAPI::ApiVersion.latest_stable_version.to_s
 
+      def add_dotenv_gem
+        gem('dotenv-rails', group: [:test, :development])
+      end
+
       def create_shopify_app_initializer
         @application_name = format_array_argument(options['application_name'])
-        @api_key = options['api_key']
-        @secret = options['secret']
-        @old_secret = options['old_secret']
         @scope = format_array_argument(options['scope'])
         @api_version = options['api_version']
 

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -1,7 +1,7 @@
 ShopifyApp.configure do |config|
   config.application_name = "<%= @application_name %>"
-  config.api_key = "<%= @api_key %>"
-  config.secret = "<%= @secret %>"
+  config.api_key = ENV['SHOPIFY_API_KEY']
+  config.secret = ENV['SHOPIFY_API_SECRET']
   config.old_secret = "<%= @old_secret %>"
   config.scope = "<%= @scope %>" # Consult this page for more scope options:
                                  # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.0.0'.freeze
+  VERSION = '11.0.1'.freeze
 end

--- a/test/app_templates/Gemfile
+++ b/test/app_templates/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 5.2.3'
+gem 'sqlite3'
+gem 'puma', '~> 3.11'
+
+gem 'shopify_app'

--- a/test/app_templates/config/initializers/shopify_app.rb
+++ b/test/app_templates/config/initializers/shopify_app.rb
@@ -1,7 +1,7 @@
 ShopifyApp.configure do |config|
   config.application_name = "name"
-  config.api_key = "key"
-  config.secret = "secret"
+  config.api_key = ENV['SHOPIFY_API_KEY']
+  config.secret = ENV['SHOPIFY_API_SECRET']
   config.scope = 'read_orders, read_products'
   config.embedded_app = true
   config.session_repository = ShopifyApp::InMemorySessionStore

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -7,6 +7,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   setup do
     prepare_destination
+    provide_existing_gemfile
     provide_existing_application_file
     provide_existing_routes_file
     provide_existing_application_controller
@@ -23,9 +24,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "My Shopify App"', shopify_app
-      assert_match 'config.api_key = "<api_key>"', shopify_app
-      assert_match 'config.secret = "<secret>"', shopify_app
-      assert_match 'config.old_secret = "<old_secret>"', shopify_app
+      assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
+      assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match "config.api_version = \"#{latest_stable_version}\"", shopify_app
@@ -37,8 +37,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(--application_name Test Name --api_key key --secret shhhhh --api_version unstable --scope read_orders, write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match 'config.api_key = "key"', shopify_app
-      assert_match 'config.secret = "shhhhh"', shopify_app
+      assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
+      assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_orders, write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
@@ -50,8 +50,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(--application_name "Test Name" --api_key key --secret shhhhh --scope "read_orders, write_products")
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match 'config.api_key = "key"', shopify_app
-      assert_match 'config.secret = "shhhhh"', shopify_app
+      assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
+      assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_orders, write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.session_repository = ShopifyApp::InMemorySessionStore', shopify_app
@@ -82,6 +82,13 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/routes.rb" do |routes|
       assert_match "mount ShopifyApp::Engine, at: '/'", routes
+    end
+  end
+
+  test "adds dotenv gem to Gemfile" do
+    run_generator
+    assert_file "Gemfile" do |gemfile|
+      assert_match "gem 'dotenv-rails', group: [:test, :development]", gemfile
     end
   end
 end

--- a/test/support/generator_test_helpers.rb
+++ b/test/support/generator_test_helpers.rb
@@ -1,6 +1,10 @@
 module GeneratorTestHelpers
   TEMPLATE_PATH = File.expand_path("../../app_templates", __FILE__)
 
+  def provide_existing_gemfile
+    copy_to_generator_root('', 'Gemfile')
+  end
+
   def provide_existing_application_controller
     copy_to_generator_root("app/controllers", "application_controller.rb")
   end


### PR DESCRIPTION
The current install generator inserts the Shopify API key and secret into `config/initializers/shopify_app.rb`, which is usually a file that is excluded from gitignore and I imagine results in leaked keys for those that aren't aware of this. Best practice at Shopify and elsewhere is to use ENV variables for these. 

This updates the generator to do so, and this has the benefit of being more compatible with shopify-app-cli.