### PR TITLE
migrate client scripts to App Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,11 @@ end
 Create your app proxy url in the [Shopify Partners' Dashboard][dashboard], making sure to point it to `https://your_app_website.com/app_proxy`.
 ![Creating an App Proxy](/images/app-proxy-screenshot.png)
 
+App Bridge
+---
+
+A basic example of using [App Bridge][app-bridge] is included in the install generator. An app instance is automatically initialized in [shopify_app.js](https://github.com/Shopify/shopify_app/blob/master/lib/generators/shopify_app/install/templates/shopify_app.js) and [flash_messages.js](https://github.com/Shopify/shopify_app/blob/master/lib/generators/shopify_app/install/templates/flash_messages.js) converts Rails [flash messages](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html) to App Bridge Toast actions automatically. By default, this library is included via [unpkg in the embedded_app layout](https://github.com/Shopify/shopify_app/blob/master/lib/generators/shopify_app/install/templates/embedded_app.html.erb#L27). For more advanced uses it is recommended to [install App Bridge via npm or yarn](https://help.shopify.com/en/api/embedded-apps/app-bridge/getting-started#set-up-shopify-app-bridge-in-your-app).
+
 Troubleshooting
 ---------------
 
@@ -537,3 +542,4 @@ is changed to
 You will need to also follow the ShopifyAPI [upgrade guide](https://github.com/Shopify/shopify_api/blob/master/README.md#-breaking-change-notice-for-version-700-) to ensure your app is ready to work with api versioning.
 
 [dashboard]:https://partners.shopify.com
+[app-bridge]:https://help.shopify.com/en/api/embedded-apps/app-bridge

--- a/lib/generators/shopify_app/home_controller/home_controller_generator.rb
+++ b/lib/generators/shopify_app/home_controller/home_controller_generator.rb
@@ -11,12 +11,6 @@ module ShopifyApp
 
       def create_home_index_view
         copy_file 'index.html.erb', 'app/views/home/index.html.erb'
-        if embedded_app?
-          prepend_to_file(
-            'app/views/home/index.html.erb',
-            File.read(File.expand_path(find_in_source_paths('shopify_app_ready_script.html.erb')))
-          )
-        end
       end
 
       def add_home_index_route

--- a/lib/generators/shopify_app/home_controller/templates/shopify_app_ready_script.html.erb
+++ b/lib/generators/shopify_app/home_controller/templates/shopify_app_ready_script.html.erb
@@ -1,7 +1,0 @@
-<% content_for :javascript do %>
-  <script type="text/javascript">
-    ShopifyApp.ready(function(){
-      ShopifyApp.Bar.initialize({ title: "Home" });
-    });
-  </script>
-<% end %>

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -24,11 +24,11 @@
 
     <%= render 'layouts/flash_messages' %>
 
-    <script src="https://cdn.shopify.com/s/assets/external/app.js?<%= Time.now.strftime('%Y%m%d%H') %>"></script>
+    <script src="https://unpkg.com/@shopify/app-bridge"></script>
 
     <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
       api_key: ShopifyApp.configuration.api_key,
-      shop_origin: ("https://#{ @shop_session.url }" if @shop_session),
+      shop_origin: (@shop_session.domain if @shop_session),
       debug: Rails.env.development?
     } ) %>
 

--- a/lib/generators/shopify_app/install/templates/flash_messages.js
+++ b/lib/generators/shopify_app/install/templates/flash_messages.js
@@ -4,12 +4,21 @@ if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
   document.addEventListener(eventName, function flash() {
     var flashData = JSON.parse(document.getElementById('shopify-app-flash').dataset.flash);
 
+    var Toast = window['app-bridge'].actions.Toast;
+
     if (flashData.notice) {
-      ShopifyApp.flashNotice(flashData.notice);
+      Toast.create(app, {
+        message: flashData.notice,
+        duration: 5000,
+      }).dispatch(Toast.Action.SHOW);
     }
 
     if (flashData.error) {
-      ShopifyApp.flashError(flashData.error);
+      Toast.create(app, {
+        message: flashData.error,
+        duration: 5000,
+        isError: true,
+      }).dispatch(Toast.Action.SHOW);
     }
 
     document.removeEventListener(eventName, flash)

--- a/lib/generators/shopify_app/install/templates/shopify_app.js
+++ b/lib/generators/shopify_app/install/templates/shopify_app.js
@@ -1,9 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
   var data = document.getElementById('shopify-app-init').dataset;
-  ShopifyApp.init({
+  var AppBridge = window['app-bridge'];
+  var createApp = AppBridge.default;
+  window.app = createApp({
     apiKey: data.apiKey,
     shopOrigin: data.shopOrigin,
-    debug: data.debug === 'true',
-    forceRedirect: true
+  });
+
+  var actions = AppBridge.actions;
+  var TitleBar = actions.TitleBar;
+  TitleBar.create(app, {
+    title: data.page,
   });
 });

--- a/test/generators/home_controller_generator_test.rb
+++ b/test/generators/home_controller_generator_test.rb
@@ -21,19 +21,10 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/controllers/home_controller.rb"
   end
 
-  test "creates the home index view with embedded options" do
-    run_generator
-    assert_file "app/views/home/index.html.erb" do |index|
-      assert_match "ShopifyApp.ready", index
-    end
-  end
-
   test "creates the home index view with embedded false" do
     ShopifyApp.configuration.embedded_app = false
     run_generator
-    assert_file "app/views/home/index.html.erb" do |index|
-      refute_match "ShopifyApp.ready", index
-    end
+    refute File.exist?('app/javascript/shopify_app/shopify_app.js')
   end
 
   test "adds home route to routes" do


### PR DESCRIPTION
This PR converts all generated JS to use App Bridge.

## Questions
- I'm using an unversioned unpkg script tag to load in the library. The only used actions are `TitleBar` and `Toast` create and I don't anticipate the types for these actions changing a lot, but I can switch to a versioned import if we feel that's better.

cc @Shopify/app-bridge 

closes #723 