### PR TITLE
Do not modify cookie policy on non SSL requests

### DIFF
--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -10,13 +10,10 @@ module ShopifyApp
       status, headers, body = @app.call(env)
       user_agent = env['HTTP_USER_AGENT']
 
-      @request = Rack::Request.new(env) 
-      is_https = @request.env['HTTPS'] == 'on' || @request.env['HTTP_X_SSL_REQUEST'] == 'on'
-
       if headers && headers['Set-Cookie'] &&
           !SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent) &&
           ShopifyApp.configuration.enable_same_site_none &&
-          is_https
+          Rack::Request.new(env).ssl?
 
         set_cookies = headers['Set-Cookie']
           .split(COOKIE_SEPARATOR)

--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -10,7 +10,7 @@ module ShopifyApp
       status, headers, body = @app.call(env)
       user_agent = env['HTTP_USER_AGENT']
 
-      @request = Rack::Request.new(env)
+      @request = Rack::Request.new(env) 
       is_https = @request.env['HTTPS'] == 'on' || @request.env['HTTP_X_SSL_REQUEST'] == 'on'
 
       if headers && headers['Set-Cookie'] &&

--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -10,9 +10,13 @@ module ShopifyApp
       status, headers, body = @app.call(env)
       user_agent = env['HTTP_USER_AGENT']
 
+      @request = Rack::Request.new(env)
+      is_https = @request.env['HTTPS'] == 'on' || @request.env['HTTP_X_SSL_REQUEST'] == 'on'
+
       if headers && headers['Set-Cookie'] &&
           !SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent) &&
-          ShopifyApp.configuration.enable_same_site_none
+          ShopifyApp.configuration.enable_same_site_none &&
+          is_https
 
         set_cookies = headers['Set-Cookie']
           .split(COOKIE_SEPARATOR)

--- a/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
+++ b/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
@@ -29,4 +29,43 @@ class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase
       refute ShopifyApp::SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent)
     end
   end
+
+  def app
+    app = Rack::Lint.new(lambda { |env|
+      req = Rack::Request.new(env)
+
+      response = Rack::Response.new("", 200, "Content-Type" => "text/yaml")
+    
+      response.set_cookie("session_test", { value: "session_test", domain: ".test.com", path: "/" })
+      response.finish
+    })
+  end
+
+  def env_for_url(url)
+    env = Rack::MockRequest.env_for(url)
+    env['HTTP_USER_AGENT'] = COMPATIBLE_USER_AGENTS.first
+    env
+  end
+
+  def middleware
+    ShopifyApp.configuration.stubs(:enable_same_site_none).returns(true)
+      
+    ShopifyApp::SameSiteCookieMiddleware.new(app)
+  end
+
+  test 'SameSite cookie attributes should be added on SSL' do
+    env = env_for_url("https://test.com/")
+    
+    status, headers, body = middleware.call(env)
+
+    assert_includes headers['Set-Cookie'], 'SameSite'
+  end
+
+  test 'SameSite cookie attributes should not be added on non SSL requests' do
+    env = env_for_url("http://test.com/")
+    
+    status, headers, body = middleware.call(env)
+
+    assert_not_includes headers['Set-Cookie'], 'SameSite'
+  end
 end


### PR DESCRIPTION
Changing cookie policy for all cookies (not only those which are relevant to Shopify App) can easily brake other functionalities of someone's app. 

E.g.: We use this gem but our Rails app does other things as well - e.g.: we have Active Admin. Developing on http://localhost:3000 became impossible because of this middleware. 

I had similar problems with rspec tests which were testing session related things (outside ShopifyApp scope). Since feature tests are running without SSL - all those tests broke. 

It seems like many problems would be solved if we would only be fixing cookies on https requests.

Relevant issue: https://github.com/Shopify/shopify_app/issues/911 