### PR TITLE
Fix return_to address in Safari after enable_cookies/granted_storage_access

### DIFF
--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -28,8 +28,8 @@
     window.parent.location.href = this.redirectData.myshopifyUrl + '/admin/apps';
   }
 
-  StorageAccessHelper.prototype.redirectToAppHome = function() {
-    window.location.href = this.redirectData.appHomeUrl;
+  StorageAccessHelper.prototype.redirectToAppTargetUrl = function() {
+    window.location.href = this.redirectData.appTargetUrl;
   }
 
   StorageAccessHelper.prototype.grantedStorageAccess = function() {
@@ -39,7 +39,7 @@
       if (!document.cookie) {
         throw 'Cannot set third-party cookie.'
       }
-      this.redirectToAppHome();
+      this.redirectToAppTargetUrl();
     } catch (error) {
       console.warn('Third party cookies may be blocked.', error);
       this.redirectToAppTLD(ACCESS_DENIED_STATUS);
@@ -61,7 +61,7 @@
   StorageAccessHelper.prototype.handleHasStorageAccess = function() {
     if (sessionStorage.getItem('shopify.granted_storage_access')) {
       // If app was classified by ITP and used Storage Access API to acquire access
-      this.redirectToAppHome();
+      this.redirectToAppTargetUrl();
     } else {
       // If app has not been classified by ITP and still has storage access
       this.redirectToAppTLD(ACCESS_GRANTED_STATUS);

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -20,11 +20,12 @@ module ShopifyApp
 
       render(:enable_cookies, layout: false, locals: {
         does_not_have_storage_access_url: top_level_interaction_path(
-          shop: sanitized_shop_name
+          shop: sanitized_shop_name,
+          return_to: params[:return_to]
         ),
         has_storage_access_url: login_url_with_optional_shop(top_level: true),
-        app_home_url: granted_storage_access_path(shop: sanitized_shop_name),
-        current_shopify_domain: current_shopify_domain,
+        app_target_url: params[:return_to] || granted_storage_access_path(shop: sanitized_shop_name),
+        current_shopify_domain: current_shopify_domain
       })
     end
 
@@ -133,11 +134,12 @@ module ShopifyApp
         layout: false,
         locals: {
           does_not_have_storage_access_url: top_level_interaction_path(
-            shop: sanitized_shop_name
+            shop: sanitized_shop_name,
+            return_to: session[:return_to]
           ),
           has_storage_access_url: login_url_with_optional_shop(top_level: true),
-          app_home_url: granted_storage_access_path(shop: sanitized_shop_name),
-          current_shopify_domain: current_shopify_domain,
+          app_target_url: session[:return_to] || granted_storage_access_path(shop: sanitized_shop_name),
+          current_shopify_domain: current_shopify_domain
         }
       )
     end

--- a/app/views/shopify_app/sessions/enable_cookies.html.erb
+++ b/app/views/shopify_app/sessions/enable_cookies.html.erb
@@ -32,7 +32,7 @@
           myshopifyUrl: "https://#{current_shopify_domain}",
           hasStorageAccessUrl: "#{has_storage_access_url}",
           doesNotHaveStorageAccessUrl: "#{does_not_have_storage_access_url}",
-          appHomeUrl: "#{app_home_url}"
+          appTargetUrl: "#{app_target_url}"
         },
       },
     )

--- a/app/views/shopify_app/sessions/request_storage_access.html.erb
+++ b/app/views/shopify_app/sessions/request_storage_access.html.erb
@@ -24,7 +24,7 @@
                       myshopifyUrl: "https://#{current_shopify_domain}",
                       hasStorageAccessUrl: "#{has_storage_access_url}",
                       doesNotHaveStorageAccessUrl: "#{does_not_have_storage_access_url}",
-                      appHomeUrl: "#{app_home_url}"
+                      appTargetUrl: "#{app_target_url}"
                   },
               },
               )

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -94,8 +94,10 @@ module ShopifyApp
       query_params = {}
       query_params[:shop] = sanitized_params[:shop] if params[:shop].present?
 
-      if session[:return_to] && return_to_param_required?
-        query_params[:return_to] = session[:return_to]
+      return_to = session[:return_to] || params[:return_to]
+
+      if return_to.present? && return_to_param_required?
+        query_params[:return_to] = return_to
       end
 
       has_referer_shop_name = referer_sanitized_shop_name.present?

--- a/test/javascripts/shopify_app/storage_access_test.js
+++ b/test/javascripts/shopify_app/storage_access_test.js
@@ -43,33 +43,33 @@ suite('StorageAccessHelper', () => {
       sinon.assert.called(storageAccessHelper.setUpCookiePartitioning);
     });
 
-    test('calls redirectToAppHome instead of manageStorageAccess or setUpCookiePartitioningStub if ITPHelper.userAgentIsAffected returns true', async () => {
+    test('calls redirectToAppTargetUrl instead of manageStorageAccess or setUpCookiePartitioningStub if ITPHelper.userAgentIsAffected returns true', async () => {
       storageAccessHelperSandbox.stub(ITPHelper.prototype, 'userAgentIsAffected').callsFake(() => false);
 
       storageAccessHelperSandbox.stub(storageAccessHelper, 'manageStorageAccess').callsFake(() => true);
 
-      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppHome');
+      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppTargetUrl');
       storageAccessHelperSandbox.stub(storageAccessHelper, 'setUpCookiePartitioning');
 
       storageAccessHelper.execute();
 
       sinon.assert.notCalled(storageAccessHelper.manageStorageAccess);
-      sinon.assert.called(storageAccessHelper.redirectToAppHome);
+      sinon.assert.called(storageAccessHelper.redirectToAppTargetUrl);
       sinon.assert.notCalled(storageAccessHelper.setUpCookiePartitioning);
     });
 
-    test('calls manageStorageAccess instead of redirectToAppHome if ITPHelper.userAgentIsAffected returns true', async () => {
+    test('calls manageStorageAccess instead of redirectToAppTargetUrl if ITPHelper.userAgentIsAffected returns true', async () => {
       storageAccessHelperSandbox.stub(ITPHelper.prototype, 'userAgentIsAffected').callsFake(() => true);
 
       storageAccessHelperSandbox.stub(storageAccessHelper, 'manageStorageAccess').callsFake(() => true);
 
-      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppHome');
+      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppTargetUrl');
       storageAccessHelperSandbox.stub(storageAccessHelper, 'setUpCookiePartitioning');
 
       storageAccessHelper.execute();
 
       sinon.assert.called(storageAccessHelper.manageStorageAccess);
-      sinon.assert.notCalled(storageAccessHelper.redirectToAppHome);
+      sinon.assert.notCalled(storageAccessHelper.redirectToAppTargetUrl);
       sinon.assert.notCalled(storageAccessHelper.setUpCookiePartitioning);
     });
   });
@@ -159,34 +159,34 @@ suite('StorageAccessHelper', () => {
   });
 
   suite('handleRequestStorageAccess', () => {
-    test('calls redirectToAppHome instead of redirectToAppsIndex when document.requestStorageAccess resolves', () => {
+    test('calls redirectToAppTargetUrl instead of redirectToAppsIndex when document.requestStorageAccess resolves', () => {
       document.requestStorageAccess = () => {
         return new Promise((resolve) => {
           resolve();
         });
       };
 
-      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppHome');
+      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppTargetUrl');
       storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppsIndex');
 
       storageAccessHelper.handleRequestStorageAccess().then(() => {
-        sinon.assert.called(storageAccessHelper.redirectToAppHome);
+        sinon.assert.called(storageAccessHelper.redirectToAppTargetUrl);
         sinon.assert.notCalled(storageAccessHelper.redirectToAppsIndex);
       });
     });
 
-    test('calls redirectToAppsIndex with "storage_access_denied" instead of calling redirectToAppHome when document.requestStorageAccess fails', () => {
+    test('calls redirectToAppsIndex with "storage_access_denied" instead of calling redirectToAppTargetUrl when document.requestStorageAccess fails', () => {
       document.requestStorageAccess = () => {
         return new Promise((resolve, reject) => {
           reject();
         });
       };
 
-      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppHome');
+      storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppTargetUrl');
       storageAccessHelperSandbox.stub(storageAccessHelper, 'redirectToAppsIndex');
 
       storageAccessHelper.handleRequestStorageAccess().then(() => {
-        sinon.assert.notCalled(storageAccessHelper.redirectToAppHome);
+        sinon.assert.notCalled(storageAccessHelper.redirectToAppTargetUrl);
         sinon.assert.calledWith(storageAccessHelper.redirectToAppsIndex, 'storage_access_denied');
       });
     });


### PR DESCRIPTION
When a user requests a deep link within the app, and is using a recent version of Safari, the `return_to` address would be lost in the chain of redirects happening for the `enable_cookies` and `granted_storage_access` steps. This PR solves the issue by converting `session[:return_to]` to `params[:return_to]` (where necessary), and ensuring that JS redirects respect the presence of `params[:return_to]` when present.

@tylerball @tanema 