### PR TITLE
Update shopify_app.rb to match the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Migrating to 13.0.0
 Version 13.0.0 adds the ability to use both user and shop sessions, concurrently. This however involved a large
 change to how session stores work. Here are the steps to migrate to 13.x
 
-### Changes to `config/initializers/shopify_app.rb.tt`
+### Changes to `config/initializers/shopify_app.rb`
 - *REMOVE* `config.per_user_tokens = [true|false]` this is no longer needed
 - *CHANGE* `config.session_repository = 'Shop'` To  `config.shop_session_repository = 'Shop'`
 - *ADD (optional)*  User Session Storage `config.user_session_repository = 'User'`

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Migrating to 13.0.0
 Version 13.0.0 adds the ability to use both user and shop sessions, concurrently. This however involved a large
 change to how session stores work. Here are the steps to migrate to 13.x
 
-### Changes to `config/initializers/shopify_app.rb`
+### Changes to `config/initializers/shopify_app.rb.tt`
 - *REMOVE* `config.per_user_tokens = [true|false]` this is no longer needed
 - *CHANGE* `config.session_repository = 'Shop'` To  `config.shop_session_repository = 'Shop'`
 - *ADD (optional)*  User Session Storage `config.user_session_repository = 'User'`

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -8,7 +8,7 @@ ShopifyApp.configure do |config|
   config.embedded_app = <%= embedded_app? %>
   config.after_authenticate_job = false
   config.api_version = "<%= @api_version %>"
-  config.shop_session_repository = 'ShopifyApp::InMemoryShopSessionStore'
+  config.shop_session_repository = 'Shop'
 end
 
 # ShopifyApp::Utils.fetch_known_api_versions                        # Uncomment to fetch known api versions from shopify servers on boot

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -37,26 +37,26 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "creates the ShopifyApp initializer with args" do
     run_generator %w(--application_name Test Name --api_key key --secret shhhhh
                      --api_version unstable --scope read_orders write_products)
-    assert_file "config/initializers/shopify_app.rb" do |shopify_app|
+    assert_file "config/initializers/shopify_app.rb.tt" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
       assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
       assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
-      assert_match "config.shop_session_repository = 'ShopifyApp::InMemoryShopSessionStore'", shopify_app
+      assert_match "config.shop_session_repository = 'Shop'", shopify_app
     end
   end
 
   test "creates the ShopifyApp initializer with double-quoted args" do
     run_generator %w(--application_name Test Name --api_key key --secret shhhhh --scope read_orders write_products)
-    assert_file "config/initializers/shopify_app.rb" do |shopify_app|
+    assert_file "config/initializers/shopify_app.rb.tt" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
       assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
       assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
-      assert_match "config.shop_session_repository = 'ShopifyApp::InMemoryShopSessionStore'", shopify_app
+      assert_match "config.shop_session_repository = 'Shop'", shopify_app
     end
   end
 

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -37,7 +37,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "creates the ShopifyApp initializer with args" do
     run_generator %w(--application_name Test Name --api_key key --secret shhhhh
                      --api_version unstable --scope read_orders write_products)
-    assert_file "config/initializers/shopify_app.rb.tt" do |shopify_app|
+    assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
       assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
       assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
@@ -50,7 +50,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   test "creates the ShopifyApp initializer with double-quoted args" do
     run_generator %w(--application_name Test Name --api_key key --secret shhhhh --scope read_orders write_products)
-    assert_file "config/initializers/shopify_app.rb.tt" do |shopify_app|
+    assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
       assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
       assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app


### PR DESCRIPTION
resolves #971 

Update the `shopify_app.rb.tt` from `  config.shop_session_repository = 'ShopifyApp::InMemoryShopSessionStore'
` to `  config.shop_session_repository = 'Shop'
`
also updates the readme to show the renaming of the `shopify_app.rb` to `shopify_app.rb.tt`

cc @tanema 