### PR TITLE
Fix Mocha deprecation warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 require 'rails/test_help'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'webmock/minitest'
 require 'byebug'
 require 'pry'


### PR DESCRIPTION
Fixes this warning:

```
    Mocha deprecation warning at
    /Users/andyw8/.gem/ruby/2.5.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in
    `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api'
    instead of 'mocha/setup'.
```