### PR TITLE
Skip CSRF check if a valid JWT is passed in

### DIFF
--- a/app/controllers/concerns/shopify_app/authenticated.rb
+++ b/app/controllers/concerns/shopify_app/authenticated.rb
@@ -7,6 +7,7 @@ module ShopifyApp
     included do
       include ShopifyApp::Localization
       include ShopifyApp::LoginProtection
+      include ShopifyApp::CsrfProtection
       include ShopifyApp::EmbeddedApp
       before_action :login_again_if_different_user_or_shop
       around_action :activate_shopify_session

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -27,6 +27,7 @@ module ShopifyApp
   require 'shopify_app/utils'
 
   # controller concerns
+  require 'shopify_app/controller_concerns/csrf_protection'
   require 'shopify_app/controller_concerns/localization'
   require 'shopify_app/controller_concerns/itp'
   require 'shopify_app/controller_concerns/login_protection'

--- a/lib/shopify_app/controller_concerns/csrf_protection.rb
+++ b/lib/shopify_app/controller_concerns/csrf_protection.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module ShopifyApp
+  module CsrfProtection
+    extend ActiveSupport::Concern
+
+    MissingIncludeError = Class.new(StandardError)
+
+    included do
+      unless ancestors.include?(ShopifyApp::LoginProtection)
+        raise(MissingIncludeError, 'You must include ShopifyApp::LoginProtection before including this module.')
+      end
+
+      protect_from_forgery with: :exception, unless: :valid_session_token?
+    end
+
+    private
+
+    def valid_session_token?
+      jwt_shopify_domain.present?
+    end
+  end
+end

--- a/lib/shopify_app/controller_concerns/csrf_protection.rb
+++ b/lib/shopify_app/controller_concerns/csrf_protection.rb
@@ -2,21 +2,14 @@
 module ShopifyApp
   module CsrfProtection
     extend ActiveSupport::Concern
-
-    MissingIncludeError = Class.new(StandardError)
-
     included do
-      unless ancestors.include?(ShopifyApp::LoginProtection)
-        raise(MissingIncludeError, 'You must include ShopifyApp::LoginProtection before including this module.')
-      end
-
       protect_from_forgery with: :exception, unless: :valid_session_token?
     end
 
     private
 
     def valid_session_token?
-      jwt_shopify_domain.present?
+      request.env['jwt.shopify_domain']
     end
   end
 end

--- a/test/controllers/concerns/authenticated_test.rb
+++ b/test/controllers/concerns/authenticated_test.rb
@@ -13,6 +13,7 @@ class AuthenticatedTest < ActionController::TestCase
   test "includes all the needed concerns" do
     AuthenticatedTestController.include?(ShopifyApp::Localization)
     AuthenticatedTestController.include?(ShopifyApp::LoginProtection)
+    AuthenticatedTestController.include?(ShopifyApp::CsrfProtection)
     AuthenticatedTestController.include?(ShopifyApp::EmbeddedApp)
   end
 end

--- a/test/shopify_app/controller_concerns/csrf_protection_test.rb
+++ b/test/shopify_app/controller_concerns/csrf_protection_test.rb
@@ -28,16 +28,6 @@ class CsrfProtectionTest < ActionDispatch::IntegrationTest
     Rails.application.reload_routes!
   end
 
-  test 'it raises an error if module is included without including ShopifyApp::LoginProtection first' do
-    error = assert_raises ShopifyApp::CsrfProtection::MissingIncludeError do
-      class Test
-        include ShopifyApp::CsrfProtection
-      end
-    end
-
-    assert_equal 'You must include ShopifyApp::LoginProtection before including this module.', error.message
-  end
-
   test 'it raises an invalid authenticity token error if a valid session token or csrf token is not provided' do
     assert_raises ActionController::InvalidAuthenticityToken do
       post '/csrf_protection_test'

--- a/test/shopify_app/controller_concerns/csrf_protection_test.rb
+++ b/test/shopify_app/controller_concerns/csrf_protection_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class CsrfProtectionController < ActionController::Base
+  include ShopifyApp::LoginProtection
+  include ShopifyApp::CsrfProtection
+
+  def authenticity_token
+    render(json: { authenticity_token: form_authenticity_token })
+  end
+
+  def csrf_test
+    head(:ok)
+  end
+end
+
+class CsrfProtectionTest < ActionDispatch::IntegrationTest
+  setup do
+    @authenticity_protection = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    Rails.application.routes.draw do
+      get '/authenticity_token', to: 'csrf_protection#authenticity_token'
+      post '/csrf_protection_test', to: 'csrf_protection#csrf_test'
+    end
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @authenticity_protection
+    Rails.application.reload_routes!
+  end
+
+  test 'it raises an error if module is included without including ShopifyApp::LoginProtection first' do
+    error = assert_raises ShopifyApp::CsrfProtection::MissingIncludeError do
+      class Test
+        include ShopifyApp::CsrfProtection
+      end
+    end
+
+    assert_equal 'You must include ShopifyApp::LoginProtection before including this module.', error.message
+  end
+
+  test 'it raises an invalid authenticity token error if a valid session token or csrf token is not provided' do
+    assert_raises ActionController::InvalidAuthenticityToken do
+      post '/csrf_protection_test'
+    end
+  end
+
+  test 'it does not raise if a valid CSRF token was provided' do
+    get '/authenticity_token'
+
+    csrf_token = JSON.parse(response.body)['authenticity_token']
+
+    post '/csrf_protection_test', headers: { 'X-CSRF-Token': csrf_token }
+
+    assert_response :ok
+  end
+
+  test 'it does not raise if a valid session token was provided' do
+    post '/csrf_protection_test', env: { 'jwt.shopify_domain': "exampleshop.myshopify.com" }
+
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
With 3p cookies being blocked, Rails will no longer be able to set CSRF tokens. This will result in requests failing with an `invalid CSRF token` error.
When using JWT based auth, a valid signed JWT is as secure than a CSRF token, since we trust that Shopify is the only source that can sign it securely.

This PR introduces a new concern that when included, skips the CSRF check  if we are able to successfully extract the shop domain from the JWT.