### PR TITLE
Make compatible with ruby 2.3.x

### DIFF
--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -16,7 +16,7 @@ module ShopifyApp
 
         cookies.each do |cookie|
           unless cookie.include?("; SameSite")
-            headers['Set-Cookie'] = headers['Set-Cookie'].gsub("#{cookie}", "#{cookie}; secure; SameSite=None")
+            headers['Set-Cookie'] = headers['Set-Cookie'].gsub(cookie, "#{cookie}; secure; SameSite=None")
           end
         end
       end
@@ -31,8 +31,8 @@ module ShopifyApp
     end
 
     def self.webkit_same_site_bug?(sniffer)
-      (sniffer.os == :ios && sniffer.os_version.match?(/^([0-9]|1[12])[\.\_]/)) ||
-        (sniffer.os == :mac && sniffer.browser == :safari && sniffer.os_version.match?(/^10[\.\_]14/))
+      (sniffer.os == :ios && sniffer.os_version.match(/^([0-9]|1[12])[\.\_]/)) ||
+        (sniffer.os == :mac && sniffer.browser == :safari && sniffer.os_version.match(/^10[\.\_]14/))
     end
 
     def self.drops_unrecognized_same_site_cookies?(sniffer)
@@ -41,11 +41,11 @@ module ShopifyApp
     end
 
     def self.chromium_based?(sniffer)
-      sniffer.browser_name.downcase.match?(/chrom(e|ium)/)
+      sniffer.browser_name.downcase.match(/chrom(e|ium)/)
     end
 
     def self.uc_browser?(sniffer)
-      sniffer.user_agent.downcase.match?(/uc\s?browser/)
+      sniffer.user_agent.downcase.match(/uc\s?browser/)
     end
 
     def self.uc_browser_version_at_least?(sniffer:, major:, minor:, build:)


### PR DESCRIPTION
fixes #888 

Our samesite cookie middleware was breaking for ruby 2.3.x and this make it compatible again.