### PR TITLE
Fix for constantization issue in session store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+13.0.1
+------
+* fix for deprecation warning while loading session storage at startup
+
 13.0.0
 ------
 + #887 Added concurrent user and shop session support (online/offline)

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -14,8 +14,6 @@ module ShopifyApp
     attr_accessor :webhooks
     attr_accessor :scripttags
     attr_accessor :after_authenticate_job
-    attr_reader :shop_session_repository
-    attr_reader :user_session_repository
     attr_accessor :api_version
 
     # customise urls
@@ -51,13 +49,19 @@ module ShopifyApp
     end
 
     def user_session_repository=(klass)
-      @user_session_repository = klass
       ShopifyApp::SessionRepository.user_storage = klass
     end
 
+    def user_session_repository
+      ShopifyApp::SessionRepository.user_storage
+    end
+
     def shop_session_repository=(klass)
-      @shop_session_repository = klass
       ShopifyApp::SessionRepository.shop_storage = klass
+    end
+
+    def shop_session_repository
+      ShopifyApp::SessionRepository.shop_storage
     end
 
     def has_webhooks?

--- a/lib/shopify_app/session/session_repository.rb
+++ b/lib/shopify_app/session/session_repository.rb
@@ -5,18 +5,10 @@ module ShopifyApp
     class << self
       def shop_storage=(storage)
         @shop_storage = storage
-
-        unless storage.nil? || self.shop_storage.respond_to?(:store) && self.shop_storage.respond_to?(:retrieve)
-          raise ArgumentError, "shop storage must respond to :store and :retrieve"
-        end
       end
 
       def user_storage=(storage)
         @user_storage = storage
-
-        unless storage.nil? || self.user_storage.respond_to?(:store) && self.user_storage.respond_to?(:retrieve)
-          raise ArgumentError, "user storage must respond to :store and :retrieve"
-        end
       end
 
       def retrieve_shop_session(id)

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -122,7 +122,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       config.shop_session_repository = 'ShopifyApp::InMemoryShopSessionStore'
     end
 
-    assert_equal 'ShopifyApp::InMemoryShopSessionStore', ShopifyApp.configuration.shop_session_repository
+    assert_equal ShopifyApp::InMemoryShopSessionStore, ShopifyApp.configuration.shop_session_repository
     assert_equal ShopifyApp::InMemoryShopSessionStore, ShopifyApp::SessionRepository.shop_storage
   end
 
@@ -140,7 +140,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       config.user_session_repository = 'ShopifyApp::InMemoryUserSessionStore'
     end
 
-    assert_equal 'ShopifyApp::InMemoryUserSessionStore', ShopifyApp.configuration.user_session_repository
+    assert_equal ShopifyApp::InMemoryUserSessionStore, ShopifyApp.configuration.user_session_repository
     assert_equal ShopifyApp::InMemoryUserSessionStore, ShopifyApp::SessionRepository.user_storage
   end
 


### PR DESCRIPTION
fix #908 

The issue is that shopify_app loads the session repo class at configuration time to check it's interface. This however breaks reloading and logs a deprecation warning `DEPRECATION WARNING: Initialization autoloaded the constant Shop`

This will now only load the ShopStore or UserStore when they are needed.

@vfonic 