### PR TITLE
Update runtime dependency browser_sniffer to 1.2.2

### DIFF
--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  s.add_runtime_dependency('browser_sniffer', '~> 1.2.0')
+  s.add_runtime_dependency('browser_sniffer', '~> 1.2.2')
   s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 9.0.2')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.2')


### PR DESCRIPTION
A [recent change in browser_sniffer](https://github.com/Shopify/browser_sniffer/pull/30) fixes the detection of the `SameSite` attribute compatibility for Chromium OS operating systems.

Previously, cookies for a Chrome OS + Chrome user agents weren't getting the `SameSite=none` and `Secure` attributes.