### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+11.6.0
+-----
+* Enable SameSite=None; Secure by default on all cookies for embedded apps [#851](https://github.com/Shopify/shopify_app/pull/851)
+  * Ensures compatibility of embedded apps with upcoming Chrome version 80 changes to cookie behaviour
+  * Configurable via `ShopifyApp.configuration.enable_same_site_none` (default true for embedded apps)
+
 11.5.1
 -----
 * Revert per-user token support temporarily

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.5.1'.freeze
+  VERSION = '11.6.0'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/karma start --browsers ChromeHeadless --single-run"
-  }
+  },
+  "version": "11.6.0"
 }


### PR DESCRIPTION
This PR bumps the version of shopify_app to 11.6.0. This version makes sure embedded apps will continue to work in Chrome version 80 (https://github.com/Shopify/shopify_app/pull/851).

I decided to make this a minor version as apps will not have to add extra configuration for their app to function correctly in most cases.