### PR TITLE
Small fix for samesite cookie middleware

### DIFF
--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -16,7 +16,7 @@ module ShopifyApp
 
         cookies.each do |cookie|
           unless cookie.include?("; SameSite")
-            headers['Set-Cookie'] = headers['Set-Cookie'].gsub("#{cookie}", "#{cookie}; secure; SameSite=None")
+            headers['Set-Cookie'] = headers['Set-Cookie'].gsub("#{cookie}", "#{cookie}; secure; SameSite=None\n")
           end
         end
       end


### PR DESCRIPTION
This was causing Oauth to no longer work on shopify_app.