### PR TITLE
Fix ShopifyDomainNotFound when JWT is enabled

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -204,6 +204,8 @@ module ShopifyApp
     def return_address
       return base_return_address unless ShopifyApp.configuration.allow_jwt_authentication
       return_address_with_params(shop: current_shopify_domain)
+    rescue ShopifyDomainNotFound
+      base_return_address
     end
 
     def base_return_address

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -178,6 +178,14 @@ module ShopifyApp
       end
     end
 
+    test '#create should return an error for a non-myshopify URL when using JWT authentication' do
+      ShopifyApp.configuration.allow_jwt_authentication = true
+      post :create, params: { shop: 'invalid domain' }
+      assert_response :redirect
+      assert_redirected_to '/'
+      assert_equal I18n.t('invalid_shop_url'), flash[:error]
+    end
+
     test "#create should render the login page if the shop param doesn't exist" do
       post :create
       assert_redirected_to '/'


### PR DESCRIPTION
### Problem
When an invalid shop domain is submitted to `SessionsController#create`, it is supposed to display an error like this:
<img width="615" alt="Shopify App — Installation 2020-07-16 14-24-33" src="https://user-images.githubusercontent.com/18235607/87973077-fb1ad900-ca95-11ea-81dc-d8127d5abe1d.png">

When `allow_jwt_authentication` is enabled, an error is raised instead:
<img width="1482" alt="Action Controller: Exception caught 2020-07-20 14-34-25" src="https://user-images.githubusercontent.com/18235607/87973193-23a2d300-ca96-11ea-986e-f5619b937ae0.png">

This bug is easily reproducible by setting up shopify_app with `allow_jwt_authentication` set to true, and then navigating to the login page and trying to install with an empty shop domain.

### Solution
This bug was introduced in #958 because when `allow_jwt_authentication` is enabled in the config, we now try to set the return address with the `current_shopify_domain` included as a parameter. `current_shopify_domain` will raise when there is no currently authenticated shop, so an error will be raised if this flow is triggered from the login page.

We should rescue from this error and fall back to the originally returned `base_return_address`.

### Template notes

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.

cc @KevenLYF 