### PR TITLE
Add a logic in login_protection.rb not to always display question mark

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -106,7 +106,7 @@ module ShopifyApp
           path = referer.path
           query = "#{referer.query}&#{sanitized_params.to_query}"
         end
-        session[:return_to] = if(query) ? "#{path}?#{query}" : "#{path}"
+        session[:return_to] = (query) ? "#{path}?#{query}" : "#{path}"
         redirect_to(login_url_with_optional_shop)
       end
     end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -106,7 +106,7 @@ module ShopifyApp
           path = referer.path
           query = "#{referer.query}&#{sanitized_params.to_query}"
         end
-        session[:return_to] = "#{path}?#{query}"
+        session[:return_to] = if(query) ? "#{path}?#{query}" : "#{path}"
         redirect_to(login_url_with_optional_shop)
       end
     end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -108,7 +108,7 @@ module ShopifyApp
           path = referer.path
           query = "#{referer.query}&#{sanitized_params.to_query}"
         end
-        session[:return_to] = (query) ? "#{path}?#{query}" : "#{path}"
+        session[:return_to] = query.blank? ? "#{path}" : "#{path}?#{query}"
         redirect_to(login_url_with_optional_shop)
       end
     end


### PR DESCRIPTION
resolves #773 

This PR adds logic in the  `redirect_to_login` method, in the absence of a query that will be set to `session[:return_to]`
If query is empty:
`session[:return_to] = "#{path}"`  
else will be set to path and query:
`session[:return_to] = `"#{path}?#{query}"`