### PR TITLE
Disable logging args in ShopifyApp jobs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,3 +12,8 @@ Authentication Issues
 A great deal of the issues surrounding this repo are around authenticating (installing) the generated app with Shopify.
 
 If you are experiencing issues with your app authenticating/installing the best way to get help fast is to create a repo with the minimal amount of code to demonstrate the issue and a clearly documented set of steps you took to arrive there. This will help us solve your problem quicker since we won't need to spend any time figuring out how to reproduce the bug. Please also include your operating system and browser.
+
+Security
+--------
+
+Please be certain to redact any private information from your logs or code snippets such as Api Keys, Api Secrets, and any authentication tokens such as shop_tokens.

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -34,7 +34,7 @@ module ShopifyApp
 
     initializer "shopify_app.redact_job_params" do
       ActiveSupport.on_load(:active_job) do
-        if ActiveJob::Base.respond_to?(:log_arguments?, true)
+        if ActiveJob::Base.respond_to?(:log_arguments?)
           WebhooksManagerJob.log_arguments = false
           ScripttagsManagerJob.log_arguments = false
         elsif ActiveJob::Logging::LogSubscriber.private_method_defined?(:args_info)


### PR DESCRIPTION
Since shop tokens are passed into the parameters of the jobs and there has been a tendency for people to copy and paste these logs while debugging, it seems safest to redact the arguments from the jobs so that this will not happen accidentally in the future.

This will patch ActiveJob::Logging::LogSubscriber for rails < 6.1 and use `log_arguments = false` for rails >= 6.1