### PR TITLE
Packaging for release 13.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+13.6.0
+------
+* Generate an optional unauthenticated home_controller and authenticated products_controller using the `--with-session-token` flag to use JWT session tokens
+
 13.5.0
 ------
 * Add `signal_access_token_required` helper method for apps to indicate access token has expired and that a new one is required

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '13.5.0'
+  VERSION = '13.6.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "13.5.0",
+  "version": "13.6.0",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
> https://github.com/Shopify/shopify_app/issues/1039 for more context

This package release allows developers to generate an optional unauthenticated home_controller and a products_controller by specifying the `--with-session-token` flag. This creates an SPA that works with JWT session tokens.

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
