### PR TITLE
Test against Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ cache:
   yarn: true
 
 rvm:
-  - 2.4.3
-  - 2.5.0
-  - 2.6.2
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 
 install:
   - bundle install


### PR DESCRIPTION
Ruby 2.7 [was released](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/) on 25 Dec 2019 and the latest version is 2.7.1