### PR TITLE
Packaging for release v13.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+13.4.0
+------
+* Skip CSRF protection if a valid signed JWT token is present as we trust Shopify to be the only source that can sign it securely. [#994](https://github.com/Shopify/shopify_app/pull/994)
+
 13.3.0
 ------
 * Added Payload Verification module [#992](https://github.com/Shopify/shopify_app/pull/992)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '13.3.0'
+  VERSION = '13.4.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
13.4.0
------
* Skip CSRF protection if a valid signed JWT token is present as we trust Shopify to be the only source that can sign it securely.
