### PR TITLE
Fix dependency on shopify_api to allow all of 9.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Upcoming changes
+------
+* Fix the version checks for the dependency on `shopify_api` to allow all of v9.X
+
 13.4.0
 ------
 * Skip CSRF protection if a valid signed JWT token is present as we trust Shopify to be the only source that can sign it securely. [#994](https://github.com/Shopify/shopify_app/pull/994)

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.2.2')
   s.add_runtime_dependency('rails', '> 5.2.1')
-  s.add_runtime_dependency('shopify_api', '~> 9.1.0')
+  s.add_runtime_dependency('shopify_api', '~> 9.1')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.2')
   s.add_runtime_dependency('jwt', '~> 2.2.1')
   s.add_runtime_dependency('redirect_safely', '~> 1.0')


### PR DESCRIPTION
Before submitting the PR, please consider if any of the following are needed:

- [X] Update `CHANGELOG.md` if the changes would impact users