### PR TITLE
Update version to 12.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+12.0.5
+-----
+* Updating shopify_api gem to 9.0.1
+
 12.0.4
 ------
 * Reverts reverted PR (#895) #897

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '12.0.4'.freeze
+  VERSION = '12.0.5'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "12.0.2",
+  "version": "12.0.5",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.2.0')
   s.add_runtime_dependency('rails', '> 5.2.1')
-  s.add_runtime_dependency('shopify_api', '~> 9.0')
+  s.add_runtime_dependency('shopify_api', '~> 9.0.1')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Updates version to 12.0.5. The latest shopify api gem version is 9.0.1 which is also added to the gemspec as a runtime dependency

