### PR TITLE
Fix issue where not redirecting user to granted storage page casues infinite loop

### DIFF
--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -24,7 +24,10 @@ module ShopifyApp
           return_to: params[:return_to]
         ),
         has_storage_access_url: login_url_with_optional_shop(top_level: true),
-        app_target_url: params[:return_to] || granted_storage_access_path(shop: sanitized_shop_name),
+        app_target_url: granted_storage_access_path(
+          shop: sanitized_shop_name,
+          return_to: params[:return_to]
+        ),
         current_shopify_domain: current_shopify_domain
       })
     end
@@ -39,8 +42,9 @@ module ShopifyApp
 
       session['shopify.granted_storage_access'] = true
 
-      params = { shop: @shop }
-      redirect_to("#{return_address}?#{params.to_query}")
+      copy_return_to_param_to_session
+
+      redirect_to(return_address_with_params({ shop: @shop }))
     end
 
     def destroy
@@ -55,7 +59,7 @@ module ShopifyApp
       return render_invalid_shop_error unless sanitized_shop_name.present?
       session['shopify.omniauth_params'] = { shop: sanitized_shop_name }
 
-      session[:return_to] = params[:return_to] if params[:return_to]
+      copy_return_to_param_to_session
 
       if user_agent_can_partition_cookies
         authenticate_with_partitioning
@@ -92,6 +96,10 @@ module ShopifyApp
       end
 
       true
+    end
+
+    def copy_return_to_param_to_session
+      session[:return_to] = params[:return_to] if params[:return_to]
     end
 
     def render_invalid_shop_error
@@ -138,7 +146,10 @@ module ShopifyApp
             return_to: session[:return_to]
           ),
           has_storage_access_url: login_url_with_optional_shop(top_level: true),
-          app_target_url: session[:return_to] || granted_storage_access_path(shop: sanitized_shop_name),
+          app_target_url: granted_storage_access_path(
+            shop: sanitized_shop_name,
+            return_to: session[:return_to]
+          ),
           current_shopify_domain: current_shopify_domain
         }
       )

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -167,5 +167,15 @@ module ShopifyApp
     def return_address
       session.delete(:return_to) || ShopifyApp.configuration.root_url
     end
+
+    def return_address_with_params(params)
+      uri = URI(return_address)
+      uri.query = CGI.parse(uri.query.to_s)
+        .symbolize_keys
+        .transform_values { |v| v.one? ? v.first : v }
+        .merge(params)
+        .to_query
+      uri.to_s
+    end
   end
 end


### PR DESCRIPTION
Addresses issues within #897 

This change ensures that users are always redirected to the `granted_storage_access` page, regardless of the presence of a `redirect_to` param. Doing so required persisting the `params[:return_to]` to the `session` after redirecting the browser to the `granted_storage_access` page, so that the behavior of `return_address` will work properly in this case.

Implementing this change revealed an existing issue with the `granted_storage_access` action, where the `shop` param would be appended to the `return_address`, even if query params were already present (ie. given a `return_address` of `/foo?user_id=1234&shop=example.myshopify.com`, the final redirect target (due to the simplistic string concatenation being used) would be `/foo?user_id=1234&shop=example.myshopify.com?shop=example.myshopify.com`. This was causing the check within `login_again_if_different_user_or_shop` to fail, triggering an additional login, because `params[:shop]` (in the above example) would be incorrectly set to `example.myshopify.com?shop=example.myshopify.com`, which can never match the value of `shop_session.domain`.

To fix, I added  a `return_address_with_params` method. This method will merge any passed params into the `return_address`, ensuring that the `return_address` params are preserved, while allowing the `shop` param to still be explicitly set within the `granted_storage_access` action. This seemed like the least invasive solution, and has the added benefit of providing the ability to merge other params into the `return_address` if needed.

cc @hurracrane @tanema 