### PR TITLE
fix: Webhook controller returns 204 instead of 200

### DIFF
--- a/app/controllers/shopify_app/webhooks_controller.rb
+++ b/app/controllers/shopify_app/webhooks_controller.rb
@@ -9,7 +9,7 @@ module ShopifyApp
       params.permit!
       job_args = { shop_domain: shop_domain, webhook: webhook_params.to_h }
       webhook_job_klass.perform_later(job_args)
-      head(:no_content)
+      head(:ok)
     end
 
     private

--- a/test/integration/webhooks_controller_test.rb
+++ b/test/integration/webhooks_controller_test.rb
@@ -16,7 +16,7 @@ module ShopifyApp
 
     test "receives webhook and performs job" do
       send_webhook 'order_update', { foo: :bar }
-      assert_response :no_content
+      assert_response :ok
       assert_enqueued_jobs 1
     end
 

--- a/test/integration/webhooks_controller_test.rb
+++ b/test/integration/webhooks_controller_test.rb
@@ -27,7 +27,7 @@ module ShopifyApp
       OrderUpdateJob.expects(:perform_later).with(job_args)
 
       send_webhook 'order_update', webhook
-      assert_response :no_content
+      assert_response :ok
     end
 
     test "returns error for webhook with no job class" do


### PR DESCRIPTION
Empty head returns 204 hence kills webhooks.

Shopify expects 200

Might fix #976 