### PR TITLE
Upgrade version of omniauth-shopify-oauth2 gem

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.1.0'.freeze
+  VERSION = '11.2.0'.freeze
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.2')
   s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 8.0')
-  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.1.0')
+  s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')


### PR DESCRIPTION
The latest version of the `omniauth-shopify-oauth2` gem offers support for user_sessions being serialized.

This PR bumps the version of the gem.