### PR TITLE
bump to v 11.0.2 and lock shopify_api to ~> 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+11.0.2
+-----
+
+* Lock shopify_api gem dependency to `~> 7.0` from `>= 7.0.0`.
+* Remove flakey JS Tests
+* bump sqlite3 development dependency to `~>1.4` from `~> 1.3.6`. [#789](https://github.com/Shopify/shopify_app/pull/789)
+
 11.0.1
 -----
 

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.0.1'.freeze
+  VERSION = '11.0.2'.freeze
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')
-  s.add_development_dependency('sqlite3', '~> 1.3.6')
+  s.add_development_dependency('sqlite3', '~> 1.4')
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')
 

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.2')
   s.add_runtime_dependency('rails', '> 5.2.1')
-  s.add_runtime_dependency('shopify_api', '>= 7.0.0')
+  s.add_runtime_dependency('shopify_api', '~> 7.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.1.0')
 
   s.add_development_dependency('rake')

--- a/test/javascripts/shopify_app/storage_access_test.js
+++ b/test/javascripts/shopify_app/storage_access_test.js
@@ -101,7 +101,7 @@ suite('StorageAccessHelper', () => {
       storageAccessHelperSandbox.stub(storageAccessHelper, 'handleGetStorageAccess');
       storageAccessHelperSandbox.stub(storageAccessHelper, 'handleHasStorageAccess');
 
-      storageAccessHelper.manageStorageAccess().then(() => { 
+      storageAccessHelper.manageStorageAccess().then(() => {
         sinon.assert.called(storageAccessHelper.handleGetStorageAccess);
         sinon.assert.notCalled(storageAccessHelper.handleHasStorageAccess);
       });
@@ -192,13 +192,6 @@ suite('StorageAccessHelper', () => {
     });
   });
 
-  suite('redirectToAppHome', () => {
-    test('sets "shopify.granted_storage_access" in sessionStorage', () => {
-      storageAccessHelper.redirectToAppHome();
-      sinon.assert.match(sessionStorage.getItem('shopify.granted_storage_access'), 'true');
-    });
-  });
-
   suite('setNormalizedLink', () => {
     test('returns redirectData.hasStorageAccessUrl if storage access is granted', () => {
       const link = storageAccessHelper.setNormalizedLink('storage_access_granted');
@@ -220,7 +213,7 @@ suite('StorageAccessHelper', () => {
       const button = document.createElement('button');
       button.type = 'button';
       button.id = 'AcceptCookies';
-      
+
       node.appendChild(button);
       document.body.appendChild(node);
 
@@ -239,7 +232,7 @@ suite('StorageAccessHelper', () => {
       const button = document.createElement('button');
       button.type = 'button';
       button.id = 'AcceptCookies';
-      
+
       node.appendChild(button);
       document.body.appendChild(node);
 
@@ -253,7 +246,7 @@ suite('StorageAccessHelper', () => {
       document.body.removeChild(node);
     });
   });
-  
+
   suite('setCookieAndRedirect', () => {
     test('sets the shopify.cookies_persist cookie', () => {
       storageAccessHelper.setCookieAndRedirect();
@@ -265,7 +258,7 @@ suite('StorageAccessHelper', () => {
     test('passes the correct redirectUrl to the ITPHelper constructor', () => {
       window.shopOrigin = 'https://test-shop.myshopify.io';
       window.apiKey = '123';
-      
+
       const itpHelper = storageAccessHelper.setUpHelper();
       sinon.assert.match(itpHelper.redirectUrl, 'https://test-shop.myshopify.io/admin/apps/123');
     })


### PR DESCRIPTION
Minor version bump to v11.0.2 which locks the shopfiy_api dependency to `~> 7.0`. Theres breaking change set for version 8 of the shopify_api gem which we want to avoid.

I'll have another PR with a minor version bump that will require version `~> 8.0` (or `<= 8.0.0` ?) of the shopify_api gem next. 