### PR TITLE
Disable Cookie Middleware in Tests

### DIFF
--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -66,7 +66,7 @@ module ShopifyApp
     end
 
     def enable_same_site_none
-      @enable_same_site_none.nil? ? embedded_app? : @enable_same_site_none
+      !Rails.env.test? && (@enable_same_site_none.nil? ? embedded_app? : @enable_same_site_none)
     end
   end
 

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -151,6 +151,15 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal ShopifyApp::InMemorySessionStore, ShopifyApp::SessionRepository.storage
   end
 
+  test "enable_same_site_none is false in tests" do
+    ShopifyApp.configure do |config|
+      config.embedded_app = true
+      config.enable_same_site_none = true
+    end
+
+    refute ShopifyApp.configuration.enable_same_site_none
+  end
+
   test "enable_same_site_none is true if embedded and enable_same_site_none is nil" do
     ShopifyApp.configure do |config|
       config.embedded_app = true

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -156,6 +156,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       config.embedded_app = true
     end
 
+    Rails.env.expects(:test?).returns(false)
     assert ShopifyApp.configuration.enable_same_site_none
   end
 
@@ -165,6 +166,8 @@ class ConfigurationTest < ActiveSupport::TestCase
       config.enable_same_site_none = false
     end
 
+
+    Rails.env.expects(:test?).returns(false)
     refute ShopifyApp.configuration.enable_same_site_none
   end
 
@@ -173,6 +176,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       config.embedded_app = false
     end
 
+    Rails.env.expects(:test?).returns(false)
     refute ShopifyApp.configuration.enable_same_site_none
   end
 
@@ -182,6 +186,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       config.enable_same_site_none = true
     end
 
+    Rails.env.expects(:test?).returns(false)
     assert ShopifyApp.configuration.enable_same_site_none
   end
 end


### PR DESCRIPTION
fixes #874 

The cookie middleware was causing issue with browser testing using capy, so this just disables the middleware for requests in tests