### PR TITLE
Show flash when navigating with turbolinks

### DIFF
--- a/lib/generators/shopify_app/install/templates/flash_messages.js
+++ b/lib/generators/shopify_app/install/templates/flash_messages.js
@@ -20,7 +20,5 @@ if (!document.documentElement.hasAttribute("data-turbolinks-preview")) {
         isError: true,
       }).dispatch(Toast.Action.SHOW);
     }
-
-    document.removeEventListener(eventName, flash)
   });
 }


### PR DESCRIPTION
fixes #1007

Removing the event listener prevents flashing messages when navigating with Turbolinks enabled.
This js works only once when using turbolinks and flash messages show only for first full page load.
Removing this line of code will allow it to run on subsequent turbolinks:load and show flash messages on all pages.