### PR TITLE
Inserting SameSite middleware higher in stack

### DIFF
--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -14,7 +14,7 @@ module ShopifyApp
     end
 
     initializer "shopify_app.middleware" do |app|
-      app.config.middleware.insert_after(ActionDispatch::Static, ShopifyApp::SameSiteCookieMiddleware)
+      app.config.middleware.insert_after(::Rack::Runtime, ShopifyApp::SameSiteCookieMiddleware)
     end
   end
 end

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -14,7 +14,7 @@ module ShopifyApp
     end
 
     initializer "shopify_app.middleware" do |app|
-      app.config.middleware.insert_before(ActionDispatch::Cookies, ShopifyApp::SameSiteCookieMiddleware)
+      app.config.middleware.insert_after(ActionDispatch::Static, ShopifyApp::SameSiteCookieMiddleware)
     end
   end
 end

--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -5,8 +5,7 @@ module ShopifyApp
     end
 
     def call(env)
-      _status, headers, _body = @app.call(env)
-    ensure
+      status, headers, body = @app.call(env)
       user_agent = env['HTTP_USER_AGENT']
 
       if headers && headers['Set-Cookie'] && !SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent) &&
@@ -16,10 +15,11 @@ module ShopifyApp
 
         cookies.each do |cookie|
           unless cookie.include?("; SameSite")
-            headers['Set-Cookie'] = headers['Set-Cookie'].gsub(cookie, "#{cookie}; secure; SameSite=None")
+            headers['Set-Cookie'] = headers['Set-Cookie'].gsub(cookie, "#{cookie}; Secure; SameSite=None")
           end
         end
       end
+      [status, headers, body]
     end
 
     def self.same_site_none_incompatible?(user_agent)


### PR DESCRIPTION
Pairprogramming with @tanema

### What we learned
We learned a couple things while working on this.
If the user does not have a tunnel
- They will receive a csrf error on the main login form
- The omniauth session wont be stored because it wont be on https

### What we did
We had to do a few things to make sessions more stable
- appropriately cased the `Secure` attribute on the cookie
- Rewrote the middleware to return the status, headers, body to conform to middleware interface
- Moved the middleware higher in the middleware order. We found examples in the wild also editing cookies where the middleware was inserted higher so we copied that and it worked better.

@jenshenny  I know you are implementing this middleware across a bunch of different applications. Do these changes seem to fix any issues you are seeing?