### PR TITLE
Allow non shop models for session

### DIFF
--- a/lib/shopify_app/session/session_storage.rb
+++ b/lib/shopify_app/session/session_storage.rb
@@ -3,6 +3,12 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     included do
+      if ShopifyApp.configuration.per_user_tokens?
+        extend ShopifyApp::SessionStorage::UserStorageStrategy
+      else
+        extend ShopifyApp::SessionStorage::ShopStorageStrategy
+      end
+
       validates :shopify_token, presence: true
       validates :api_version, presence: true
       validates :shopify_domain, presence: true,
@@ -18,23 +24,6 @@ module ShopifyApp
         api_version: api_version,
         &block
       )
-    end
-
-    class_methods do
-
-      def strategy_klass
-        ShopifyApp.configuration.per_user_tokens? ? 
-          ShopifyApp::SessionStorage::UserStorageStrategy : 
-          ShopifyApp::SessionStorage::ShopStorageStrategy
-      end
-
-      def store(auth_session, user: nil)
-        strategy_klass.store(auth_session, user)
-      end
-
-      def retrieve(id)
-        strategy_klass.retrieve(id)
-      end
     end
   end
 end

--- a/lib/shopify_app/session/storage_strategies/shop_storage_strategy.rb
+++ b/lib/shopify_app/session/storage_strategies/shop_storage_strategy.rb
@@ -1,17 +1,16 @@
 module ShopifyApp
   module SessionStorage
-    class ShopStorageStrategy
-
-      def self.store(auth_session, *args)
-        shop = Shop.find_or_initialize_by(shopify_domain: auth_session.domain)
+    module ShopStorageStrategy
+      def store(auth_session, *args)
+        shop = find_or_initialize_by(shopify_domain: auth_session.domain)
         shop.shopify_token = auth_session.token
         shop.save!
         shop.id
       end
 
-      def self.retrieve(id)
+      def retrieve(id)
         return unless id
-        if shop = Shop.find_by(id: id)
+        if shop = self.find_by(id: id)
           ShopifyAPI::Session.new(
             domain: shop.shopify_domain,
             token: shop.shopify_token,

--- a/lib/shopify_app/session/storage_strategies/user_storage_strategy.rb
+++ b/lib/shopify_app/session/storage_strategies/user_storage_strategy.rb
@@ -1,18 +1,17 @@
 module ShopifyApp
   module SessionStorage
-    class UserStorageStrategy
-
-      def self.store(auth_session, user)
-        user = User.find_or_initialize_by(shopify_user_id: user[:id])
+    module UserStorageStrategy
+      def store(auth_session, user)
+        user = find_or_initialize_by(shopify_user_id: user[:id])
         user.shopify_token = auth_session.token
         user.shopify_domain = auth_session.domain
         user.save!
         user.id
       end
 
-      def self.retrieve(id)
+      def retrieve(id)
         return unless id
-        if user = User.find_by(shopify_user_id: id)
+        if user = self.find_by(shopify_user_id: id)
           ShopifyAPI::Session.new(
             domain: user.shopify_domain,
             token: user.shopify_token,
@@ -20,7 +19,6 @@ module ShopifyApp
           )
         end
       end
-
     end
   end
 end

--- a/test/shopify_app/session/shopify_session_repository_test.rb
+++ b/test/shopify_app/session/shopify_session_repository_test.rb
@@ -78,23 +78,4 @@ class ShopifySessionRepositoryTest < ActiveSupport::TestCase
     ShopifyApp::SessionRepository.storage = 'TestSessionStoreClass'
     assert_equal TestSessionStoreClass, ShopifyApp::SessionRepository.storage
   end
-
-  test "session store picks correct session strategy for per-store tokens" do
-    begin
-      ShopifyApp.configuration.per_user_tokens = false
-      assert_equal MockSessionStore.strategy_klass, ShopifyApp::SessionStorage::ShopStorageStrategy
-    ensure
-      ShopifyApp.configuration.per_user_tokens = false
-    end
-  end
-
-  test "session store picks correct session strategy for per-users tokens" do
-    begin
-      ShopifyApp.configuration.per_user_tokens = true
-      assert_equal MockSessionStore.strategy_klass, ShopifyApp::SessionStorage::UserStorageStrategy
-    ensure
-      ShopifyApp.configuration.per_user_tokens = false
-    end
-  end
-
 end

--- a/test/shopify_app/session/storage_strategies/shop_storage_strategy_test.rb
+++ b/test/shopify_app/session/storage_strategies/shop_storage_strategy_test.rb
@@ -1,46 +1,36 @@
 require 'test_helper'
 
-
 module ShopifyApp
   class ShopStorageStrategyTest < ActiveSupport::TestCase
-
     test "tests that session store can retrieve shop session records" do
       TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
       TEST_SHOPIFY_TOKEN = "1234567890qwertyuiop"
 
-      mock_shop_class = Object.new
-
-      mock_shop_class.stubs(:find_by).returns(MockShopInstance.new(
+      MockSessionStore.stubs(:find_by).returns(MockShopInstance.new(
         shopify_domain:TEST_SHOPIFY_DOMAIN,
         shopify_token:TEST_SHOPIFY_TOKEN
       ))
-      ShopifyApp::SessionStorage::ShopStorageStrategy.const_set("Shop", mock_shop_class)
 
       begin
         ShopifyApp.configuration.per_user_tokens = false
         session = MockSessionStore.retrieve(id=1)
-
         assert_equal TEST_SHOPIFY_DOMAIN, session.domain
         assert_equal TEST_SHOPIFY_TOKEN, session.token
       ensure
         ShopifyApp.configuration.per_user_tokens = false
       end
-
-      ShopifyApp::SessionStorage::ShopStorageStrategy.send(:remove_const , "Shop")
     end
 
     test "tests that session store can store shop session records" do
       mock_shop_instance = MockShopInstance.new(id:12345)
       mock_shop_instance.stubs(:save!).returns(true)
 
-      mock_shop_class = Object.new
-      mock_shop_class.stubs(:find_or_initialize_by).returns(mock_shop_instance)
-    
-      ShopifyApp::SessionStorage::ShopStorageStrategy.const_set("Shop", mock_shop_class)
+      MockSessionStore.stubs(:find_or_initialize_by).returns(mock_shop_instance)
+
 
       begin
         ShopifyApp.configuration.per_user_tokens = false
-        
+
         mock_auth_hash = mock()
         mock_auth_hash.stubs(:domain).returns(mock_shop_instance.shopify_domain)
         mock_auth_hash.stubs(:token).returns("a-new-token!")
@@ -48,11 +38,9 @@ module ShopifyApp
 
         assert_equal "a-new-token!", mock_shop_instance.shopify_token
         assert_equal mock_shop_instance.id, saved_id
-
       ensure
         ShopifyApp.configuration.per_user_tokens = false
       end
-      ShopifyApp::SessionStorage::ShopStorageStrategy.send(:remove_const , "Shop")
     end
   end
 end

--- a/test/shopify_app/session/storage_strategies/user_storage_strategy_test.rb
+++ b/test/shopify_app/session/storage_strategies/user_storage_strategy_test.rb
@@ -8,29 +8,16 @@ end
 
 module ShopifyApp
   class UserStorageStrategyTest < ActiveSupport::TestCase
-
-    test "tests that UserStorageStrategy is used for session storage" do
-      begin
-        ShopifyApp.configuration.per_user_tokens = true
-        assert_equal MockSessionStore.strategy_klass, ShopifyApp::SessionStorage::UserStorageStrategy
-      ensure
-        ShopifyApp.configuration.per_user_tokens = false
-      end
-    end
-
     test "tests that session store can retrieve user session records" do
       TEST_SHOPIFY_USER_ID = 42
       TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
       TEST_SHOPIFY_USER_TOKEN = "some-user-token-42"
 
-      mock_user_class = Object.new
-
-      mock_user_class.stubs(:find_by).returns(MockUserInstance.new(
+      MockSessionStore.stubs(:find_by).returns(MockUserInstance.new(
         shopify_user_id:TEST_SHOPIFY_USER_ID,
         shopify_domain:TEST_SHOPIFY_DOMAIN,
         shopify_token:TEST_SHOPIFY_USER_TOKEN
       ))
-      ShopifyApp::SessionStorage::UserStorageStrategy.const_set("User", mock_user_class)
 
       begin
         ShopifyApp.configuration.per_user_tokens = true
@@ -40,7 +27,6 @@ module ShopifyApp
         assert_equal TEST_SHOPIFY_USER_TOKEN, session.token
       ensure
         ShopifyApp.configuration.per_user_tokens = false
-        ShopifyApp::SessionStorage::UserStorageStrategy.send(:remove_const , "User")
       end
     end
 
@@ -49,12 +35,11 @@ module ShopifyApp
       mock_user_instance.stubs(:save!).returns(true)
 
       mock_user_class = Object.new
-      mock_user_class.stubs(:find_or_initialize_by).returns(mock_user_instance)
-    
-      ShopifyApp::SessionStorage::UserStorageStrategy.const_set("User", mock_user_class)
+      MockSessionStore.stubs(:find_or_initialize_by).returns(mock_user_instance)
+
       begin
         ShopifyApp.configuration.per_user_tokens = true
-        
+
         mock_auth_hash = mock()
         mock_auth_hash.stubs(:domain).returns(mock_user_instance.shopify_domain)
         mock_auth_hash.stubs(:token).returns("a-new-user_token!")
@@ -62,7 +47,7 @@ module ShopifyApp
         associated_user = {
           id: 100,
         }
-        
+
         saved_id = MockSessionStore.store(mock_auth_hash, user:associated_user)
 
         assert_equal "a-new-user_token!", mock_user_instance.shopify_token
@@ -70,7 +55,6 @@ module ShopifyApp
 
       ensure
         ShopifyApp.configuration.per_user_tokens = false
-        ShopifyApp::SessionStorage::UserStorageStrategy.send(:remove_const , "User")
       end
     end
   end


### PR DESCRIPTION
fixes #868 

This allows the models used by our session store be named other than Shop and User. This also allows for easier extension in the future.