### PR TITLE
Update api version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ config.api_version = '2019-04'
 
 ### Session storage change
 
-You will need to add an `api_version` method to you session storage object.  The default implmentation for this is.
+You will need to add an `api_version` method to you session storage object.  The default implementation for this is.
 ```ruby
 def api_version
   ShopifyApp.configuration.api_version
@@ -480,7 +480,7 @@ end
 
 ### Generated file change
 
-`embedded_app.html.erb` the useage of `shop_session.url` needs to be changed to `shop_session.domain`
+`embedded_app.html.erb` the usage of `shop_session.url` needs to be changed to `shop_session.domain`
 ```erb
 <script type="text/javascript">
   ShopifyApp.init({

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -3,7 +3,6 @@ Releasing ShopifyApp
 1. Check the Semantic Versioning page for info on how to version the new release: http://semver.org
 2. Create a pull request with the following changes:
   * Update the version of ShopifyApp in lib/shopify_app/version.rb
-  * Update the version in package.json, then run `npm install` to make sure the lock file gets updated
   * Add a CHANGELOG entry for the new release with the date
   * Change the title of the PR to something like: "Packaging for release X.Y.Z"
 3. Merge your pull request

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -9,7 +9,7 @@ module ShopifyApp
       class_option :application_name, type: :array, default: ['My', 'Shopify', 'App']
       class_option :scope, type: :array, default: ['read_products']
       class_option :embedded, type: :string, default: 'true'
-      class_option :api_version, type: :string, default: ShopifyAPI::ApiVersion.latest_stable_version.to_s
+      class_option :api_version, type: :string, default: nil
 
       def add_dotenv_gem
         gem('dotenv-rails', group: [:test, :development])
@@ -18,7 +18,7 @@ module ShopifyApp
       def create_shopify_app_initializer
         @application_name = format_array_argument(options['application_name'])
         @scope = format_array_argument(options['scope'])
-        @api_version = options['api_version']
+        @api_version = options['api_version'] || ShopifyAPI::Meta.admin_versions.find(&:latest_supported).handle
 
         template 'shopify_app.rb', 'config/initializers/shopify_app.rb'
       end

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -10,3 +10,6 @@ ShopifyApp.configure do |config|
   config.api_version = "<%= @api_version %>"
   config.session_repository = ShopifyApp::InMemorySessionStore
 end
+
+# ShopifyApp::Utils.fetch_known_api_versions                        # Uncomment to fetch known api versions from shopify servers on boot
+# ShopifyAPI::ApiVersion.version_lookup_mode = :raise_on_unknown    # Uncomment to raise an error if attempting to use an api version that was not previously known

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -12,5 +12,12 @@ module ShopifyApp
       nil
     end
 
+    def self.fetch_known_api_versions
+      Rails.logger.info("[ShopifyAPI::ApiVersion] Fetching known Admin API Versions from Shopify...")
+      ShopifyAPI::ApiVersion.fetch_known_versions
+      Rails.logger.info("[ShopifyAPI::ApiVersion] Known API Versions: #{ShopifyAPI::ApiVersion.versions.keys}")
+      rescue ActiveResource::ConnectionError
+        logger.error( "[ShopifyAPI::ApiVersion] Unable to fetch api_versions from Shopify")
+    end
   end
 end

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.0.2'.freeze
+  VERSION = '11.1.0'.freeze
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -12,14 +12,16 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.2')
   s.add_runtime_dependency('rails', '> 5.2.1')
-  s.add_runtime_dependency('shopify_api', '~> 7.0')
+  s.add_runtime_dependency('shopify_api', '~> 8.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.1.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')
+  s.add_development_dependency('pry')
   s.add_development_dependency('sqlite3', '~> 1.4')
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')
+  s.add_development_dependency('webmock')
 
   s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|example)/}) }
   s.test_files    = `git ls-files -- {test}/*`.split("\n")

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -14,13 +14,10 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   teardown do
-    ShopifyAPI::ApiVersion.clear_defined_versions
-    ShopifyAPI::ApiVersion.define_known_versions
+    ShopifyAPI::ApiVersion.clear_known_versions
   end
 
   test "creates the ShopifyApp initializer" do
-    latest_stable_version = ShopifyAPI::ApiVersion.latest_stable_version
-
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "My Shopify App"', shopify_app
@@ -28,8 +25,10 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
-      assert_match "config.api_version = \"#{latest_stable_version}\"", shopify_app
+      assert_match 'config.api_version = "2019-10"', shopify_app
       assert_match "config.after_authenticate_job = false", shopify_app
+      assert_match "# ShopifyApp::Utils.fetch_known_api_versions", shopify_app
+      assert_match "# ShopifyAPI::ApiVersion.version_lookup_mode = :raise_on_unknown ", shopify_app
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,9 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
 require 'rails/test_help'
 require 'mocha/setup'
+require 'webmock/minitest'
 require 'byebug'
+require 'pry'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
@@ -15,8 +17,30 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 class ActiveSupport::TestCase
   include GeneratorTestHelpers
 
+  API_META_TEST_RESPONSE =  <<~JSON
+  {
+    "apis": [{
+      "handle": "admin",
+      "versions": [{
+        "handle": "2019-07",
+        "display_name": "2019-07",
+        "supported": true,
+        "latest_supported": false
+      },{
+          "handle": "2019-10",
+          "latest_supported": true,
+          "display_name": "2019-10",
+          "supported": true
+        }]
+      }]
+    }
+  JSON
+
+
   def before_setup
     super
+    WebMock.disable_net_connect!
+    WebMock.stub_request(:get, "https://app.shopify.com/services/apis.json").to_return(body: API_META_TEST_RESPONSE)
     ShopifyAppConfigurer.call
   end
 end


### PR DESCRIPTION
Updates the install generator to use the new api_version from v8.0.0 of shopify_api

I debated adding adding config flags for the generator to set the api_version lookup mode and the fetch_known_version on boot, but it doesn't strike me as something you'd want to necessarily configure via a flag. I opted to just add it to the initializer and comment it out in case anyone wants to enable it. 

I wrapped `ShopifyAPI::ApiVersion.fetch_known_versions` in a utility method that just logs out that its fetching the versions and rescues and logs that the versions could not be fetched if it hits an `ActiveResource::ConnectionError`

