### PR TITLE
Update Rubocop TargetRubyVersion to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
     rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   Exclude:
     - 'lib/generators/**/*'
     - 'test/tmp/**/*'


### PR DESCRIPTION
Ruby 2.4 has already reached it's EOL – see https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/.

The target version is debatable, but latest Rubocop versions contain lots of changes related to Ruby 2.7.

This PR kind of depends on https://github.com/Shopify/shopify_app/pull/959.