### PR TITLE
Add shop parameter when redirecting after callback

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -205,11 +205,16 @@ module ShopifyApp
     end
 
     def return_address
+      return base_return_address unless ShopifyApp.configuration.allow_jwt_authentication
+      return_address_with_params(shop: current_shopify_domain)
+    end
+
+    def base_return_address
       session.delete(:return_to) || ShopifyApp.configuration.root_url
     end
 
     def return_address_with_params(params)
-      uri = URI(return_address)
+      uri = URI(base_return_address)
       uri.query = CGI.parse(uri.query.to_s)
         .symbolize_keys
         .transform_values { |v| v.one? ? v.first : v }

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -208,6 +208,23 @@ module ShopifyApp
       end
     end
 
+    test "#callback redirects to the root_url when not using JWT authentication" do
+      mock_shopify_omniauth
+
+      get :callback, params: { shop: 'shop' }
+
+      assert_redirected_to '/'
+    end
+
+    test "#callback redirects to the root_url with shop parameter when using JWT authentication" do
+      ShopifyApp.configuration.allow_jwt_authentication = true
+      mock_shopify_omniauth
+
+      get :callback, params: { shop: 'shop' }
+
+      assert_redirected_to "/?shop=#{TEST_SHOPIFY_DOMAIN}"
+    end
+
     private
 
     def mock_shopify_omniauth


### PR DESCRIPTION
The callback controller redirects to the root url after the app has been installed.
Currently, the root url depends on the cookie to fetch the shop and load the app.

In a world without 3rd party cookies, the app has no way of knowing which shop the request is for. By having the Callback Controller add a Shop parameter to the root url, we can load the app and fetch the JWT for the particular shop.