### PR TITLE
Remove rescue in SameSite middleware

### DIFF
--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -23,32 +23,34 @@ module ShopifyApp
     end
 
     def self.same_site_none_incompatible?(user_agent)
+      return true unless user_agent
       sniffer = BrowserSniffer.new(user_agent)
 
       webkit_same_site_bug?(sniffer) || drops_unrecognized_same_site_cookies?(sniffer)
-    rescue
-      true
     end
 
     def self.webkit_same_site_bug?(sniffer)
+      return false unless sniffer.os && sniffer.os_version && sniffer.browser
       (sniffer.os == :ios && sniffer.os_version.match(/^([0-9]|1[12])[\.\_]/)) ||
         (sniffer.os == :mac && sniffer.browser == :safari && sniffer.os_version.match(/^10[\.\_]14/))
     end
 
     def self.drops_unrecognized_same_site_cookies?(sniffer)
+      return false unless sniffer.major_browser_version
       (chromium_based?(sniffer) && sniffer.major_browser_version >= 51 && sniffer.major_browser_version <= 66) ||
         (uc_browser?(sniffer) && !uc_browser_version_at_least?(sniffer: sniffer, major: 12, minor: 13, build: 2))
     end
 
     def self.chromium_based?(sniffer)
-      sniffer.browser_name.downcase.match(/chrom(e|ium)/)
+      sniffer.browser_name ? sniffer.browser_name.downcase.match(/chrom(e|ium)/) : false
     end
 
     def self.uc_browser?(sniffer)
-      sniffer.user_agent.downcase.match(/uc\s?browser/)
+      sniffer.user_agent ? sniffer.user_agent.downcase.match(/uc\s?browser/) : false
     end
 
     def self.uc_browser_version_at_least?(sniffer:, major:, minor:, build:)
+      return false unless sniffer.browser_version
       digits = sniffer.browser_version.split('.').map(&:to_i)
       return false unless digits.count >= 3
 

--- a/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
+++ b/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
@@ -8,6 +8,7 @@ class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase
       " Version/12.1.2 Safari/605.1.15",
     "Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G935F Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) "\
       "Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30",
+    nil,
   ]
 
   INCOMPATIBLE_USER_AGENTS.each do |user_agent|
@@ -22,10 +23,11 @@ class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4"\
       " Safari/605.1.15",
+    "Custom User Agent",
   ]
 
   COMPATIBLE_USER_AGENTS.each do |user_agent|
-    test "user agent #{user_agent} is correctly marked as incompatible" do
+    test "user agent #{user_agent} is correctly marked as compatible" do
       refute ShopifyApp::SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent)
     end
   end


### PR DESCRIPTION
The rescue true in `same_site_none_incompatible` isn't the best way to catch errors. This should catch all the `NoMethodErrors` that should be expected if the BrowserSniffer can't parse some user agents when they are custom.