### PR TITLE
Packaging for release 14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-13.6.0
+14.0.0
 ------
-* Generate an optional unauthenticated home_controller and authenticated products_controller using the `--with-session-token` flag to use JWT session tokens
+* Ruby 2.4 is no longer supported by this gem
+* Bump gemspec ruby dependency to 2.5
+* (Beta) Add `--with-session-token` flag to the Shopify App generator to create an app that is compatible with App Bridge Authentication
 
 13.5.0
 ------

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '13.6.0'
+  VERSION = '14.0.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "13.6.0",
+  "version": "14.0.0",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
> Context: https://github.com/Shopify/shopify_app/pull/1040
> Context: https://github.com/Shopify/shopify_app/issues/1039

This is a packaging major release for shopify_app 14.0.0. It introduces:

* Bump gemspec ruby dependency to 2.5 (breaking change)
* Bump elliptic from 6.5.1 to 6.5.3
* (Beta) Add `--with-session-token` flag to the Shopify App generator to create an app that is compatible with App Bridge Authentication (originally supposed to be released in 13.6.0)

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
