### PR TITLE
Add SameSite=None and secure to App Session

### DIFF
--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -43,6 +43,9 @@ module ShopifyApp
   require 'shopify_app/managers/webhooks_manager'
   require 'shopify_app/managers/scripttags_manager'
 
+  # middleware
+  require 'shopify_app/middleware/same_site_cookie_middleware'
+
   # session
   require 'shopify_app/session/session_storage'
   require 'shopify_app/session/session_repository'

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -34,6 +34,9 @@ module ShopifyApp
     # allow namespacing webhook jobs
     attr_accessor :webhook_jobs_namespace
 
+    # allow enabling of same site none on cookies
+    attr_accessor :enable_same_site_none
+
     def initialize
       @root_url = '/'
       @myshopify_domain = 'myshopify.com'
@@ -57,6 +60,10 @@ module ShopifyApp
 
     def has_scripttags?
       scripttags.present?
+    end
+
+    def enable_same_site_none
+      @enable_same_site_none.nil? ? embedded_app? : @enable_same_site_none
     end
   end
 

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -12,5 +12,9 @@ module ShopifyApp
         storage_access.svg
       ]
     end
+
+    initializer "shopify_app.middleware" do |app|
+      app.config.middleware.insert_before(ActionDispatch::Cookies, ShopifyApp::SameSiteCookieMiddleware)
+    end
   end
 end

--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -10,7 +10,7 @@ module ShopifyApp
       user_agent = env['HTTP_USER_AGENT']
 
       if headers && headers['Set-Cookie'] && !SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent) &&
-        ShopifyApp.configuration.embedded_app == true
+          ShopifyApp.configuration.enable_same_site_none
 
         cookies = headers['Set-Cookie'].split("\n").compact
 

--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -1,0 +1,58 @@
+module ShopifyApp
+  class SameSiteCookieMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      _status, headers, _body = @app.call(env)
+    ensure
+      user_agent = env['HTTP_USER_AGENT']
+
+      if headers && headers['Set-Cookie'] && !SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent) &&
+        ShopifyApp.configuration.embedded_app == true
+
+        cookies = headers['Set-Cookie'].split("\n").compact
+
+        cookies.each do |cookie|
+          headers['Set-Cookie'] = headers['Set-Cookie'].gsub("#{cookie}", "#{cookie}; secure; SameSite=None")
+        end
+      end
+    end
+
+    def self.same_site_none_incompatible?(user_agent)
+      sniffer = BrowserSniffer.new(user_agent)
+
+      webkit_same_site_bug?(sniffer) || drops_unrecognized_same_site_cookies?(sniffer)
+    rescue
+      true
+    end
+
+    def self.webkit_same_site_bug?(sniffer)
+      (sniffer.os == :ios && sniffer.os_version.match?(/^([0-9]|1[12])[\.\_]/)) ||
+        (sniffer.os == :mac && sniffer.browser == :safari && sniffer.os_version.match?(/^10[\.\_]14/))
+    end
+
+    def self.drops_unrecognized_same_site_cookies?(sniffer)
+      (chromium_based?(sniffer) && sniffer.major_browser_version >= 51 && sniffer.major_browser_version <= 66) ||
+        (uc_browser?(sniffer) && !uc_browser_version_at_least?(sniffer: sniffer, major: 12, minor: 13, build: 2))
+    end
+
+    def self.chromium_based?(sniffer)
+      sniffer.browser_name.downcase.match?(/chrom(e|ium)/)
+    end
+
+    def self.uc_browser?(sniffer)
+      sniffer.user_agent.downcase.match?(/uc\s?browser/)
+    end
+
+    def self.uc_browser_version_at_least?(sniffer:, major:, minor:, build:)
+      digits = sniffer.browser_version.split('.').map(&:to_i)
+      return false unless digits.count >= 3
+
+      return digits[0] > major if digits[0] != major
+      return digits[1] > minor if digits[1] != minor
+      digits[2] >= build
+    end
+  end
+end

--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -15,7 +15,9 @@ module ShopifyApp
         cookies = headers['Set-Cookie'].split("\n").compact
 
         cookies.each do |cookie|
-          headers['Set-Cookie'] = headers['Set-Cookie'].gsub("#{cookie}", "#{cookie}; secure; SameSite=None")
+          unless cookie.include?("; SameSite")
+            headers['Set-Cookie'] = headers['Set-Cookie'].gsub("#{cookie}", "#{cookie}; secure; SameSite=None")
+          end
         end
       end
     end

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -134,4 +134,38 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal ShopifyApp::InMemorySessionStore, ShopifyApp.configuration.session_repository
     assert_equal ShopifyApp::InMemorySessionStore, ShopifyApp::SessionRepository.storage
   end
+
+  test "enable_same_site_none is true if embedded and enable_same_site_none is nil" do
+    ShopifyApp.configure do |config|
+      config.embedded_app = true
+    end
+
+    assert ShopifyApp.configuration.enable_same_site_none
+  end
+
+  test "enable_same_site_none is false if embedded and enable_same_site_none is false" do
+    ShopifyApp.configure do |config|
+      config.embedded_app = true
+      config.enable_same_site_none = false
+    end
+
+    refute ShopifyApp.configuration.enable_same_site_none
+  end
+
+  test "enable_same_site_none is false if not embedded and enable_same_site_none is nil" do
+    ShopifyApp.configure do |config|
+      config.embedded_app = false
+    end
+
+    refute ShopifyApp.configuration.enable_same_site_none
+  end
+
+  test "enable_same_site_none is true if not embedded and enable_same_site_none is true" do
+    ShopifyApp.configure do |config|
+      config.embedded_app = false
+      config.enable_same_site_none = true
+    end
+
+    assert ShopifyApp.configuration.enable_same_site_none
+  end
 end

--- a/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
+++ b/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase 
+  INCOMPATIBLE_USER_AGENTS = [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)"\
+      " GSA/87.0.279142407 Mobile/15E148 Safari/605.1",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko)"\
+      " Version/12.1.2 Safari/605.1.15",
+    "Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G935F Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) "\
+      "Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30",
+  ]
+
+  INCOMPATIBLE_USER_AGENTS.each do |user_agent|
+    test "user agent #{user_agent} is correctly marked as incompatible" do
+      assert ShopifyApp::SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent)
+    end
+  end
+
+  COMPATIBLE_USER_AGENTS = [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117"\
+      " Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4"\
+      " Safari/605.1.15",
+  ]
+
+  COMPATIBLE_USER_AGENTS.each do |user_agent|
+    test "user agent #{user_agent} is correctly marked as incompatible" do
+      refute ShopifyApp::SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent)
+    end
+  end
+end


### PR DESCRIPTION
### Background

In Chrome 80, the default value of the `SameSite` cookie property will switch from `None` to `Lax` ([more details here](https://docs.google.com/document/d/1d2OTcEHQaRvHaJumPuKyu0pVPre_p_GU5hp_S-Ul_7w/edit)). This means that all iframe'd and cross-origin non-GET requests will not send cookies, meaning that it will break  embedded app functionality (you can try enabling the [SameSite None flag](chrome://flags/#same-site-by-default-cookies) and accessing an embedded app in your admin)

Additionally, `SameSite=None` (which we do not use today) is unfortunately interpreted incorrectly by [specific browsers](https://www.chromium.org/updates/same-site/incompatible-clients), so this PR handles such situations as well.

### Changes
Added a middleware that sets all app sessions to `SameSite=None` and `secure` if the browser is compatible and the app is an embedded app.

Decided to add a middleware as setting the session option to `same_site: :none` isn't applied to set-cookie headers for `shopify_app` assets and `/auth/shopify` (omniauth)

### Tophatting
Tophatted with a new shopify app (where `_example_session` has secure and SameSite None.

![image](https://user-images.githubusercontent.com/42748004/72276148-4c38a480-35fd-11ea-852a-671fdec77fd1.png)

 Also tophatted with one of our first party embedded apps Exchange (though I removed the `ShopifyApp.configuration.embedded_app == true` check to test as Exchange runs both as an embedded app and non embedded app). Also tophatted with the user agent `Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Tablet/15E148 Safari/604.1`.

If the session already has  `secure` and `SameSite` set, a `secure` and `SameSite` will still be appended to the end of the set-cookie header. I personally don't think it's a huge problem as the browser ignores the previous `secure` and `SameSite` in the header, but would love to get more opinions on it.