### PR TITLE
App Extensions Generators 

### DIFF
--- a/lib/generators/shopify_app/add_marketing_activity_extension/add_marketing_activity_extension_generator.rb
+++ b/lib/generators/shopify_app/add_marketing_activity_extension/add_marketing_activity_extension_generator.rb
@@ -1,0 +1,39 @@
+require 'rails/generators/base'
+
+module ShopifyApp
+  module Generators
+    class AddMarketingActivityExtensionGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+
+      def generate_app_extension
+        template "marketing_activities_controller.rb", "app/controllers/marketing_activities_controller.rb"
+        generate_routes
+      end
+
+      private
+
+      def generate_routes
+        inject_into_file(
+          'config/routes.rb',
+          optimize_indentation(routes, 2),
+          after: "root :to => 'home#index'\n"
+        )
+      end
+
+      def routes
+        <<~EOS
+
+          resource :marketing_activities, only: [:create, :update] do
+            patch :resume
+            patch :pause
+            patch :delete
+            post :republish
+            post :preload_form_data
+            post :preview
+            post :errors
+          end
+        EOS
+      end
+    end
+  end
+end

--- a/lib/generators/shopify_app/add_marketing_activity_extension/templates/marketing_activities_controller.rb
+++ b/lib/generators/shopify_app/add_marketing_activity_extension/templates/marketing_activities_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class MarketingActivitiesController < ExtensionVerificationController
+  def preload_form_data
+    preload_data = {
+      "form_data": {
+        "budget": {
+          "currency": "USD",
+        }
+      }
+    }
+    render(json: preload_data, status: :ok)
+  end
+
+  def update
+    render(json: {}, status: :accepted)
+  end
+
+  def pause
+    render(json: {}, status: :accepted)
+  end
+
+  def resume
+    render(json: {}, status: :accepted)
+  end
+
+  def delete
+    render(json: {}, status: :accepted)
+  end
+
+  def preview
+    placeholder_img = "https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-image_small.png"
+    preview_response = {
+      "desktop": {
+        "preview_url": placeholder_img,
+        "content_type": "text/html",
+        "width": 360,
+        "height": 200
+      },
+      "mobile": {
+        "preview_url": placeholder_img,
+        "content_type": "text/html",
+        "width": 360,
+        "height": 200
+      }
+    }
+    render(json: preview_response, status: :ok)
+  end
+
+  def create
+    render(json: {}, status: :ok)
+  end
+
+  def republish
+    render(json: {}, status: :accepted)
+  end
+
+  def errors
+    request_id = params[:request_id]
+    message = params[:message]
+
+    Rails.logger.info("[Marketing Activity App Error Feedback] Request id: #{request_id}, message: #{message}")
+
+    render(json: {}, status: :ok)
+  end
+end

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -25,6 +25,9 @@ require 'shopify_app/controller_concerns/app_proxy_verification'
 require 'shopify_app/jobs/webhooks_manager_job'
 require 'shopify_app/jobs/scripttags_manager_job'
 
+# controllers
+require 'shopify_app/controllers/extension_verification_controller'
+
 # managers
 require 'shopify_app/managers/webhooks_manager'
 require 'shopify_app/managers/scripttags_manager'

--- a/lib/shopify_app/controllers/extension_verification_controller.rb
+++ b/lib/shopify_app/controllers/extension_verification_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ExtensionVerificationController < ActionController::Base
+  before_action :verify_request
+
+  private
+
+  def verify_request
+    hmac_header = request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
+    request_body = request.body.read
+    secret = ShopifyApp.configuration.secret
+    digest = OpenSSL::Digest.new('sha256')
+
+    expected_hmac = Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, request_body))
+    head(:unauthorized) unless ActiveSupport::SecurityUtils.secure_compare(expected_hmac, hmac_header)
+  end
+end

--- a/test/generators/add_marketing_activity_extension_generator_test.rb
+++ b/test/generators/add_marketing_activity_extension_generator_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+require 'generators/shopify_app/add_marketing_activity_extension/add_marketing_activity_extension_generator'
+
+class AddMarketingActivityExtensionGeneratorTest < Rails::Generators::TestCase
+  tests ShopifyApp::Generators::AddMarketingActivityExtensionGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+
+  test "adds the extension controller" do
+    provide_existing_routes_file
+
+    run_generator
+
+    assert_file "app/controllers/marketing_activities_controller.rb" do |controller|
+      assert_match 'class MarketingActivitiesController < ExtensionVerificationController', controller
+    end
+  end
+
+  test "adds the endpoint routes to routes" do
+    provide_existing_routes_file
+
+    run_generator
+
+    assert_file "config/routes.rb" do |routes|
+      resource_declaration = "resource :marketing_activities, only: [:create, :update] do"
+      routes_declarations = <<~EOS
+        patch :resume
+        patch :pause
+        patch :delete
+        post :republish
+        post :preload_form_data
+        post :preview
+        post :errors
+      EOS
+      assert resource_declaration, routes
+      assert routes_declarations, routes
+    end
+  end
+end

--- a/test/shopify_app/controllers/extension_verification_controller_test.rb
+++ b/test/shopify_app/controllers/extension_verification_controller_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class ExtensionController < ExtensionVerificationController
+  def extension_action
+    head :ok
+  end
+end
+
+class ExtensionVerificationControllerTest < ActionController::TestCase
+  tests ExtensionController
+
+  setup do
+    ShopifyApp.configure do |config|
+      config.secret = 'secret'
+      config.old_secret = 'old_secret'
+    end
+  end
+
+  test "return unauthorized when hmac is incorrect" do
+    with_application_test_routes do
+      @request.headers["HTTP_X_SHOPIFY_HMAC_SHA256"] = "invalid_hmac"
+      post :extension_action, params: { foo: 'anything' }
+      assert_response :unauthorized
+    end
+  end
+
+  test "responds ok when hmac is correct" do
+    with_application_test_routes do
+      params = { foo: 'anything' }
+      valid_hmac = 'yCGX/RrK4fcuNtr3ztk5tQGsOBjcAzHpGLdMUrbV8yI=' # Valid hmac using the new secret
+      @request.headers["HTTP_X_SHOPIFY_HMAC_SHA256"] = valid_hmac
+      post 'extension_action', params: params
+      assert_response :ok
+    end
+  end
+
+  private
+
+  def with_application_test_routes
+    with_routing do |set|
+      set.draw do
+        post '/extension_action' => 'extension#extension_action'
+      end
+      yield
+    end
+  end
+end


### PR DESCRIPTION
This pr adds generators for building app extensions (though only endpoints at the moment, no related graphql queries or jobs). 

Specifically, this PR currently supports Marketing Activities, but is (hopfully) designed to support other extensions such as Shopify POS and Kit Skills (more info at https://help.shopify.com/en/api/embedded-apps/app-extensions)

I'll put on some comments on other design decisions that were made, though some general goals were; 
 - Make sure the setup works for other app extensions 
 - Things that are optional to a minimal usage flow do not exist