### PR TITLE
Added Payload Verification module

### DIFF
--- a/app/controllers/shopify_app/extension_verification_controller.rb
+++ b/app/controllers/shopify_app/extension_verification_controller.rb
@@ -2,19 +2,8 @@
 
 module ShopifyApp
   class ExtensionVerificationController < ActionController::Base
+    include ShopifyApp::PayloadVerification
     protect_from_forgery with: :null_session
     before_action :verify_request
-
-    private
-
-    def verify_request
-      hmac_header = request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
-      request_body = request.body.read
-      secret = ShopifyApp.configuration.secret
-      digest = OpenSSL::Digest.new('sha256')
-
-      expected_hmac = Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, request_body))
-      head(:unauthorized) unless ActiveSupport::SecurityUtils.secure_compare(expected_hmac, hmac_header)
-    end
   end
 end

--- a/app/controllers/shopify_app/extension_verification_controller.rb
+++ b/app/controllers/shopify_app/extension_verification_controller.rb
@@ -5,5 +5,9 @@ module ShopifyApp
     include ShopifyApp::PayloadVerification
     protect_from_forgery with: :null_session
     before_action :verify_request
+
+    def verify_request
+      head(:unauthorized) unless hmac_valid?(request.body.read)
+    end
   end
 end

--- a/app/controllers/shopify_app/extension_verification_controller.rb
+++ b/app/controllers/shopify_app/extension_verification_controller.rb
@@ -6,6 +6,8 @@ module ShopifyApp
     protect_from_forgery with: :null_session
     before_action :verify_request
 
+    private
+
     def verify_request
       head(:unauthorized) unless hmac_valid?(request.body.read)
     end

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -31,8 +31,8 @@ module ShopifyApp
   require 'shopify_app/controller_concerns/itp'
   require 'shopify_app/controller_concerns/login_protection'
   require 'shopify_app/controller_concerns/embedded_app'
-  require 'shopify_app/controller_concerns/app_proxy_verification'
   require 'shopify_app/controller_concerns/payload_verification'
+  require 'shopify_app/controller_concerns/app_proxy_verification'
   require 'shopify_app/controller_concerns/webhook_verification'
 
   # jobs

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -33,6 +33,7 @@ module ShopifyApp
   require 'shopify_app/controller_concerns/embedded_app'
   require 'shopify_app/controller_concerns/webhook_verification'
   require 'shopify_app/controller_concerns/app_proxy_verification'
+  require 'shopify_app/controller_concerns/payload_verification'
 
   # jobs
   require 'shopify_app/jobs/webhooks_manager_job'

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -31,9 +31,9 @@ module ShopifyApp
   require 'shopify_app/controller_concerns/itp'
   require 'shopify_app/controller_concerns/login_protection'
   require 'shopify_app/controller_concerns/embedded_app'
-  require 'shopify_app/controller_concerns/webhook_verification'
   require 'shopify_app/controller_concerns/app_proxy_verification'
   require 'shopify_app/controller_concerns/payload_verification'
+  require 'shopify_app/controller_concerns/webhook_verification'
 
   # jobs
   require 'shopify_app/jobs/webhooks_manager_job'

--- a/lib/shopify_app/controller_concerns/app_proxy_verification.rb
+++ b/lib/shopify_app/controller_concerns/app_proxy_verification.rb
@@ -2,6 +2,7 @@
 module ShopifyApp
   module AppProxyVerification
     extend ActiveSupport::Concern
+    include ShopifyApp::PayloadVerification
 
     included do
       skip_before_action :verify_authenticity_token, raise: false
@@ -23,16 +24,6 @@ module ShopifyApp
       ActiveSupport::SecurityUtils.secure_compare(
         calculated_signature(query_hash),
         signature
-      )
-    end
-
-    def calculated_signature(query_hash_without_signature)
-      sorted_params = query_hash_without_signature.collect { |k, v| "#{k}=#{Array(v).join(',')}" }.sort.join
-
-      OpenSSL::HMAC.hexdigest(
-        OpenSSL::Digest.new('sha256'),
-        ShopifyApp.configuration.secret,
-        sorted_params
       )
     end
   end

--- a/lib/shopify_app/controller_concerns/payload_verification.rb
+++ b/lib/shopify_app/controller_concerns/payload_verification.rb
@@ -3,41 +3,21 @@ module ShopifyApp
   module PayloadVerification
     extend ActiveSupport::Concern
 
+    def shopify_hmac
+      request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
+    end
+
     def hmac_valid?(data)
       secrets = [ShopifyApp.configuration.secret, ShopifyApp.configuration.old_secret].reject(&:blank?)
 
       secrets.any? do |secret|
         digest = OpenSSL::Digest.new('sha256')
-
         ActiveSupport::SecurityUtils.secure_compare(
+          # request.headers['HTTP_X_SHOPIFY_HMAC_SHA256'],
           shopify_hmac,
           Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, data))
         )
       end
-    end
-
-    def shopify_hmac
-      request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
-    end
-
-    def verify_request
-      hmac_header = request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
-      request_body = request.body.read
-      secret = ShopifyApp.configuration.secret
-      digest = OpenSSL::Digest.new('sha256')
-
-      expected_hmac = Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, request_body))
-      head(:unauthorized) unless ActiveSupport::SecurityUtils.secure_compare(expected_hmac, hmac_header)
-    end
-
-    def calculated_signature(query_hash_without_signature)
-      sorted_params = query_hash_without_signature.collect { |k, v| "#{k}=#{Array(v).join(',')}" }.sort.join
-
-      OpenSSL::HMAC.hexdigest(
-        OpenSSL::Digest.new('sha256'),
-        ShopifyApp.configuration.secret,
-        sorted_params
-      )
     end
   end
 end

--- a/lib/shopify_app/controller_concerns/payload_verification.rb
+++ b/lib/shopify_app/controller_concerns/payload_verification.rb
@@ -19,5 +19,25 @@ module ShopifyApp
     def shopify_hmac
       request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
     end
+
+    def verify_request
+      hmac_header = request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
+      request_body = request.body.read
+      secret = ShopifyApp.configuration.secret
+      digest = OpenSSL::Digest.new('sha256')
+
+      expected_hmac = Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, request_body))
+      head(:unauthorized) unless ActiveSupport::SecurityUtils.secure_compare(expected_hmac, hmac_header)
+    end
+
+    def calculated_signature(query_hash_without_signature)
+      sorted_params = query_hash_without_signature.collect { |k, v| "#{k}=#{Array(v).join(',')}" }.sort.join
+
+      OpenSSL::HMAC.hexdigest(
+        OpenSSL::Digest.new('sha256'),
+        ShopifyApp.configuration.secret,
+        sorted_params
+      )
+    end
   end
 end

--- a/lib/shopify_app/controller_concerns/payload_verification.rb
+++ b/lib/shopify_app/controller_concerns/payload_verification.rb
@@ -13,7 +13,6 @@ module ShopifyApp
       secrets.any? do |secret|
         digest = OpenSSL::Digest.new('sha256')
         ActiveSupport::SecurityUtils.secure_compare(
-          # request.headers['HTTP_X_SHOPIFY_HMAC_SHA256'],
           shopify_hmac,
           Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, data))
         )

--- a/lib/shopify_app/controller_concerns/payload_verification.rb
+++ b/lib/shopify_app/controller_concerns/payload_verification.rb
@@ -3,12 +3,6 @@ module ShopifyApp
   module PayloadVerification
     extend ActiveSupport::Concern
 
-    included do
-      skip_before_action :verify_authenticity_token, raise: false
-    end
-
-    private
-
     def hmac_valid?(data)
       secrets = [ShopifyApp.configuration.secret, ShopifyApp.configuration.old_secret].reject(&:blank?)
 

--- a/lib/shopify_app/controller_concerns/payload_verification.rb
+++ b/lib/shopify_app/controller_concerns/payload_verification.rb
@@ -3,6 +3,8 @@ module ShopifyApp
   module PayloadVerification
     extend ActiveSupport::Concern
 
+    private
+
     def shopify_hmac
       request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
     end

--- a/lib/shopify_app/controller_concerns/payload_verification.rb
+++ b/lib/shopify_app/controller_concerns/payload_verification.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module ShopifyApp
+  module PayloadVerification
+    extend ActiveSupport::Concern
+
+    included do
+      skip_before_action :verify_authenticity_token, raise: false
+    end
+
+    private
+
+    def hmac_valid?(data)
+      secrets = [ShopifyApp.configuration.secret, ShopifyApp.configuration.old_secret].reject(&:blank?)
+
+      secrets.any? do |secret|
+        digest = OpenSSL::Digest.new('sha256')
+
+        ActiveSupport::SecurityUtils.secure_compare(
+          shopify_hmac,
+          Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, data))
+        )
+      end
+    end
+
+    def shopify_hmac
+      request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
+    end
+  end
+end

--- a/lib/shopify_app/controller_concerns/webhook_verification.rb
+++ b/lib/shopify_app/controller_concerns/webhook_verification.rb
@@ -2,6 +2,7 @@
 module ShopifyApp
   module WebhookVerification
     extend ActiveSupport::Concern
+    include PayloadVerification
 
     included do
       skip_before_action :verify_authenticity_token, raise: false
@@ -14,26 +15,8 @@ module ShopifyApp
       data = request.raw_post
       return head(:unauthorized) unless hmac_valid?(data)
     end
-
-    def hmac_valid?(data)
-      secrets = [ShopifyApp.configuration.secret, ShopifyApp.configuration.old_secret].reject(&:blank?)
-
-      secrets.any? do |secret|
-        digest = OpenSSL::Digest.new('sha256')
-
-        ActiveSupport::SecurityUtils.secure_compare(
-          shopify_hmac,
-          Base64.strict_encode64(OpenSSL::HMAC.digest(digest, secret, data))
-        )
-      end
-    end
-
     def shop_domain
       request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN']
-    end
-
-    def shopify_hmac
-      request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
     end
   end
 end

--- a/lib/shopify_app/controller_concerns/webhook_verification.rb
+++ b/lib/shopify_app/controller_concerns/webhook_verification.rb
@@ -2,7 +2,7 @@
 module ShopifyApp
   module WebhookVerification
     extend ActiveSupport::Concern
-    include PayloadVerification
+    include ShopifyApp::PayloadVerification
 
     included do
       skip_before_action :verify_authenticity_token, raise: false
@@ -15,6 +15,7 @@ module ShopifyApp
       data = request.raw_post
       return head(:unauthorized) unless hmac_valid?(data)
     end
+
     def shop_domain
       request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN']
     end


### PR DESCRIPTION
This PR resolves #926 

Creates a payload_verifcation.rb and moves the `def hmac_valid?(data)` and `def shopify_hmac`. It then includes this module inside `webhook_verication.rb`.  All tests are passing. 

![Screen Shot 2020-05-22 at 12 16 46 PM](https://user-images.githubusercontent.com/35715329/82688033-2c0d9780-9c26-11ea-96d8-8094862ff5fd.png)


cc @tanema 