### PR TITLE
adds note about dot-env gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ SHOPIFY_API_KEY=your api key
 SHOPIFY_API_SECRET=your api secret
 ```
 
-These values can be found on the "App Setup" page in the [Shopify Partners Dashboard][dashboard]. If you are checking your code into a code repository, ensure your `.gitignore` prevents your `.env` file from being checked into any publicly accessible code. 
+These values can be found on the "App Setup" page in the [Shopify Partners Dashboard][dashboard]. If you are checking your code into a code repository, ensure your `.gitignore` prevents your `.env` file from being checked into any publicly accessible code.
+
+**You will need to load the ENV variables into your enviroment, you can do this with the [dot-env](https://github.com/bkeepers/dotenv) gem or any other method you wish to.**
 
 ### Install Generator
 

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -5,7 +5,7 @@ module ShopifyApp
     # for the app in your Shopify Partners page. Change your settings in
     # `config/initializers/shopify_app.rb`
     attr_accessor :application_name
-    attr_accessor :api_key
+    attr_writer   :api_key
     attr_accessor :secret
     attr_accessor :old_secret
     attr_accessor :scope
@@ -63,6 +63,11 @@ module ShopifyApp
 
     def has_scripttags?
       scripttags.present?
+    end
+
+    def api_key
+      raise 'API Key is required and is being returned nil. Are you loading your enviroment variables?' if @api_key.nil?
+      @api_key
     end
 
     def enable_same_site_none

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -5,7 +5,7 @@ module ShopifyApp
     # for the app in your Shopify Partners page. Change your settings in
     # `config/initializers/shopify_app.rb`
     attr_accessor :application_name
-    attr_writer   :api_key
+    attr_reader   :api_key
     attr_accessor :secret
     attr_accessor :old_secret
     attr_accessor :scope
@@ -65,9 +65,10 @@ module ShopifyApp
       scripttags.present?
     end
 
-    def api_key
-      raise 'API Key is required and is being returned nil. Are you loading your enviroment variables?' if @api_key.nil?
-      @api_key
+    def api_key=(key)
+      raise 'API Key is required and is being returned nil. \
+      This may indicate that your enviroment variables have not been loaded.' if key.nil?
+      @api_key = key
     end
 
     def enable_same_site_none

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -14,6 +14,7 @@ module ShopifyApp
       ShopifyApp::SessionRepository.storage = ShopifyApp::InMemorySessionStore
       ShopifyApp.configuration = nil
       ShopifyApp.configuration.embedded_app = true
+      ShopifyApp.configuration.api_key = 'abc123'
 
       I18n.locale = :en
 


### PR DESCRIPTION
During OAuth, the shopify_app initializer template [expects ENV variables](https://github.com/Shopify/shopify_app/blob/master/lib/generators/shopify_app/install/templates/shopify_app.rb#L3). 

This adds a note to read the env vars.