### PR TITLE
Migrate redirect calls to App Bridge

### DIFF
--- a/app/assets/javascripts/shopify_app/app_bridge_redirect.js
+++ b/app/assets/javascripts/shopify_app/app_bridge_redirect.js
@@ -1,18 +1,18 @@
-(function() {
+(function (window) {
   function appBridgeRedirect(url) {
     var AppBridge = window['app-bridge'];
     var createApp = AppBridge.default;
     var Redirect = AppBridge.actions.Redirect;
     var app = createApp({
       apiKey: window.apiKey,
-      shopOrigin: window.shopOrigin.replace(/^https:\/\//, ''),
+      shopOrigin: window.shopOrigin,
     });
-  
+
     var normalizedLink = document.createElement('a');
     normalizedLink.href = url;
-  
+
     Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
   }
 
-  this.appBridgeRedirect = appBridgeRedirect;
+  window.appBridgeRedirect = appBridgeRedirect;
 })(window);

--- a/app/assets/javascripts/shopify_app/app_bridge_redirect.js
+++ b/app/assets/javascripts/shopify_app/app_bridge_redirect.js
@@ -1,0 +1,18 @@
+(function() {
+  function appBridgeRedirect(url) {
+    var AppBridge = window['app-bridge'];
+    var createApp = AppBridge.default;
+    var Redirect = AppBridge.actions.Redirect;
+    var app = createApp({
+      apiKey: window.apiKey,
+      shopOrigin: window.shopOrigin.replace(/^https:\/\//, ''),
+    });
+  
+    var normalizedLink = document.createElement('a');
+    normalizedLink.href = url;
+  
+    Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
+  }
+
+  this.appBridgeRedirect = appBridgeRedirect;
+})(window);

--- a/app/assets/javascripts/shopify_app/app_bridge_redirect.js
+++ b/app/assets/javascripts/shopify_app/app_bridge_redirect.js
@@ -1,16 +1,16 @@
-(function (window) {
+(function(window) {
   function appBridgeRedirect(url) {
     var AppBridge = window['app-bridge'];
     var createApp = AppBridge.default;
     var Redirect = AppBridge.actions.Redirect;
     var app = createApp({
       apiKey: window.apiKey,
-      shopOrigin: window.shopOrigin,
+      shopOrigin: window.shopOrigin.replace(/^https:\/\//, ''),
     });
-
+  
     var normalizedLink = document.createElement('a');
     normalizedLink.href = url;
-
+  
     Redirect.create(app).dispatch(Redirect.Action.REMOTE, normalizedLink.href);
   }
 

--- a/app/assets/javascripts/shopify_app/redirect.js
+++ b/app/assets/javascripts/shopify_app/redirect.js
@@ -1,3 +1,5 @@
+//= require ./app_bridge_redirect.js
+
 (function() {
   function redirect() {
     var redirectTargetElement = document.getElementById("redirection-target");
@@ -13,7 +15,7 @@
       window.top.location.href = targetInfo.url;
     } else {
       // If the current window is the 'child', change the parent's URL with App Bridge Redirect
-      appBridgeRedirect(targetInfo.url);
+      window.appBridgeRedirect(targetInfo.url);
     }
   }
 

--- a/app/assets/javascripts/shopify_app/redirect.js
+++ b/app/assets/javascripts/shopify_app/redirect.js
@@ -12,15 +12,8 @@
       // If the current window is the 'parent', change the URL by setting location.href
       window.top.location.href = targetInfo.url;
     } else {
-      // If the current window is the 'child', change the parent's URL with postMessage
-      normalizedLink = document.createElement('a');
-      normalizedLink.href = targetInfo.url;
-
-      data = JSON.stringify({
-        message: 'Shopify.API.remoteRedirect',
-        data: {location: normalizedLink.href}
-      });
-      window.parent.postMessage(data, targetInfo.myshopifyUrl);
+      // If the current window is the 'child', change the parent's URL with App Bridge Redirect
+      appBridgeRedirect(targetInfo.url);
     }
   }
 

--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -11,17 +11,7 @@
   }
 
   StorageAccessHelper.prototype.redirectToAppTLD = function(storageAccessStatus) {
-    var normalizedLink = document.createElement('a');
-
-    normalizedLink.href = this.setNormalizedLink(storageAccessStatus);
-
-    data = JSON.stringify({
-      message: 'Shopify.API.remoteRedirect',
-      data: {
-        location: normalizedLink.href,
-      }
-    });
-    window.parent.postMessage(data, this.redirectData.myshopifyUrl);
+    appBridgeRedirect(this.setNormalizedLink(storageAccessStatus));
   }
 
   StorageAccessHelper.prototype.redirectToAppsIndex = function() {

--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -11,7 +11,7 @@
   }
 
   StorageAccessHelper.prototype.redirectToAppTLD = function(storageAccessStatus) {
-    appBridgeRedirect(this.setNormalizedLink(storageAccessStatus));
+    window.appBridgeRedirect(this.setNormalizedLink(storageAccessStatus));
   }
 
   StorageAccessHelper.prototype.redirectToAppsIndex = function() {

--- a/app/assets/javascripts/shopify_app/storage_access.js
+++ b/app/assets/javascripts/shopify_app/storage_access.js
@@ -1,3 +1,5 @@
+//= require ./app_bridge_redirect.js
+
 (function() {
   var ACCESS_GRANTED_STATUS = 'storage_access_granted';
   var ACCESS_DENIED_STATUS = 'storage_access_denied';

--- a/app/views/shopify_app/sessions/enable_cookies.html.erb
+++ b/app/views/shopify_app/sessions/enable_cookies.html.erb
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
   <title>Redirecting…</title>
+  <script src="https://unpkg.com/@shopify/app-bridge@^1"></script>
+  <script>
+    window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
+    window.shopOrigin = "https://<%= @shop %>";
+    window.returnTo = "<%= params[:return_to] %>"
+  </script>
   <%= render 'shopify_app/partials/layout_styles' %>
   <%= render 'shopify_app/partials/typography_styles' %>
   <%= render 'shopify_app/partials/card_styles' %>
@@ -14,12 +20,6 @@
       display: none;
     }
   </style>
-  <script>
-    window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
-    window.shopOrigin = "https://<%= @shop %>";
-    window.returnTo = "<%= params[:return_to] %>"
-  </script>
-
   <%= javascript_include_tag('shopify_app/enable_cookies', crossorigin: 'anonymous', integrity: true) %>
 </head>
 <body>

--- a/app/views/shopify_app/sessions/request_storage_access.html.erb
+++ b/app/views/shopify_app/sessions/request_storage_access.html.erb
@@ -8,7 +8,7 @@
   <script src="https://unpkg.com/@shopify/app-bridge@^1"></script>
   <script>
     window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
-    window.shopOrigin = "https://<%= current_shopify_domain %>";
+    window.shopOrigin = "<%= current_shopify_domain %>";
   </script>
   <%= render 'shopify_app/partials/layout_styles' %>
   <%= render 'shopify_app/partials/typography_styles' %>

--- a/app/views/shopify_app/sessions/request_storage_access.html.erb
+++ b/app/views/shopify_app/sessions/request_storage_access.html.erb
@@ -8,7 +8,7 @@
   <script src="https://unpkg.com/@shopify/app-bridge@^1"></script>
   <script>
     window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
-    window.shopOrigin = "<%= current_shopify_domain %>";
+    window.shopOrigin = "https://<%= current_shopify_domain %>";
   </script>
   <%= render 'shopify_app/partials/layout_styles' %>
   <%= render 'shopify_app/partials/typography_styles' %>

--- a/app/views/shopify_app/sessions/request_storage_access.html.erb
+++ b/app/views/shopify_app/sessions/request_storage_access.html.erb
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
   <title>Redirecting…</title>
+  <script src="https://unpkg.com/@shopify/app-bridge@^1"></script>
+  <script>
+    window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
+    window.shopOrigin = "https://<%= current_shopify_domain %>";
+  </script>
   <%= render 'shopify_app/partials/layout_styles' %>
   <%= render 'shopify_app/partials/typography_styles' %>
   <%= render 'shopify_app/partials/card_styles' %>

--- a/app/views/shopify_app/shared/redirect.html.erb
+++ b/app/views/shopify_app/shared/redirect.html.erb
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= I18n.locale %>">>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
   <title>Redirecting…</title>
+  <script src="https://unpkg.com/@shopify/app-bridge@^1"></script>
+  <script>
+    window.apiKey = "<%= ShopifyApp.configuration.api_key %>";
+    window.shopOrigin = "https://<%= current_shopify_domain %>";
+  </script>
   <%= javascript_include_tag('shopify_app/redirect', crossorigin: 'anonymous', integrity: true) %>
 </head>
 <body>

--- a/app/views/shopify_app/shared/redirect.html.erb
+++ b/app/views/shopify_app/shared/redirect.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">>
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/test/javascripts/shopify_app/app_bridge_redirect_test.js
+++ b/test/javascripts/shopify_app/app_bridge_redirect_test.js
@@ -1,0 +1,64 @@
+suite('appBridgeRedirect', () => {
+  const sandbox = sinon.createSandbox();
+  const url = '/settings';
+
+  setup(() => {
+    window['app-bridge'] = {
+      default() {},
+      actions: {
+        Redirect: {
+          Action: {
+            REMOTE: 'REDIRECT::REMOTE',
+          },
+          create() {
+            return {
+              dispatch() {},
+            };
+          },
+        },
+      },
+    };
+    window.apiKey = '123';
+    window.shopOrigin = "https://myshop.com";
+  });
+  
+  teardown(() => {
+    sandbox.restore();
+    delete window['app-bridge'];
+  });
+  
+
+  test('calls App Bridge to create an app with the apiKey and shopOrigin from window', () => {
+    var createApp = sinon.spy();
+    sinon.stub(window['app-bridge'], 'default').callsFake(createApp);
+    
+    appBridgeRedirect(url);
+
+    sinon.assert.calledWith(createApp, {
+      apiKey: window.apiKey,
+      shopOrigin: 'myshop.com',
+    });
+  });
+
+  test('calls to dispatch a remote redirect App Bridge action with the url normalized to be relative to the window origin', () => {
+    const AppBridge = window['app-bridge'];
+    const Redirect = AppBridge.actions.Redirect;
+    var mockApp = {};
+    var RedirectInstance = {
+      dispatch: sinon.spy(),
+    };
+    sinon.stub(AppBridge, 'default').callsFake(() => mockApp);
+    sinon.stub(Redirect, 'create').callsFake(() => RedirectInstance);
+
+    const normalizedUrl = `${window.location.origin}${url}`;
+
+    appBridgeRedirect(url);
+
+    sinon.assert.calledWith(Redirect.create, mockApp);
+    sinon.assert.calledWith(
+      RedirectInstance.dispatch,
+      'REDIRECT::REMOTE',
+      normalizedUrl
+    );
+  });
+});

--- a/test/javascripts/shopify_app/redirect_test.js
+++ b/test/javascripts/shopify_app/redirect_test.js
@@ -1,0 +1,26 @@
+suite('redirect', () => {
+  const redirectHelperSandbox = sinon.createSandbox();
+  
+  let contentContainer;
+  let url = '/settings';
+
+  setup(() => {
+    contentContainer = document.createElement('div');
+
+    contentContainer.setAttribute('id', 'redirection-target');
+    contentContainer.dataset['target'] = JSON.stringify({url});
+    document.body.appendChild(contentContainer);
+
+    redirectHelperSandbox.stub(window, 'appBridgeRedirect').callsFake(() => {});
+  });
+  
+  teardown(() => {
+    redirectHelperSandbox.restore();
+    document.body.removeChild(contentContainer);
+  });
+  
+  test('calls appBridgeRedirect', () => {
+    require('../../../app/assets/javascripts/shopify_app/redirect');
+    sinon.assert.calledWith(window.appBridgeRedirect, url);
+  });
+});

--- a/test/javascripts/shopify_app/storage_access_test.js
+++ b/test/javascripts/shopify_app/storage_access_test.js
@@ -12,8 +12,6 @@ suite('StorageAccessHelper', () => {
   let button;
 
   setup(() => {
-    storageAccessHelperSandbox.stub(window.parent, 'postMessage');
-
     contentContainer = document.createElement('div');
     button = document.createElement('button');
 
@@ -30,6 +28,21 @@ suite('StorageAccessHelper', () => {
   teardown(() => {
     document.body.removeChild(contentContainer);
     storageAccessHelperSandbox.restore();
+  });
+
+  suite('redirectToAppTLD', () => {
+    test('calls appBridgeRedirect with the normalized storage access link', () => {
+      const normalizedLink = 'some_link';
+      storageAccessHelperSandbox.stub(window, 'appBridgeRedirect').callsFake(() => {});
+      storageAccessHelperSandbox.stub(storageAccessHelper, 'setNormalizedLink').callsFake(() => normalizedLink);
+      
+      storageAccessHelper.redirectToAppTLD('storage_access_granted');
+      
+      sinon.assert.calledWith(
+        appBridgeRedirect,
+        normalizedLink,
+      );
+    });
   });
 
   suite('execute', () => {


### PR DESCRIPTION
Fixes https://github.com/Shopify/app-bridge/issues/1410

### Tophat

1. In a project consuming Shopify App Gem, open the gemfile
2. Change the gem path for "shopify_app" to point to the local directory of the Shopify_app repo. Ex. 
> gem "shopify_app", path: "../shopify_app"
3. Ensure that you can build and run the project