### PR TITLE
remove dotenv-rails from generator

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -11,10 +11,6 @@ module ShopifyApp
       class_option :embedded, type: :string, default: 'true'
       class_option :api_version, type: :string, default: nil
 
-      def add_dotenv_gem
-        gem('dotenv-rails', group: [:test, :development])
-      end
-
       def create_shopify_app_initializer
         @application_name = format_array_argument(options['application_name'])
         @scope = format_array_argument(options['scope'])

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -85,13 +85,6 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "adds dotenv gem to Gemfile" do
-    run_generator
-    assert_file "Gemfile" do |gemfile|
-      assert_match "gem 'dotenv-rails', group: [:test, :development]", gemfile
-    end
-  end
-
   test "adds host config to development.rb" do
     run_generator
     assert_file "config/environments/development.rb" do |config|


### PR DESCRIPTION
#835 remove dotenv but it is still in the generator. I will re-release 11.4.0 with this fix.