### PR TITLE
Webhook jobs default behavior

### DIFF
--- a/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb
+++ b/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb
@@ -2,6 +2,11 @@ class <%= @job_class_name %> < ActiveJob::Base
   def perform(shop_domain:, webhook:)
     shop = Shop.find_by(shopify_domain: shop_domain)
 
+    if shop.nil?
+      logger.error("#{self.class} failed: cannot find shop with domain '#{shop_domain}'")
+      return
+    end
+
     shop.with_shopify_session do
     end
   end


### PR DESCRIPTION
resolves #722 

This PR implements the logic suggested by @sshaw. If a shop doesn't exist, will exit with an error message. 

