### PR TITLE
Fix nested route throws routing exception on install

### DIFF
--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -138,7 +138,7 @@ module ShopifyApp
     end
 
     def authenticate_in_context
-      redirect_to "#{main_app.root_path}auth/shopify"
+      redirect_to "#{ShopifyApp.configuration.root_url}/auth/shopify"
     end
 
     def authenticate_at_top_level


### PR DESCRIPTION
fixes #603 

There is an issue where the engine is mounted at a nested path, the route will not be valid and throws an exception when redirected the auth page.

This changes the `authenticate_in_context` to use the root_url configuration.