### PR TITLE
Split out return_to session setting to own method

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -66,17 +66,21 @@ module ShopifyApp
       if request.xhr?
         head :unauthorized
       else
-        if request.get?
-          path = request.path
-          query = sanitized_params.to_query
-        else
-          referer = URI(request.referer || "/")
-          path = referer.path
-          query = "#{referer.query}&#{sanitized_params.to_query}"
-        end
-        session[:return_to] = "#{path}?#{query}"
+        set_session_return_to_current_path
         redirect_to(login_url_with_optional_shop)
       end
+    end
+
+    def set_session_return_to_current_path
+      if request.get?
+        path = request.path
+        query = sanitized_params.to_query
+      else
+        referer = URI(request.referer || "/")
+        path = referer.path
+        query = "#{referer.query}&#{sanitized_params.to_query}"
+      end
+      session[:return_to] = "#{path}?#{query}"
     end
 
     def close_session

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -243,6 +243,15 @@ class LoginProtectionTest < ActionController::TestCase
     end
   end
 
+  test '#set_session_return_to_current_path sets session correctly for get request' do
+    with_application_test_routes do
+      request.path = 'go_back_to_this_path'
+      @controller.params = { shop: 'foobar' }
+      @controller.send(:set_session_return_to_current_path)
+      assert_equal 'go_back_to_this_path?shop=foobar.myshopify.com', session[:return_to]
+    end
+  end
+
   test '#activate_shopify_session with no Shopify session, sets session[:return_to]' do
     with_application_test_routes do
       get :index, params: { shop: 'foobar' }


### PR DESCRIPTION
Hello, I would like to the function of setting the `return_to` session variable split out to it's own function so that I can call it from our app in contexts where we can't call the `redirect_to_login` method (JSON api call).