### PR TITLE
Don't do CSRF validation for extensions

### DIFF
--- a/lib/shopify_app/controllers/extension_verification_controller.rb
+++ b/lib/shopify_app/controllers/extension_verification_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ExtensionVerificationController < ActionController::Base
+  protect_from_forgery with: :null_session
   before_action :verify_request
 
   private


### PR DESCRIPTION
Quick fix so that extensions don't validate csrf (because they shouldn't)