### PR TITLE
Add Rubocop to CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,28 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Cache gems
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-rubocop-
+    - name: Install gems
+      run: |
+        bundle config path vendor/bundle
+        bundle config set without 'default development test'
+        bundle install --jobs 4 --retry 3
+    - name: Run RuboCop
+      run: bundle exec rubocop --parallel

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   TargetRubyVersion: 2.7
   Exclude:
     - 'test/tmp/**/*'
+    - 'vendor/bundle/**/*'
 
 Style/MethodCallWithArgsParentheses:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gemspec
 
 gem 'rails-controller-testing', group: :test
 
-gem 'rubocop-shopify', require: false
+group :rubocop do
+  gem 'rubocop-shopify', require: false
+end

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ShopifyApp
   class JWTMiddleware
     TOKEN_REGEX = /^Bearer\s+(.*?)$/

--- a/test/controllers/concerns/require_known_shop_test.rb
+++ b/test/controllers/concerns/require_known_shop_test.rb
@@ -5,7 +5,7 @@ class RequireKnownShopTest < ActionController::TestCase
     include ShopifyApp::RequireKnownShop
 
     def index
-      render html: '<h1>Success</ h1>'
+      render(html: '<h1>Success</ h1>')
     end
   end
 

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -25,7 +25,9 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "can set root_url which affects login_url" do
-    begin
+    # TODO: drop `rubocop:todo Style/RedundantBegin` together with Ruby 2.4 support
+    #   As this style is supported since Ruby 2.5 (see https://bugs.ruby-lang.org/issues/12906)
+    begin # rubocop:todo Style/RedundantBegin
       original_root = ShopifyApp.configuration.root_url
 
       ShopifyApp.configure do |config|

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -369,9 +369,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
   test '#fullpage_redirect_to, when the shop params is missing, sends a post message to the shop in the jwt' do
     ShopifyApp.configuration.allow_jwt_authentication = true
     domain = 'shop.myshopify.com'
-    payload = {
-      'dest' => domain,
-    }
 
     with_application_test_routes do
       request.env['jwt.shopify_domain'] = domain


### PR DESCRIPTION
Simply replicated https://github.com/rails/rails/blob/100f7a7f643ae6766f406ccf1e049050199caddc/.github/workflows/rubocop.yml.

Depends on https://github.com/Shopify/shopify_app/pull/959 and https://github.com/Shopify/shopify_app/pull/963.