### PR TITLE
[Marketing activity template] Remove budget field because not every extension has budget

### DIFF
--- a/lib/generators/shopify_app/add_marketing_activity_extension/templates/marketing_activities_controller.rb
+++ b/lib/generators/shopify_app/add_marketing_activity_extension/templates/marketing_activities_controller.rb
@@ -3,11 +3,7 @@
 class MarketingActivitiesController < ShopifyApp::ExtensionVerificationController
   def preload_form_data
     preload_data = {
-      "form_data": {
-        "budget": {
-          "currency": "USD",
-        }
-      }
+      "form_data": {}
     }
     render(json: preload_data, status: :ok)
   end


### PR DESCRIPTION
#### What are you trying to accomplish with this PR?
Part of: https://github.com/Shopify/marketing-integrations/issues/486

Removing `budget` in preload form data because not all extension will use that field (for example: Facebook page post). Also the field name (in this case is `budget`) and currency can be different. We should let the app developers follow the [doc](https://help.shopify.com/en/api/embedded-apps/app-extensions/shopify-admin/marketing-activities/endpoints#preload-a-marketing-activity-form) and determine what are returned from the app's `preload_form_data` endpoint.

#### How does it do it?
Remove budget.
#### What could go wrong? (if anything)
N/A