### PR TITLE
Implement JWT callback endpoint

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -6,15 +6,22 @@ module ShopifyApp
     include ShopifyApp::LoginProtection
 
     def callback
-      if jwt_shopify_domain || jwt_shopify_user_id
-        jwt_callback
-        return
+      unless auth_hash
+        return respond_with_error
       end
 
-      if auth_hash
-        login_shop
+      if jwt_request? && !valid_jwt_auth?
+        return respond_with_error
+      end
 
-        if ShopifyApp::SessionRepository.user_storage.present? && user_session.blank?
+      if jwt_request?
+        set_shopify_session
+        head(:ok)
+      else
+        reset_session_options
+        set_shopify_session
+
+        if redirect_for_user_token?
           return redirect_to(login_url_with_optional_shop)
         end
 
@@ -23,30 +30,30 @@ module ShopifyApp
         perform_after_authenticate_job
 
         redirect_to(return_address)
+      end
+    end
+
+    private
+
+    def respond_with_error
+      if jwt_request?
+        head(:unauthorized)
       else
         flash[:error] = I18n.t('could_not_log_in')
         redirect_to(login_url_with_optional_shop)
       end
     end
 
-    private
+    def redirect_for_user_token?
+      ShopifyApp::SessionRepository.user_storage.present? && user_session.blank?
+    end
 
-    def jwt_callback
-      if valid_jwt_auth?
-        set_shopify_session
-        head(:ok)
-      else
-        head(:unauthorized)
-      end
+    def jwt_request?
+      jwt_shopify_domain || jwt_shopify_user_id
     end
 
     def valid_jwt_auth?
       auth_hash && jwt_shopify_domain == shop_name && jwt_shopify_user_id == associated_user_id
-    end
-
-    def login_shop
-      reset_session_options
-      set_shopify_session
     end
 
     def auth_hash

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -33,7 +33,7 @@ module ShopifyApp
 
     def jwt_callback
       if valid_jwt_auth?
-        create_user_session_from_jwt_callback
+        set_shopify_session
         head(:ok)
       else
         head(:unauthorized)
@@ -42,16 +42,6 @@ module ShopifyApp
 
     def valid_jwt_auth?
       auth_hash && jwt_shopify_domain == shop_name && jwt_shopify_user_id == associated_user_id
-    end
-
-    def create_user_session_from_jwt_callback
-      session = ShopifyAPI::Session.new(
-        domain: shop_name,
-        token: token,
-        api_version: ShopifyApp.configuration.api_version
-      )
-
-      ShopifyApp::SessionRepository.store_user_session(session, associated_user)
     end
 
     def login_shop

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -24,6 +24,22 @@ module ShopifyApp
       end
     end
 
+    def jwt_callback
+      if auth_hash && jwt_shopify_domain == shop_name && jwt_shopify_user_id == associated_user_id
+        session_store = ShopifyAPI::Session.new(
+          domain: shop_name,
+          token: token,
+          api_version: ShopifyApp.configuration.api_version
+        )
+
+        ShopifyApp::SessionRepository.store_user_session(session_store, associated_user)
+
+        head(:ok)
+      else
+        head(:unauthorized)
+      end
+    end
+
     private
 
     def login_shop
@@ -43,6 +59,10 @@ module ShopifyApp
       return unless auth_hash['extra'].present?
 
       auth_hash['extra']['associated_user']
+    end
+
+    def associated_user_id
+      associated_user && associated_user['id']
     end
 
     def token

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -6,6 +6,11 @@ module ShopifyApp
     include ShopifyApp::LoginProtection
 
     def callback
+      if jwt_shopify_domain || jwt_shopify_user_id
+        jwt_callback
+        return
+      end
+
       if auth_hash
         login_shop
 
@@ -24,6 +29,8 @@ module ShopifyApp
       end
     end
 
+    private
+
     def jwt_callback
       if valid_jwt_auth?
         create_user_session_from_jwt_callback
@@ -32,8 +39,6 @@ module ShopifyApp
         head(:unauthorized)
       end
     end
-
-    private
 
     def valid_jwt_auth?
       auth_hash && jwt_shopify_domain == shop_name && jwt_shopify_user_id == associated_user_id

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -25,15 +25,8 @@ module ShopifyApp
     end
 
     def jwt_callback
-      if auth_hash && jwt_shopify_domain == shop_name && jwt_shopify_user_id == associated_user_id
-        session_store = ShopifyAPI::Session.new(
-          domain: shop_name,
-          token: token,
-          api_version: ShopifyApp.configuration.api_version
-        )
-
-        ShopifyApp::SessionRepository.store_user_session(session_store, associated_user)
-
+      if valid_jwt_auth?
+        create_user_session_from_jwt_callback
         head(:ok)
       else
         head(:unauthorized)
@@ -41,6 +34,20 @@ module ShopifyApp
     end
 
     private
+
+    def valid_jwt_auth?
+      auth_hash && jwt_shopify_domain == shop_name && jwt_shopify_user_id == associated_user_id
+    end
+
+    def create_user_session_from_jwt_callback
+      session = ShopifyAPI::Session.new(
+        domain: shop_name,
+        token: token,
+        api_version: ShopifyApp.configuration.api_version
+      )
+
+      ShopifyApp::SessionRepository.store_user_session(session, associated_user)
+    end
 
     def login_shop
       reset_session_options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ ShopifyApp::Engine.routes.draw do
 
   controller :callback do
     get 'auth/shopify/callback' => :callback
+    get 'auth/shopify/jwt_callback' => :jwt_callback
   end
 
   namespace :webhooks do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ ShopifyApp::Engine.routes.draw do
 
   controller :callback do
     get 'auth/shopify/callback' => :callback
-    get 'auth/shopify/jwt_callback' => :jwt_callback
   end
 
   namespace :webhooks do

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -43,6 +43,7 @@ module ShopifyApp
   require 'shopify_app/managers/scripttags_manager'
 
   # middleware
+  require 'shopify_app/middleware/jwt_middleware'
   require 'shopify_app/middleware/same_site_cookie_middleware'
 
   # session

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -83,17 +83,11 @@ module ShopifyApp
     protected
 
     def jwt_shopify_domain
-      return unless jwt
-      @jwt_shopify_domain ||= JWT.new(jwt).shopify_domain
+      request.env['jwt.shopify_domain']
     end
 
     def jwt_shopify_user_id
-      return unless jwt
-      @jwt_user_id ||= JWT.new(jwt).shopify_user_id
-    end
-
-    def jwt
-      @jwt ||= authenticate_with_http_token { |token| token }
+      request.env['jwt.shopify_user_id']
     end
 
     def redirect_to_login

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -16,6 +16,10 @@ module ShopifyApp
 
     initializer "shopify_app.middleware" do |app|
       app.config.middleware.insert_after(::Rack::Runtime, ShopifyApp::SameSiteCookieMiddleware)
+
+      if ShopifyApp.configuration.allow_jwt_authentication
+        app.config.middleware.insert_after(ShopifyApp::SameSiteCookieMiddleware, ShopifyApp::JWTMiddleware)
+      end
     end
   end
 end

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -7,7 +7,7 @@ module ShopifyApp
     end
 
     def call(env)
-      return call_next(env) unless authorization_header?(env)
+      return call_next(env) unless authorization_header(env)
 
       token = extract_token(env)
       return call_next(env) unless token
@@ -22,12 +22,12 @@ module ShopifyApp
       @app.call(env)
     end
 
-    def authorization_header?(env)
+    def authorization_header(env)
       env['HTTP_AUTHORIZATION']
     end
 
     def extract_token(env)
-      match = env['HTTP_AUTHORIZATION'].match(TOKEN_REGEX)
+      match = authorization_header(env).match(TOKEN_REGEX)
       match && match[1]
     end
 

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -7,18 +7,20 @@ module ShopifyApp
     end
 
     def call(env)
-      return unless env['HTTP_AUTHORIZATION']
+      response = @app.call(env)
+
+      return response unless env['HTTP_AUTHORIZATION']
 
       match = env['HTTP_AUTHORIZATION'].match(TOKEN_REGEX)
       token = match && match[1]
-      return unless token
+      return response unless token
 
       jwt = ShopifyApp::JWT.new(token)
 
       env['jwt.shopify_domain'] = jwt.shopify_domain
       env['jwt.shopify_user_id'] = jwt.shopify_user_id
 
-      @app.call(env)
+      response
     end
   end
 end

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -1,0 +1,24 @@
+module ShopifyApp
+  class JWTMiddleware
+    TOKEN_REGEX = /^Bearer\s+(.*?)$/
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      return unless env['HTTP_AUTHORIZATION']
+
+      match = env['HTTP_AUTHORIZATION'].match(TOKEN_REGEX)
+      token = match && match[1]
+      return unless token
+
+      jwt = ShopifyApp::JWT.new(token)
+
+      env['jwt.shopify_domain'] = jwt.shopify_domain
+      env['jwt.shopify_user_id'] = jwt.shopify_user_id
+
+      @app.call(env)
+    end
+  end
+end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.2.2')
   s.add_runtime_dependency('rails', '> 5.2.1')
-  s.add_runtime_dependency('shopify_api', '~> 9.0.2')
+  s.add_runtime_dependency('shopify_api', '~> 9.1.0')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.2')
   s.add_runtime_dependency('jwt', '~> 2.2.1')
   s.add_runtime_dependency('redirect_safely', '~> 1.0')

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -11,7 +11,7 @@ end
 module ShopifyApp
   class CallbackControllerTest < ActionController::TestCase
     TEST_SHOPIFY_DOMAIN = "shop.myshopify.com"
-    TEST_ASSOCIATED_USER = { "shopify_user_id" => 'test-shopify-user' }
+    TEST_ASSOCIATED_USER = { 'id' => 'test-shopify-user' }
     TEST_SESSION = "this.is.a.user.session"
 
     setup do

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -102,15 +102,11 @@ module ShopifyApp
     test '#jwt_callback persists the user token' do
       mock_shopify_user_omniauth
       session = mock_user_session
-      jwt_mock = Struct.new(:shopify_domain, :shopify_user_id).new(
-        TEST_SHOPIFY_DOMAIN,
-        TEST_ASSOCIATED_USER['id']
-      )
 
-      ShopifyApp::JWT.stubs(:new).returns(jwt_mock)
       ShopifyApp::SessionRepository.expects(:store_user_session).with(session, TEST_ASSOCIATED_USER)
 
-      request.env['HTTP_AUTHORIZATION'] = "Bearer 123"
+      request.env['jwt.shopify_domain'] = TEST_SHOPIFY_DOMAIN
+      request.env['jwt.shopify_user_id'] = TEST_ASSOCIATED_USER['id']
       get :jwt_callback
       assert_response :ok
     end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -75,28 +75,24 @@ class LoginProtectionControllerTest < ActionController::TestCase
     ShopifyApp.configuration.allow_jwt_authentication = true
     domain = 'https://test.myshopify.io'
     token = 'admin_api_token'
-    payload = {
-      'dest' => 'shopify_domain',
-      'sub' => 'shopify_user',
-    }
-
-    jwt = JWT.encode(payload, nil, 'none')
-    jwt_mock = Struct.new(:shopify_user_id).new(payload['sub'])
-    ShopifyApp::JWT.stubs(:new).with(jwt).returns(jwt_mock)
+    dest = 'shopify_domain'
+    sub = 'shopify_user'
 
     expected_session = ShopifyAPI::Session.new(
       domain: domain,
       token: token,
       api_version: '2020-01',
     )
+
     ShopifyApp::SessionRepository.expects(:retrieve_user_session_by_shopify_user_id)
-      .with(payload['sub']).returns(expected_session)
+      .with(sub).returns(expected_session)
     ShopifyApp::SessionRepository.expects(:retrieve_user_session).never
     ShopifyApp::SessionRepository.expects(:retrieve_shop_session_by_shopify_domain).never
     ShopifyApp::SessionRepository.expects(:retrieve_shop_session).never
 
     with_application_test_routes do
-      request.env['HTTP_AUTHORIZATION'] = "Bearer #{jwt}"
+      request.env['jwt.shopify_domain'] = dest
+      request.env['jwt.shopify_user_id'] = sub
       get :index
 
       assert_equal expected_session, @controller.current_shopify_session
@@ -107,13 +103,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     ShopifyApp.configuration.allow_jwt_authentication = true
     domain = 'https://test.myshopify.io'
     token = 'admin_api_token'
-    payload = {
-      'dest' => 'test.shopify.com',
-    }
-
-    jwt = JWT.encode(payload, nil, 'none')
-    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id).new(payload['dest'], nil)
-    ShopifyApp::JWT.stubs(:new).with(jwt).returns(jwt_mock)
+    dest = 'test.shopify.com'
 
     expected_session = ShopifyAPI::Session.new(
       domain: domain,
@@ -124,11 +114,11 @@ class LoginProtectionControllerTest < ActionController::TestCase
     ShopifyApp::SessionRepository.expects(:retrieve_user_session_by_shopify_user_id).never
     ShopifyApp::SessionRepository.expects(:retrieve_user_session).never
     ShopifyApp::SessionRepository.expects(:retrieve_shop_session_by_shopify_domain)
-      .with(payload['dest']).returns(expected_session)
+      .with(dest).returns(expected_session)
     ShopifyApp::SessionRepository.expects(:retrieve_shop_session).never
 
     with_application_test_routes do
-      request.env['HTTP_AUTHORIZATION'] = "Bearer #{jwt}"
+      request.env['jwt.shopify_domain'] = dest
       get :index
 
       assert_equal expected_session, @controller.current_shopify_session

--- a/test/shopify_app/middleware/jwt_middleware_test.rb
+++ b/test/shopify_app/middleware/jwt_middleware_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ShopifyApp::JWTMiddlewareTest < ActiveSupport::TestCase
+  def app
+    Rack::Lint.new(lambda { |env|
+      Rack::Request.new(env)
+
+      response = Rack::Response.new("", 200, "Content-Type" => "text/yaml")
+      response.finish
+    })
+  end
+
+  test 'does not change env if no authorization header' do
+    env = Rack::MockRequest.env_for('https://example.com')
+
+    ShopifyApp::JWTMiddleware.new(app).call(env)
+
+    assert_nil env['jwt.shopify_domain']
+  end
+
+  test 'does not change env if no bearer token' do
+    env = Rack::MockRequest.env_for('https://example.com')
+    env['HTTP_AUTHORIZATION'] = 'something'
+
+    ShopifyApp::JWTMiddleware.new(app).call(env)
+
+    assert_nil env['jwt.shopify_domain']
+  end
+
+  test 'does not add the shop to the env if nil shop value' do
+    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id).new(nil, 1)
+    ShopifyApp::JWT.stubs(:new).with('abc').returns(jwt_mock)
+
+    env = Rack::MockRequest.env_for('https://example.com')
+    env['HTTP_AUTHORIZATION'] = 'Bearer abc'
+
+    ShopifyApp::JWTMiddleware.new(app).call(env)
+
+    assert_nil env['jwt.shopify_domain']
+    assert_equal 1, env['jwt.shopify_user_id']
+  end
+
+  test 'does not add the user to the env if nil user value' do
+    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id).new('example.myshopify.com', nil)
+    ShopifyApp::JWT.stubs(:new).with('abc').returns(jwt_mock)
+
+    env = Rack::MockRequest.env_for('https://example.com')
+    env['HTTP_AUTHORIZATION'] = 'Bearer abc'
+
+    ShopifyApp::JWTMiddleware.new(app).call(env)
+
+    assert_equal 'example.myshopify.com', env['jwt.shopify_domain']
+    assert_nil env['jwt.shopify_user_id']
+  end
+
+  test 'sets shopify_domain and shopify_user_id if non-nil values' do
+    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id).new('example.myshopify.com', 1)
+    ShopifyApp::JWT.stubs(:new).with('abc').returns(jwt_mock)
+
+    env = Rack::MockRequest.env_for('https://example.com')
+    env['HTTP_AUTHORIZATION'] = 'Bearer abc'
+
+    ShopifyApp::JWTMiddleware.new(app).call(env)
+
+    assert_equal 'example.myshopify.com', env['jwt.shopify_domain']
+    assert_equal 1, env['jwt.shopify_user_id']
+  end
+end
+


### PR DESCRIPTION
## Goals

When we receive an OAuth callback with a JWT in the headers, we want to do two things:
1. Validate that the omniauth data matches the JWT data.
2. Persist the token information to the session store.

## Implementation

1. It's a bit of a pain to have two separate callback paths in omniauth. There is a callback_path option, and it does take a block, but I'm a little unclear about how it knows how to start the normal OAuth flow if you use a block for this option. I elected to incorporate the JWT flow into the existing callback path in a backwards-compatible fashion.
2. Omniauth tries to check the state param as part of the callback action and throws an error if the param doesn't exist or doesn't match the param in the session. We won't have a param in the session in this context. So we need to conditionally disable the state check, based on whether we have a valid JWT. This is safe, I believe, because the goal of the state check is to avoid CSRF, and we can trust the JWT as evidence that the user is doing this from the Shopify context.
  * To make this work, I moved the JWT logic into a Rack middleware. This has two benefits: (1) it means that other Rack middleware (such as omniauth) can make decisions based on the JWT data, and (2) it allows any Rack application to decode our JWT, even if they're not using Rails or the `shopify_app` controller stuff.