### PR TITLE
Populate current_shopify_domain from the jwt

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -164,7 +164,10 @@ module ShopifyApp
     end
 
     def current_shopify_domain
-      shopify_domain = sanitized_shop_name || session[:shopify_domain]
+      shopify_domain = sanitized_shop_name ||
+        jwt_shopify_domain ||
+        session[:shopify_domain]
+
       return shopify_domain if shopify_domain.present?
 
       raise ShopifyDomainNotFound

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -366,6 +366,20 @@ class LoginProtectionControllerTest < ActionController::TestCase
     end
   end
 
+  test '#fullpage_redirect_to, when the shop params is missing, sends a post message to the shop in the jwt' do
+    ShopifyApp.configuration.allow_jwt_authentication = true
+    domain = 'shop.myshopify.com'
+    payload = {
+      'dest' => domain,
+    }
+
+    with_application_test_routes do
+      request.env['jwt.shopify_domain'] = domain
+      get :redirect
+      assert_fullpage_redirected(domain, response)
+    end
+  end
+
   test '#fullpage_redirect_to, when the shop params is missing, sends a post message to the shop in the session' do
     with_application_test_routes do
       example_shop = 'shop.myshopify.com'


### PR DESCRIPTION
With the new JWT based auth, we won't always have a session. In such cases, `current_shopify_domain` would return a nil value. 

This PR addresses that by fetching the domain from the JWT when it is not present in the session.