### PR TITLE
Clear stale session IDs in callback

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -92,9 +92,11 @@ module ShopifyApp
 
       session[:shopify_user] = associated_user
       if session[:shopify_user].present?
+        session[:shop_id] = nil if shop_session && shop_session.domain != shop_name
         session[:user_id] = ShopifyApp::SessionRepository.store_user_session(session_store, associated_user)
       else
         session[:shop_id] = ShopifyApp::SessionRepository.store_shop_session(session_store)
+        session[:user_id] = nil if user_session && user_session.domain != shop_name
       end
       session[:shopify_domain] = shop_name
       session[:user_session] = auth_hash&.extra&.session


### PR DESCRIPTION
When the OAuth callback is triggered, there may already be session IDs
in the session, and sometimes those IDs will be for a different shop.
This can happen if the user was previously accessing the app for shop 1
and now accesses the app for shop 2.

These edge cases can result in incorrectly attempting to use a token on
the wrong shop, which fails.

To avoid this scenario, we check that the IDs in the session belong to
the shop that triggered the callback, and clear the values if not.