### PR TITLE
Packaging for release 13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+13.1.0
+------
+* Adds the shop URL as a parameter when redirecting after the callback
+* Bump minimum Ruby version to 2.4
+* Bug fixes
+
 13.0.1
 ------
 * Small addition to WebhookJob to return if the shop is nil #952

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '13.0.1'
+  VERSION = '13.1.0'
 end


### PR DESCRIPTION
This PR is a release for version 13.1.1, which includes the following changes:
* Adds the shop URL as a parameter when redirecting after the callback
* Bump minimum Ruby version to 2.4
* Bug fixes