### PR TITLE
FIX: FIX: Adding ngrok to config.hosts in development.rb breaks in Rails v5

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -67,7 +67,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           'config/environments/development.rb',
-          "  config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/",
+          "  config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/\n",
           after: "Rails.application.configure do\n"
         )
       end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -67,7 +67,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           'config/environments/development.rb',
-          "  config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/\n",
+          "  config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/",
           after: "Rails.application.configure do\n"
         )
       end

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -67,7 +67,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           'config/environments/development.rb',
-          "  config.hosts << /\\h+.ngrok.io/\n",
+          "  config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/\n",
           after: "Rails.application.configure do\n"
         )
       end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -95,7 +95,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "adds host config to development.rb" do
     run_generator
     assert_file "config/environments/development.rb" do |config|
-      assert_match "config.hosts << /\\h+.ngrok.io/", config
+      assert_match "config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/", config
     end
   end
 end


### PR DESCRIPTION
This should resolve the PR 822 test failures.

A recent commit added an ngrok entry to Rails.application.config.hosts. This seems to work in Rails 6, but it breaks in Rails 5. I understand the argument for adding ngrok, but there are other proxy services one could use. None of those alternatives are included. A security minded person might argue that this gem should not be doing such an update at all, but rather it should be an exercise left to the user.

The video referenced here: https://help.shopify.com/en/api/tutorials/build-a-shopify-app-with-ruby-and-sinatra, must be using Rails 5.x.