### PR TITLE
bump minimum required Ruby to 2.4

### DIFF
--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = 'This gem is used to get quickly started with the Shopify API'
 
-  s.required_ruby_version = ">= 2.3.1"
+  s.required_ruby_version = ">= 2.4"
 
   s.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
1. The gem spec specifies `s.add_runtime_dependency('shopify_api', '~> 9.0.2')`  
2. The shopify_api gem spec requires `s.required_ruby_version = ">= 2.4"`, see https://github.com/Shopify/shopify_api/blob/v9.0.2/shopify_api.gemspec#L26

Even though ["all support of the Ruby 2.4 series has ended"](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/) in my view we should keep it for compatibility reasons until it causes problems.