### PR TITLE
Fix RuboCop failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
 Style/MethodCallWithArgsParentheses:
   Exclude:
     - '**/Gemfile'
+    - 'test/**/*'
 
 Style/ClassAndModuleChildren:
   Exclude:

--- a/lib/generators/shopify_app/controllers/controllers_generator.rb
+++ b/lib/generators/shopify_app/controllers/controllers_generator.rb
@@ -8,7 +8,7 @@ module ShopifyApp
 
       def create_controllers
         controllers.each do |controller|
-          copy_file controller
+          copy_file(controller)
         end
       end
 

--- a/lib/generators/shopify_app/views/views_generator.rb
+++ b/lib/generators/shopify_app/views/views_generator.rb
@@ -8,7 +8,7 @@ module ShopifyApp
 
       def create_views
         views.each do |view|
-          copy_file view
+          copy_file(view)
         end
       end
 


### PR DESCRIPTION
This repo isn't locked to a particular RuboCop version, but when running against the latest RuboCop there are some failures.