### PR TITLE
Add access_token_headers concern

### DIFF
--- a/app/controllers/concerns/shopify_app/access_token_headers.rb
+++ b/app/controllers/concerns/shopify_app/access_token_headers.rb
@@ -4,22 +4,10 @@ module ShopifyApp
   module AccessTokenHeaders
     extend ActiveSupport::Concern
 
-    included do
-      after_action(:set_access_token_headers)
-    end
-
-    ACCESS_TOKEN_REQUIRED_HEADER = 'X-Shopify-Request-Auth-Code'
+    ACCESS_TOKEN_REQUIRED_HEADER = 'X-Shopify-API-Request-Failure-Unauthorized'
 
     def signal_access_token_required
       response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, true)
-    end
-
-    private
-
-    def set_access_token_headers
-      if response.get_header(ACCESS_TOKEN_REQUIRED_HEADER).nil?
-        response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, false)
-      end
     end
   end
 end

--- a/app/controllers/concerns/shopify_app/access_token_headers.rb
+++ b/app/controllers/concerns/shopify_app/access_token_headers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module AccessTokenHeaders
+    extend ActiveSupport::Concern
+
+    included do
+      after_action(:set_access_token_headers)
+    end
+
+    ACCESS_TOKEN_REQUIRED_HEADER = 'X-Shopify-Request-Auth-Code'
+
+    def signal_access_token_required
+      response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, true)
+    end
+
+    private
+
+    def set_access_token_headers
+      if response.get_header(ACCESS_TOKEN_REQUIRED_HEADER).nil?
+        response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, false)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/shopify_app/authenticated.rb
+++ b/app/controllers/concerns/shopify_app/authenticated.rb
@@ -9,6 +9,7 @@ module ShopifyApp
       include ShopifyApp::LoginProtection
       include ShopifyApp::CsrfProtection
       include ShopifyApp::EmbeddedApp
+      include ShopifyApp::AccessTokenHeaders
       before_action :login_again_if_different_user_or_shop
       around_action :activate_shopify_session
     end

--- a/test/controllers/concerns/access_token_headers_test.rb
+++ b/test/controllers/concerns/access_token_headers_test.rb
@@ -4,12 +4,8 @@ class AccessTokenHeadersTest < ActionController::TestCase
   class TestController < ActionController::Base
     include ShopifyApp::AccessTokenHeaders
 
-    def without_header
-      response.set_header('Mock-Header', 'mock')
-      render(html: '<h1>Success</h1>')
-    end
-
     def with_header
+      response.set_header('Mock-Header', 'mock')
       signal_access_token_required
       render(html: '<h1>Success</h1>')
     end
@@ -20,7 +16,6 @@ class AccessTokenHeadersTest < ActionController::TestCase
   setup do
     Rails.application.routes.draw do
       get '/with-header', to: 'access_token_headers_test/test#with_header'
-      get '/without-header', to: 'access_token_headers_test/test#without_header'
     end
   end
 
@@ -28,22 +23,16 @@ class AccessTokenHeadersTest < ActionController::TestCase
     Rails.application.reload_routes!
   end
 
-  test 'sets response X-Shopify-Request-Auth-Code header to false when not set' do
-    get :without_header
-
-    assert_equal false, response.get_header('X-Shopify-Request-Auth-Code')
-  end
-
-  test 'does not change X-Shopify-Request-Auth-Code header if previously set' do
+  test 'sets the X-Shopify-API-Request-Failure-Unauthorized header to true when signalled' do
     get :with_header
 
-    assert_equal true, response.get_header('X-Shopify-Request-Auth-Code')
+    assert_equal true, response.get_header('X-Shopify-API-Request-Failure-Unauthorized')
   end
 
-  test 'does not overwrite previously set headers when setting X-Shopify-Request-Auth-Code header' do
-    get :without_header
+  test 'does not overwrite previously set headers when setting X-Shopify-API-Request-Failure-Unauthorized header' do
+    get :with_header
 
     assert_equal 'mock', response.get_header('Mock-Header')
-    assert_equal false, response.get_header('X-Shopify-Request-Auth-Code')
+    assert_equal true, response.get_header('X-Shopify-API-Request-Failure-Unauthorized')
   end
 end

--- a/test/controllers/concerns/access_token_headers_test.rb
+++ b/test/controllers/concerns/access_token_headers_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class AccessTokenHeadersTest < ActionController::TestCase
+  class TestController < ActionController::Base
+    include ShopifyApp::AccessTokenHeaders
+
+    def without_header
+      response.set_header('Mock-Header', 'mock')
+      render(html: '<h1>Success</h1>')
+    end
+
+    def with_header
+      signal_access_token_required
+      render(html: '<h1>Success</h1>')
+    end
+  end
+
+  tests TestController
+
+  setup do
+    Rails.application.routes.draw do
+      get '/with-header', to: 'access_token_headers_test/test#with_header'
+      get '/without-header', to: 'access_token_headers_test/test#without_header'
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+
+  test 'sets response X-Shopify-Request-Auth-Code header to false when not set' do
+    get :without_header
+
+    assert_equal false, response.get_header('X-Shopify-Request-Auth-Code')
+  end
+
+  test 'does not change X-Shopify-Request-Auth-Code header if previously set' do
+    get :with_header
+
+    assert_equal true, response.get_header('X-Shopify-Request-Auth-Code')
+  end
+
+  test 'does not overwrite previously set headers when setting X-Shopify-Request-Auth-Code header' do
+    get :without_header
+
+    assert_equal 'mock', response.get_header('Mock-Header')
+    assert_equal false, response.get_header('X-Shopify-Request-Auth-Code')
+  end
+end

--- a/test/controllers/concerns/authenticated_test.rb
+++ b/test/controllers/concerns/authenticated_test.rb
@@ -15,5 +15,6 @@ class AuthenticatedTest < ActionController::TestCase
     AuthenticatedTestController.include?(ShopifyApp::LoginProtection)
     AuthenticatedTestController.include?(ShopifyApp::CsrfProtection)
     AuthenticatedTestController.include?(ShopifyApp::EmbeddedApp)
+    AuthenticatedTestController.include?(ShopifyApp::AccessTokenHeaders)
   end
 end


### PR DESCRIPTION
## What this PR does

This PR introduces a new concern for the Authenticated shopify_app controller. ~~The `access_token_headers.rb` concern sets a custom `X-Shopify-Request-Auth-Code` response header after the controller action.~~ This is part of the Next Gen token-based auth strategy.

This response header is intended to be used as a signal by app clients to fetch an authorization code to exchange with Shopify for an access token. If this header is set to `true`, the app client uses App Bridge to initiate this exchange flow.

~~The standard default behaviour we expect is that every response has the custom `X-Shopify-Request-Auth-Code` response header set to `false`.~~ This concern provides a helper method to set it to `true` when app developers need to refresh their user access tokens (e.g when calls to Shopify API return as 401 Unauthorized).

See the following PRs that reference this behaviour and changes:

- https://github.com/Shopify/app-bridge/pull/1603
- https://github.com/Shopify/next-gen-auth-app-demo/pull/10/files#diff-e54f3c67ff47c764363e39152508a4ddL15-L16
    - An example app that would rely on this concern to communicate the need for a user access token refresh

---
Before submitting the PR, please consider if any of the following are needed:

- [ ] Rebase/squash fixup commits
- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
