### PR TITLE
Pass along the associated_user_scope

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -65,9 +65,9 @@ module ShopifyApp
     end
 
     def associated_user
-      return unless auth_hash['extra'].present?
+      return unless auth_hash.dig('extra', 'associated_user').present?
 
-      auth_hash['extra']['associated_user']
+      auth_hash['extra']['associated_user'].merge('scope' => auth_hash['extra']['associated_user_scope'])
     end
 
     def associated_user_id

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -12,6 +12,8 @@ module ShopifyApp
   class CallbackControllerTest < ActionController::TestCase
     TEST_SHOPIFY_DOMAIN = "shop.myshopify.com"
     TEST_ASSOCIATED_USER = { 'id' => 'test-shopify-user' }
+    ASSOCIATED_USER_SCOPE = "read_products"
+    TEST_ASSOCIATED_USER_WITH_SCOPE = TEST_ASSOCIATED_USER.merge('scope' => ASSOCIATED_USER_SCOPE)
     TEST_SESSION = "this.is.a.user.session"
 
     setup do
@@ -133,7 +135,7 @@ module ShopifyApp
       get :callback, params: { shop: 'shop' }
       assert_equal '4321', session[:user_id]
       assert_equal TEST_SHOPIFY_DOMAIN, session[:shopify_domain]
-      assert_equal TEST_ASSOCIATED_USER, session[:shopify_user]
+      assert_equal TEST_ASSOCIATED_USER_WITH_SCOPE, session[:shopify_user]
       assert_equal TEST_SESSION, session[:user_session]
     end
 
@@ -164,7 +166,7 @@ module ShopifyApp
       mock_shopify_jwt
       session = mock_user_session
 
-      ShopifyApp::SessionRepository.expects(:store_user_session).with(session, TEST_ASSOCIATED_USER)
+      ShopifyApp::SessionRepository.expects(:store_user_session).with(session, TEST_ASSOCIATED_USER_WITH_SCOPE)
 
       get :callback
       assert_response :ok
@@ -353,7 +355,7 @@ module ShopifyApp
         credentials: { token: '1234' },
         extra: {
           associated_user: TEST_ASSOCIATED_USER,
-          associated_user_scope: "read_products",
+          associated_user_scope: ASSOCIATED_USER_SCOPE,
           scope: "read_products",
           session: TEST_SESSION,
         }


### PR DESCRIPTION
I'd like my app to know whether the user token has all the scopes I need, or a subset.

This change will allow me to intercept the `User.store(session, auth_user)` call and do things (in my case I'll store the scope in the DB, and have the UX tell them which scopes they are missing by comparing to `ShopifyApp.configuration.scope`).

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.