### PR TITLE
Update version to 12.0.0 for breaking ShopifyAPI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+12.0.0
+-----
+* Updating shopify_api gem to 9.0.0
+
 11.7.1
 -----
 * Fix to allow SessionStorage to be flexible on what model names that the are used for storing shop and user data

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '11.7.1'.freeze
+  VERSION = '12.0.0'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
   "scripts": {
     "test": "./node_modules/.bin/karma start --browsers ChromeHeadless --single-run"
   },
-  "version": "11.7.1"
+  "version": "12.0.0"
 }

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.1.3')
   s.add_runtime_dependency('rails', '> 5.2.1')
-  s.add_runtime_dependency('shopify_api', '~> 8.0')
+  s.add_runtime_dependency('shopify_api', '~> 9.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
The latest shopify api gem version is 9.0.0. 

The shopify app gem had a dependency for the api gem that was set to version 8.0.0. This is now updated to 9.0.0

Correspondingly, the ShopifyApp version is updated from 11.7.1 to 12.0.0
<img width="847" alt="Screen Shot 2020-01-28 at 1 17 01 PM" src="https://user-images.githubusercontent.com/19610799/73292732-8f377200-41d0-11ea-835c-3d4fbe3d853c.png">
