### PR TITLE
Use a string when setting session_repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ provider :shopify,
   per_user_permissions: true
 
 # In the `shopify_app.rb` initializer:
-config.session_repository = User
+config.session_repository = 'User'
 config.per_user_tokens = true
 ```
 

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb
@@ -8,7 +8,7 @@ ShopifyApp.configure do |config|
   config.embedded_app = <%= embedded_app? %>
   config.after_authenticate_job = false
   config.api_version = "<%= @api_version %>"
-  config.session_repository = ShopifyApp::InMemorySessionStore
+  config.session_repository = 'ShopifyApp::InMemorySessionStore'
 end
 
 # ShopifyApp::Utils.fetch_known_api_versions                        # Uncomment to fetch known api versions from shopify servers on boot

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -50,13 +50,8 @@ module ShopifyApp
     end
 
     def session_repository=(klass)
-      if Rails.configuration.cache_classes
-        ShopifyApp::SessionRepository.storage = klass
-      else
-        ActiveSupport::Reloader.to_prepare do
-          ShopifyApp::SessionRepository.storage = klass
-        end
-      end
+      @session_repository = klass
+      ShopifyApp::SessionRepository.storage = klass
     end
 
     def has_webhooks?

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -14,7 +14,7 @@ module ShopifyApp
     attr_accessor :webhooks
     attr_accessor :scripttags
     attr_accessor :after_authenticate_job
-    attr_accessor :session_repository
+    attr_reader :session_repository
     attr_accessor :per_user_tokens
     alias_method :per_user_tokens?, :per_user_tokens
     attr_accessor :api_version

--- a/test/app_templates/config/initializers/shopify_app.rb
+++ b/test/app_templates/config/initializers/shopify_app.rb
@@ -4,5 +4,5 @@ ShopifyApp.configure do |config|
   config.secret = ENV['SHOPIFY_API_SECRET']
   config.scope = 'read_orders, read_products'
   config.embedded_app = true
-  config.session_repository = ShopifyApp::InMemorySessionStore
+  config.session_repository = 'ShopifyApp::InMemorySessionStore'
 end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -42,7 +42,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match 'config.scope = "read_orders, write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
-      assert_match 'config.session_repository = ShopifyApp::InMemorySessionStore', shopify_app
+      assert_match "config.session_repository = 'ShopifyApp::InMemorySessionStore'", shopify_app
     end
   end
 
@@ -54,7 +54,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_orders, write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
-      assert_match 'config.session_repository = ShopifyApp::InMemorySessionStore', shopify_app
+      assert_match "config.session_repository = 'ShopifyApp::InMemorySessionStore'", shopify_app
     end
   end
 

--- a/test/generators/shop_model_generator_test.rb
+++ b/test/generators/shop_model_generator_test.rb
@@ -29,7 +29,7 @@ class ShopModelGeneratorTest < Rails::Generators::TestCase
   test "updates the shopify_app initializer" do
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |file|
-      assert_match "config.session_repository = Shop", file
+      assert_match "config.session_repository = 'Shop'", file
     end
   end
 

--- a/test/generators/user_model_generator_test.rb
+++ b/test/generators/user_model_generator_test.rb
@@ -29,7 +29,7 @@ class UserModelGeneratorTest < Rails::Generators::TestCase
   test "updates the shopify_app initializer to use User to store session" do
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |file|
-      assert_match "config.session_repository = User", file
+      assert_match "config.session_repository = 'User'", file
     end
   end
 

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -133,4 +133,21 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "Shopify::Webhooks::TestJob", ShopifyApp::WebhooksController.new.send(:webhook_job_klass_name, 'test')
   end
 
+  test "can set session_repository with a string" do
+    ShopifyApp.configure do |config|
+      config.session_repository = 'ShopifyApp::InMemorySessionStore'
+    end
+
+    assert_equal 'ShopifyApp::InMemorySessionStore', ShopifyApp.configuration.session_repository
+    assert_equal ShopifyApp::InMemorySessionStore, ShopifyApp::SessionRepository.storage
+  end
+
+  test "can set session_repository with a class" do
+    ShopifyApp.configure do |config|
+      config.session_repository = ShopifyApp::InMemorySessionStore
+    end
+
+    assert_equal ShopifyApp::InMemorySessionStore, ShopifyApp.configuration.session_repository
+    assert_equal ShopifyApp::InMemorySessionStore, ShopifyApp::SessionRepository.storage
+  end
 end


### PR DESCRIPTION
As reported in https://github.com/Shopify/shopify_app/issues/757 and https://github.com/Shopify/shopify_app/issues/812, currently our generated initializer running with rails 6 will give this warning:

```
DEPRECATION WARNING: Initialization autoloaded the constant Shop.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Shop, for example,
the expected changes won't be reflected in that stale Class object.

This autoloaded constant has been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```

We can avoid issues with the autoloader all-together by just using a string to configure the `session_repository` (and `ShopifyApp::SessionRepository.storage`). 

PR also fixes the setter to actually store the value in `@session_repository`.

These changes are backwards compatible, but anyone using Rails 6 should change their initializer to configure `session_repository` with a string to avoid the deprecation and eventual load error. Replaces https://github.com/Shopify/shopify_app/pull/841.