### PR TITLE
Ensure post authenticate jobs run after for jwt based callback requests

### DIFF
--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -322,6 +322,48 @@ module ShopifyApp
       assert_redirected_to "/?shop=#{TEST_SHOPIFY_DOMAIN}"
     end
 
+    test "#callback performs install_webhook job after JWT authentication" do
+      mock_shopify_user_omniauth
+      mock_shopify_jwt
+
+      ShopifyApp.configure do |config|
+        config.webhooks = [{ topic: 'carts/update', address: 'example-app.com/webhooks' }]
+      end
+
+      ShopifyApp::WebhooksManager.expects(:queue)
+
+      get :callback
+      assert_response :ok
+    end
+
+    test "#callback performs install_scripttags job after JWT authentication" do
+      mock_shopify_user_omniauth
+      mock_shopify_jwt
+
+      ShopifyApp.configure do |config|
+        config.scripttags = [{ topic: 'carts/update', address: 'example-app.com/webhooks' }]
+      end
+
+      ShopifyApp::ScripttagsManager.expects(:queue)
+
+      get :callback
+      assert_response :ok
+    end
+
+    test "#callback performs after_authenticate job after JWT authentication" do
+      mock_shopify_user_omniauth
+      mock_shopify_jwt
+
+      ShopifyApp.configure do |config|
+        config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: true }
+      end
+
+      Shopify::AfterAuthenticateJob.expects(:perform_now)
+
+      get :callback
+      assert_response :ok
+    end
+
     private
 
     def mock_shopify_jwt


### PR DESCRIPTION
### What does this PR solve?
There is an issue noticed where the OAuth flow for getting an online (user) token fails to redirect back into the callback endpoint. The online token is eventually retrieved on failed requests to the Shopify API and we exchange an auth code for the online token via App Bridge Auth. However, when making the callback request to with session tokens (as JWTs) in the Authorization header, the post authenticate background jobs are not run, which is undesirable.

This PR ensures that the post authenticated background jobs are triggered after the callback request is made with session tokens in the request.

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
