### PR TITLE
revert warning about api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+12.0.7
+------
+* Remove check for API_KEY in config that was throwing errors during install #919
+
 12.0.6
 ------
 * Adds changelog information and README updates for 8.4.0 #916

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -5,7 +5,7 @@ module ShopifyApp
     # for the app in your Shopify Partners page. Change your settings in
     # `config/initializers/shopify_app.rb`
     attr_accessor :application_name
-    attr_reader   :api_key
+    attr_accessor  :api_key
     attr_accessor :secret
     attr_accessor :old_secret
     attr_accessor :scope
@@ -63,12 +63,6 @@ module ShopifyApp
 
     def has_scripttags?
       scripttags.present?
-    end
-
-    def api_key=(key)
-      raise 'API Key is required and is being returned nil. \
-      This may indicate that your enviroment variables have not been loaded.' if key.nil?
-      @api_key = key
     end
 
     def enable_same_site_none

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,3 +1,3 @@
 module ShopifyApp
-  VERSION = '12.0.6'.freeze
+  VERSION = '12.0.7'.freeze
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -14,7 +14,6 @@ module ShopifyApp
       ShopifyApp::SessionRepository.storage = ShopifyApp::InMemorySessionStore
       ShopifyApp.configuration = nil
       ShopifyApp.configuration.embedded_app = true
-      ShopifyApp.configuration.api_key = 'abc123'
 
       I18n.locale = :en
 


### PR DESCRIPTION
it seems like this check for api key is running when it shouldn't be and causing installation errors. I'd like to remove it for now as it's causing issues for users. 