### PR TITLE
Remove mentions of unused generator flags

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -64,14 +64,13 @@ Generate the code for your app by running these commands:
 
 ```sh
 # Use the keys from your app you created in the partners area
-$ rails generate shopify_app --api_key <shopify_api_key> --secret <shopify_api_secret>
+$ rails generate shopify_app
 $ git add .
 $ git commit -m 'generated shopify app'
 ```
 
-If you forget to set your keys or redirect uri above, you will find them in the shopify_app initializer at: `/config/initializers/shopify_app.rb`.
-
-We recommend adding a gem or utilizing environment variables (`.env`) to handle your keys before releasing your app. [Learn more about using environment variables.](https://www.honeybadger.io/blog/ruby-guide-environment-variables/)
+Your API key and secret are read from environment variables. Refer to the main
+README for further details on how to set this up.
 
 6. Deploy your app
 ---------

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -35,7 +35,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates the ShopifyApp initializer with args" do
-    run_generator %w(--application_name Test Name --api_key key --secret shhhhh
+    run_generator %w(--application_name Test Name
                      --api_version unstable --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
@@ -49,7 +49,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates the ShopifyApp initializer with double-quoted args" do
-    run_generator %w(--application_name Test Name --api_key key --secret shhhhh --scope read_orders write_products)
+    run_generator %w(--application_name Test Name --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
       assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app


### PR DESCRIPTION
In #776 we switched to reading the Shopify API key and secret from the environment, but a few references to the old approach were left over.

cc @tylerball 