### PR TITLE
Packaging for release 13.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+13.1.1
+------
+* Update browser_sniffer to 1.2.2
+
 13.1.0
 ------
 * Adds the shop URL as a parameter when redirecting after the callback

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '13.1.0'
+  VERSION = '13.1.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "13.0.1",
+  "version": "13.1.1",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
The 13.1.1 release includes an update to the `browser_sniffer` dependency. This dependency update will allow the `SameSite=none` and `Secure` cookie attributes to be configured for Chrome OS + Chrome user agents (cookie configuration done in [same_site_cookie_middleware.rb](https://github.com/Shopify/shopify_app/blob/master/lib/shopify_app/middleware/same_site_cookie_middleware.rb)).