### PR TITLE
Bump browser_sniffer to 1.2.0

### DIFF
--- a/lib/shopify_app/middleware/same_site_cookie_middleware.rb
+++ b/lib/shopify_app/middleware/same_site_cookie_middleware.rb
@@ -11,7 +11,7 @@ module ShopifyApp
       user_agent = env['HTTP_USER_AGENT']
 
       if headers && headers['Set-Cookie'] &&
-          !SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent) &&
+          BrowserSniffer.new(user_agent).same_site_none_compatible? &&
           ShopifyApp.configuration.enable_same_site_none &&
           Rack::Request.new(env).ssl?
 
@@ -28,41 +28,6 @@ module ShopifyApp
       end
 
       [status, headers, body]
-    end
-
-    def self.same_site_none_incompatible?(user_agent)
-      sniffer = BrowserSniffer.new(user_agent)
-
-      webkit_same_site_bug?(sniffer) || drops_unrecognized_same_site_cookies?(sniffer)
-    rescue
-      true
-    end
-
-    def self.webkit_same_site_bug?(sniffer)
-      (sniffer.os == :ios && sniffer.os_version.match(/^([0-9]|1[12])[\.\_]/)) ||
-        (sniffer.os == :mac && sniffer.browser == :safari && sniffer.os_version.match(/^10[\.\_]14/))
-    end
-
-    def self.drops_unrecognized_same_site_cookies?(sniffer)
-      (chromium_based?(sniffer) && sniffer.major_browser_version >= 51 && sniffer.major_browser_version <= 66) ||
-        (uc_browser?(sniffer) && !uc_browser_version_at_least?(sniffer: sniffer, major: 12, minor: 13, build: 2))
-    end
-
-    def self.chromium_based?(sniffer)
-      sniffer.browser_name.downcase.match(/chrom(e|ium)/)
-    end
-
-    def self.uc_browser?(sniffer)
-      sniffer.user_agent.downcase.match(/uc\s?browser/)
-    end
-
-    def self.uc_browser_version_at_least?(sniffer:, major:, minor:, build:)
-      digits = sniffer.browser_version.split('.').map(&:to_i)
-      return false unless digits.count >= 3
-
-      return digits[0] > major if digits[0] != major
-      return digits[1] > minor if digits[1] != minor
-      digits[2] >= build
     end
   end
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3.1"
 
-  s.add_runtime_dependency('browser_sniffer', '~> 1.1.3')
+  s.add_runtime_dependency('browser_sniffer', '~> 1.2.0')
   s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 9.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.0')

--- a/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
+++ b/test/shopify_app/middleware/same_site_cookie_middleware_test.rb
@@ -1,35 +1,6 @@
 require 'test_helper'
 
-class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase 
-  INCOMPATIBLE_USER_AGENTS = [
-    "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)"\
-      " GSA/87.0.279142407 Mobile/15E148 Safari/605.1",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko)"\
-      " Version/12.1.2 Safari/605.1.15",
-    "Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G935F Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) "\
-      "Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30",
-  ]
-
-  INCOMPATIBLE_USER_AGENTS.each do |user_agent|
-    test "user agent #{user_agent} is correctly marked as incompatible" do
-      assert ShopifyApp::SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent)
-    end
-  end
-
-  COMPATIBLE_USER_AGENTS = [
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117"\
-      " Safari/537.36",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4"\
-      " Safari/605.1.15",
-  ]
-
-  COMPATIBLE_USER_AGENTS.each do |user_agent|
-    test "user agent #{user_agent} is correctly marked as incompatible" do
-      refute ShopifyApp::SameSiteCookieMiddleware.same_site_none_incompatible?(user_agent)
-    end
-  end
-
+class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase
   def app
     app = Rack::Lint.new(lambda { |env|
       req = Rack::Request.new(env)
@@ -43,7 +14,8 @@ class ShopifyApp::SameSiteCookieMiddlewareTest < ActiveSupport::TestCase
 
   def env_for_url(url)
     env = Rack::MockRequest.env_for(url)
-    env['HTTP_USER_AGENT'] = COMPATIBLE_USER_AGENTS.first
+    env['HTTP_USER_AGENT'] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko)"\
+      " Chrome/79.0.3945.117 Safari/537.36"
     env
   end
 


### PR DESCRIPTION
Added SameSite None compatible check to [browser_sniffer](https://github.com/Shopify/browser_sniffer/pull/25/files) gem, thus removing the check and its tests here. Tophatted on my local app.