### PR TITLE
bump browser_sniffer to 1.1.3

### DIFF
--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.3.0'.freeze
+  VERSION = '11.3.1'.freeze
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3.1"
 
-  s.add_runtime_dependency('browser_sniffer', '~> 1.1.2')
+  s.add_runtime_dependency('browser_sniffer', '~> 1.1.3')
   s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 8.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.0')


### PR DESCRIPTION
This bumps the browser_sniffer gem to 1.1.3, which included changes to support a new format of user agent strings in POS Next.

I also bumped the version.rb so that dependent apps can pull in this change.