### PR TITLE
Add signal_access_token_required helper method to LoginProtection con…

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -14,6 +14,8 @@ module ShopifyApp
       rescue_from ActiveResource::UnauthorizedAccess, with: :close_session
     end
 
+    ACCESS_TOKEN_REQUIRED_HEADER = 'X-Shopify-API-Request-Failure-Unauthorized'
+
     def activate_shopify_session
       return redirect_to_login if current_shopify_session.blank?
       clear_top_level_oauth_cookie
@@ -78,6 +80,10 @@ module ShopifyApp
         clear_shopify_session
         redirect_to_login
       end
+    end
+
+    def signal_access_token_required
+      response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, true)
     end
 
     protected

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -16,6 +16,12 @@ class LoginProtectionController < ActionController::Base
     render(plain: "OK")
   end
 
+  def index_with_headers
+    response.set_header('Mock-Header', 'Mock-Value')
+    signal_access_token_required
+    render(plain: "OK")
+  end
+
   def second_login
     render(plain: "OK")
   end
@@ -413,6 +419,20 @@ class LoginProtectionControllerTest < ActionController::TestCase
     end
   end
 
+  test 'signal_access_token_required sets X-Shopify-API-Request-Unauthorized header' do
+    with_application_test_routes do
+      get :index_with_headers
+      assert_equal true, response.get_header('X-Shopify-API-Request-Failure-Unauthorized')
+    end
+  end
+
+  test 'signal_access_token_required does not overwrite previously set headers' do
+    with_application_test_routes do
+      get :index_with_headers
+      assert_equal 'Mock-Value', response.get_header('Mock-Header')
+    end
+  end
+
   private
 
   def assert_fullpage_redirected(shop_domain, _response)
@@ -432,6 +452,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
         get '/second_login' => 'login_protection#second_login'
         get '/redirect' => 'login_protection#redirect'
         get '/raise_unauthorized' => 'login_protection#raise_unauthorized'
+        get '/index_with_headers' => 'login_protection#index_with_headers'
       end
       yield
     end


### PR DESCRIPTION
…cern

This builds on https://github.com/Shopify/shopify_app/pull/1025

This PR introduces a helper method in the `LoginProtection` concern that helps developers set an `X-Shopify-API-Request-Failure-Unauthorized` header.

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
