### PR TITLE
WIP: Inject Session Storage Strategy & Fix user hash value parameter bug

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -55,6 +55,7 @@ module ShopifyApp
         token: token,
         api_version: ShopifyApp.configuration.api_version
       )
+      #byebug
       session[:shopify] = ShopifyApp::SessionRepository.store(session_store, user: associated_user)
       session[:shopify_domain] = shop_name
       session[:shopify_user] = associated_user

--- a/lib/shopify_app/session/storage_strategies/shop_storage_strategy.rb
+++ b/lib/shopify_app/session/storage_strategies/shop_storage_strategy.rb
@@ -1,8 +1,12 @@
 module ShopifyApp
   module SessionStorage
-    module ShopStorageStrategy
+    class ShopStorageStrategy
+      def initialize(storage_class)
+        @storage_class = storage_class
+      end
+
       def store(auth_session, *args)
-        shop = find_or_initialize_by(shopify_domain: auth_session.domain)
+        shop = @storage_class.find_or_initialize_by(shopify_domain: auth_session.domain)
         shop.shopify_token = auth_session.token
         shop.save!
         shop.id
@@ -10,7 +14,7 @@ module ShopifyApp
 
       def retrieve(id)
         return unless id
-        if shop = self.find_by(id: id)
+        if shop = @storage_class.find_by(id: id)
           ShopifyAPI::Session.new(
             domain: shop.shopify_domain,
             token: shop.shopify_token,

--- a/lib/shopify_app/session/storage_strategies/shop_storage_strategy.rb
+++ b/lib/shopify_app/session/storage_strategies/shop_storage_strategy.rb
@@ -6,19 +6,19 @@ module ShopifyApp
       end
 
       def store(auth_session, *args)
-        shop = @storage_class.find_or_initialize_by(shopify_domain: auth_session.domain)
-        shop.shopify_token = auth_session.token
-        shop.save!
-        shop.id
+        shop_session = @storage_class.find_or_initialize_by(shopify_domain: auth_session.domain)
+        shop_session.shopify_token = auth_session.token
+        shop_session.save!
+        shop_session.id
       end
 
       def retrieve(id)
         return unless id
-        if shop = @storage_class.find_by(id: id)
+        if shop_session = @storage_class.find_by(id: id)
           ShopifyAPI::Session.new(
-            domain: shop.shopify_domain,
-            token: shop.shopify_token,
-            api_version: shop.api_version
+            domain: shop_session.shopify_domain,
+            token: shop_session.shopify_token,
+            api_version: shop_session.api_version
           )
         end
       end

--- a/lib/shopify_app/session/storage_strategies/user_storage_strategy.rb
+++ b/lib/shopify_app/session/storage_strategies/user_storage_strategy.rb
@@ -5,21 +5,21 @@ module ShopifyApp
         @storage_class = storage_class
       end
 
-      def store(auth_session, user)
-        user = @storage_class.find_or_initialize_by(shopify_user_id: user[:id])
-        user.shopify_token = auth_session.token
-        user.shopify_domain = auth_session.domain
-        user.save!
-        user.id
+      def store(auth_session, user:)
+        user_session = @storage_class.find_or_initialize_by(shopify_user_id: user[:id])
+        user_session.shopify_token = auth_session.token
+        user_session.shopify_domain = auth_session.domain
+        user_session.save!
+        user_session.id
       end
 
       def retrieve(id)
         return unless id
-        if user = @storage_class.find_by(shopify_user_id: id)
+        if user_session = @storage_class.find_by(shopify_user_id: id)
           ShopifyAPI::Session.new(
-            domain: user.shopify_domain,
-            token: user.shopify_token,
-            api_version: user.api_version
+            domain: user_session.shopify_domain,
+            token: user_session.shopify_token,
+            api_version: user_session.api_version
           )
         end
       end

--- a/lib/shopify_app/session/storage_strategies/user_storage_strategy.rb
+++ b/lib/shopify_app/session/storage_strategies/user_storage_strategy.rb
@@ -1,8 +1,12 @@
 module ShopifyApp
   module SessionStorage
-    module UserStorageStrategy
+    class UserStorageStrategy
+      def initialize(storage_class)
+        @storage_class = storage_class
+      end
+
       def store(auth_session, user)
-        user = find_or_initialize_by(shopify_user_id: user[:id])
+        user = @storage_class.find_or_initialize_by(shopify_user_id: user[:id])
         user.shopify_token = auth_session.token
         user.shopify_domain = auth_session.domain
         user.save!
@@ -11,7 +15,7 @@ module ShopifyApp
 
       def retrieve(id)
         return unless id
-        if user = self.find_by(shopify_user_id: id)
+        if user = @storage_class.find_by(shopify_user_id: id)
           ShopifyAPI::Session.new(
             domain: user.shopify_domain,
             token: user.shopify_token,

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -2,10 +2,6 @@
 
 require 'test_helper'
 
-class MockSessionStore < ActiveRecord::Base
-  include ShopifyApp::SessionStorage
-end
-
 module Shopify
   class AfterAuthenticateJob < ActiveJob::Base
     def perform; end
@@ -14,6 +10,11 @@ end
 
 module ShopifyApp
   class CallbackControllerTest < ActionController::TestCase
+
+    class MockSessionStore < ActiveRecord::Base
+      include ShopifyApp::SessionStorage
+    end
+
     TEST_SHOP_DOMAIN = 'shop.myshopify.com'
     TEST_ASSOCIATED_USER = { id: '515132' }
     TEST_CREDENTIALS = { token: '121455' }
@@ -45,8 +46,8 @@ module ShopifyApp
     test '#callback sets up a shopify session' do
       ShopifyApp::SessionRepository.storage = ShopifyApp::SessionStorage::ShopStorageStrategy.new(MockSessionStore)
       MockSessionStore.stubs(:find_or_initialize_by).with(shopify_domain: TEST_SHOP_DOMAIN).returns(MockShopInstance.new(
-        shopify_domain:TEST_SHOP_DOMAIN,
-        shopify_token:TEST_CREDENTIALS
+        shopify_domain: TEST_SHOP_DOMAIN,
+        shopify_token: TEST_CREDENTIALS
       ))
 
       mock_shopify_omniauth
@@ -68,10 +69,12 @@ module ShopifyApp
     test '#callback sets up a shopify session with a user for online mode' do
       ShopifyApp.configuration.per_user_tokens = true
       ShopifyApp::SessionRepository.storage = ShopifyApp::SessionStorage::UserStorageStrategy.new(MockSessionStore)
-      MockSessionStore.stubs(:find_or_initialize_by).with(shopify_user_id: TEST_ASSOCIATED_USER[:id]).returns(MockUserInstance.new(
-        shopify_user_id: TEST_ASSOCIATED_USER[:id],
-        shopify_domain: TEST_SHOP_DOMAIN,
-        shopify_token: TEST_CREDENTIALS,
+      MockSessionStore.stubs(:find_or_initialize_by)
+        .with(shopify_user_id: TEST_ASSOCIATED_USER[:id])
+        .returns(MockUserInstance.new(
+          shopify_user_id: TEST_ASSOCIATED_USER[:id],
+          shopify_domain: TEST_SHOP_DOMAIN,
+          shopify_token: TEST_CREDENTIALS
         ))
 
       begin

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -66,15 +66,15 @@ module ShopifyApp
     end
 
     test '#callback sets up a shopify session with a user for online mode' do
-      begin
-        ShopifyApp.configuration.per_user_tokens = true
-        ShopifyApp::SessionRepository.storage = ShopifyApp::SessionStorage::UserStorageStrategy.new(MockSessionStore)
-        MockSessionStore.stubs(:find_or_initialize_by).with(shopify_user_id: TEST_ASSOCIATED_USER[:id]).returns(MockUserInstance.new(
-          shopify_user_id: TEST_ASSOCIATED_USER[:id],
-          shopify_domain: TEST_SHOP_DOMAIN,
-          shopify_token: TEST_CREDENTIALS,
-          ))
+      ShopifyApp.configuration.per_user_tokens = true
+      ShopifyApp::SessionRepository.storage = ShopifyApp::SessionStorage::UserStorageStrategy.new(MockSessionStore)
+      MockSessionStore.stubs(:find_or_initialize_by).with(shopify_user_id: TEST_ASSOCIATED_USER[:id]).returns(MockUserInstance.new(
+        shopify_user_id: TEST_ASSOCIATED_USER[:id],
+        shopify_domain: TEST_SHOP_DOMAIN,
+        shopify_token: TEST_CREDENTIALS,
+        ))
 
+      begin
         mock_shopify_user_omniauth
 
         get :callback, params: { shop: 'shop' }

--- a/test/shopify_app/session/session_storage_test.rb
+++ b/test/shopify_app/session/session_storage_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+module ShopifyApp
+  class SessionStorageTest < ActiveSupport::TestCase
+    class MockSessionStore < ActiveRecord::Base
+      include ShopifyApp::SessionStorage
+    end
+
+    test "#storage_strategy is ShopStorageStrategy when per_user_token is false" do
+      ShopifyApp.configuration.per_user_tokens = false
+      assert_instance_of(ShopifyApp::SessionStorage::ShopStorageStrategy, MockSessionStore.storage_strategy)
+    ensure
+      MockSessionStore.storage_strategy = nil
+    end
+
+    test "#storage_strategy is UserStorageStrategy when per_user_token is true" do
+      ShopifyApp.configuration.per_user_tokens = true
+      assert_instance_of(ShopifyApp::SessionStorage::UserStorageStrategy, MockSessionStore.storage_strategy)
+    ensure
+      MockSessionStore.storage_strategy = nil
+    end
+  end
+end

--- a/test/shopify_app/session/session_storage_test.rb
+++ b/test/shopify_app/session/session_storage_test.rb
@@ -7,17 +7,23 @@ module ShopifyApp
     end
 
     test "#storage_strategy is ShopStorageStrategy when per_user_token is false" do
-      ShopifyApp.configuration.per_user_tokens = false
-      assert_instance_of(ShopifyApp::SessionStorage::ShopStorageStrategy, MockSessionStore.storage_strategy)
+      begin
+        ShopifyApp.configuration.per_user_tokens = false
+        assert_instance_of(ShopifyApp::SessionStorage::ShopStorageStrategy, MockSessionStore.storage_strategy)
+      ensure
+        MockSessionStore.storage_strategy = nil
+      end
     ensure
-      MockSessionStore.storage_strategy = nil
+
     end
 
     test "#storage_strategy is UserStorageStrategy when per_user_token is true" do
-      ShopifyApp.configuration.per_user_tokens = true
-      assert_instance_of(ShopifyApp::SessionStorage::UserStorageStrategy, MockSessionStore.storage_strategy)
-    ensure
+      begin
+        ShopifyApp.configuration.per_user_tokens = true
+        assert_instance_of(ShopifyApp::SessionStorage::UserStorageStrategy, MockSessionStore.storage_strategy)
+      ensure
       MockSessionStore.storage_strategy = nil
+      end
     end
   end
 end

--- a/test/shopify_app/session/storage_strategies/user_storage_strategy_test.rb
+++ b/test/shopify_app/session/storage_strategies/user_storage_strategy_test.rb
@@ -8,11 +8,11 @@ end
 
 module ShopifyApp
   class UserStorageStrategyTest < ActiveSupport::TestCase
-    test "tests that session store can retrieve user session records" do
-      TEST_SHOPIFY_USER_ID = 42
-      TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
-      TEST_SHOPIFY_USER_TOKEN = "some-user-token-42"
+    TEST_SHOPIFY_USER_ID = 42
+    TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
+    TEST_SHOPIFY_USER_TOKEN = "some-user-token-42"
 
+    test "tests that session store can retrieve user session records" do
       MockSessionStore.stubs(:find_by).with(shopify_user_id: TEST_SHOPIFY_USER_ID).returns(MockUserInstance.new(
         shopify_user_id: TEST_SHOPIFY_USER_ID,
         shopify_domain: TEST_SHOPIFY_DOMAIN,
@@ -50,7 +50,7 @@ module ShopifyApp
           id: 100,
         }
 
-        saved_id = MockSessionStore.store(mock_auth_hash, associated_user)
+        saved_id = MockSessionStore.store(mock_auth_hash, user: associated_user)
 
         assert_equal "a-new-user_token!", mock_user_instance.shopify_token
         assert_equal mock_user_instance.id, saved_id

--- a/test/support/session_store_strategy_test_helpers.rb
+++ b/test/support/session_store_strategy_test_helpers.rb
@@ -3,17 +3,21 @@ module SessionStoreStrategyTestHelpers
   class MockSessionStore < ActiveRecord::Base
     include ShopifyApp::SessionStorage
   end
-    
+
 
   class MockShopInstance
     attr_reader :id, :shopify_domain, :shopify_token, :api_version
     attr_writer :shopify_token
-      
+
     def initialize(id:1, shopify_domain:'example.myshopify.com', shopify_token:'abcd-shop-token', api_version:'unstable')
       @id = id
       @shopify_domain = shopify_domain
       @shopify_token = shopify_token
       @api_version = api_version
+    end
+
+    def save!
+      true
     end
   end
 
@@ -27,6 +31,10 @@ module SessionStoreStrategyTestHelpers
       @shopify_domain = shopify_domain
       @shopify_token = shopify_token
       @api_version = api_version
+    end
+
+    def save!
+      true
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
This PR deals with two aspects:

1. Refactoring how session storage strategies are determined by a session repository as it currently toggles it based on the `per_user_token` flag
2. Fixing a bug in `UserStorageStrategy` where the `user` parameter in `store(auth_session, user)` method is expected to be a regular object with an `id` field. However, what is passed is a hash value that `user` maps to as shown in the following example:

**Expected**: 
`{account_owner=true collaborator=false email="testuser@email.com" email_verified=nil first_name="User's Test Store" id=46774203221 last_name="Admin" locale="en"}`
**Actual**: 
`{:user=>#<OmniAuth::AuthHash account_owner=true collaborator=false email="testuser@email.com" email_verified=nil first_name="User's Test Store" id=46774203221 last_name="Admin" locale="en">}`

### What approach did you choose and why?

1. We are now able to set the storage strategy for a session repository. Thus being able to set the storage strategy if new strategies are added, while also retaining the same logic for determining a strategy based on the `per_user_token`.  Please see `session_storage.rb`

2. To fix the bug, we have made the `user` argument into a keyword argument. 

In addition to this, changes have been made to the `callback_controller_test.rb` to test with the correct storage strategies (Shop/User).

### What should reviewers focus on?

1. Refactored code for setting the session storage strategy (`SessionStorage`, `UserStorageStrategy`, `ShopStorageStrategy`)
2. Bugfix made to `store` method in `UserStorageStrategy`
3. Tests to ensure that correct strategies are being used, particularly in `callback_controller_test.rb`

### The impact of these changes

1. Refactoring the session storage strategy injection will work as per usual
2. Bugfix will now allow app owners to leverage the user session storage strategy as they will not get 500 Internal Server errors complaining `shopify_user_id` being NULL.

### Before you deploy
