### PR TITLE
adds config host for ngrok url

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -57,6 +57,14 @@ module ShopifyApp
         route "mount ShopifyApp::Engine, at: '/'"
       end
 
+      def insert_hosts_into_development_config
+        inject_into_file(
+          'config/environments/development.rb',
+          "  config.hosts << /\\h+.ngrok.io/\n",
+          after: "Rails.application.configure do\n"
+        )
+      end
+
       private
 
       def embedded_app?

--- a/test/app_templates/config/environments/development.rb
+++ b/test/app_templates/config/environments/development.rb
@@ -1,0 +1,2 @@
+Rails.application.configure do
+end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -11,6 +11,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     provide_existing_application_file
     provide_existing_routes_file
     provide_existing_application_controller
+    provide_development_config_file
   end
 
   teardown do
@@ -88,6 +89,13 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "Gemfile" do |gemfile|
       assert_match "gem 'dotenv-rails', group: [:test, :development]", gemfile
+    end
+  end
+
+  test "adds host config to development.rb" do
+    run_generator
+    assert_file "config/environments/development.rb" do |config|
+      assert_match "config.hosts << /\\h+.ngrok.io/", config
     end
   end
 end

--- a/test/support/generator_test_helpers.rb
+++ b/test/support/generator_test_helpers.rb
@@ -25,6 +25,10 @@ module GeneratorTestHelpers
     copy_to_generator_root("config/initializers", "shopify_app_with_webhooks.rb", rename: 'shopify_app.rb')
   end
 
+  def provide_development_config_file
+    copy_to_generator_root("config/environments", "development.rb")
+  end
+
   private
 
   def copy_to_generator_root(destination, template, rename: nil)


### PR DESCRIPTION
Adds config.hosts [required by Rails 6](https://www.fngtps.com/2019/rails6-blocked-host/).
[Fixes issue brought up in Shopify-App-CLI](https://github.com/Shopify/shopify-app-cli/issues/323)