### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,8 +529,10 @@ change to how session stores work. Here are the steps to migrate to 13.x
 ### Changes to `ShopifyApp::LoginProtection`
 `ShopifyApp::LoginProtection`
 
-if you are using `ShopifyApp::LoginProtection#shop_session` in your code, it will need to be
+- CHANGE if you are using `ShopifyApp::LoginProtection#shopify_session` in your code, it will need to be
 changed to `ShopifyApp::LoginProtection#activate_shopify_session`
+- CHANGE if you are using `ShopifyApp::LoginProtection#clear_shop_session` in your code, it will need to be
+changed to `ShopifyApp::LoginProtection#clear_shopify_session`
 
 ### Notes
 You do not need a user model; a shop session is fine for most applications.


### PR DESCRIPTION
- In #887, The following methods were renamed
  - `shop_session` was renamed to `shopify_session`. [Here](https://github.com/Shopify/shopify_app/commit/342c09b6c2444541e9b546fdd46121d14ce3f2dd#diff-b9a7bf8308ef283be1ea3ec13833b5c7R29
) is the diff for the change
  - `clear_shop_session ` was renamed to `clear_shopify_session`. [Here](https://github.com/Shopify/shopify_app/commit/342c09b6c2444541e9b546fdd46121d14ce3f2dd#diff-b9a7bf8308ef283be1ea3ec13833b5c7R84
) is the diff for the change

