### PR TITLE
Remove dotenv from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+11.4.0
+-----
+* Remove `dotenv-rails` dependency. [#835](https://github.com/Shopify/shopify_app/pull/835)
+
 11.3.2
 -----
 * Fix hosts generator in Rails 5 [#823](https://github.com/Shopify/shopify_app/pull/823)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.3.2'.freeze
+  VERSION = '11.4.0'.freeze
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 8.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.0')
-  s.add_runtime_dependency('dotenv-rails', '~> 2.7.5')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('byebug')


### PR DESCRIPTION
Nothing in the gem uses this dependency. It should be up to each app how they manage their own environment variables.