### PR TITLE
Simplify installation command with bundle add

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ $ cd my_shopify_app
 
 # Add the gem shopify_app to your Gemfile
 $ bundle add shopify_app
-$ bundle install
 ```
 
 Now we are ready to run any of the [generators](#generators) included with `shopify_app`. The following section explains the generators and what you can do with them.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ rails new my_shopify_app
 $ cd my_shopify_app
 
 # Add the gem shopify_app to your Gemfile
-$ echo "gem 'shopify_app'" >> Gemfile
+$ bundle add shopify_app
 $ bundle install
 ```
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -40,7 +40,7 @@ $ heroku create name
 4. Add ShopifyApp to Gemfile
 ----------------------------
 
-Run these commands to add the `shopify_app` Gem to your app:
+Run this command to add the `shopify_app` Gem to your app:
 
 ```sh
 $ bundle add shopify_app

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -43,8 +43,7 @@ $ heroku create name
 Run these commands to add the `shopify_app` Gem to your app:
 
 ```sh
-$ echo "gem 'shopify_app'" >> Gemfile
-$ bundle install
+$ bundle add shopify_app
 ```
 
 **Note:** we recommend using the latest version of Shopify Gem. Check the [Git tags](https://github.com/Shopify/shopify_app/tags) to see the latest release version and then add it to your Gemfile e.g `gem 'shopify_app', '~> 7.0.0'`


### PR DESCRIPTION
We can now use `bundle add` instead of manually `echo`ing the gem name to `Gemfile`