### PR TITLE
Switch boolean HTTP header value to string

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -100,7 +100,7 @@ module ShopifyApp
     end
 
     def signal_access_token_required
-      response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, true)
+      response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, "true")
     end
 
     protected

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -451,7 +451,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
   test 'signal_access_token_required sets X-Shopify-API-Request-Unauthorized header' do
     with_application_test_routes do
       get :index_with_headers
-      assert_equal true, response.get_header('X-Shopify-API-Request-Failure-Unauthorized')
+      assert_equal 'true', response.get_header('X-Shopify-API-Request-Failure-Unauthorized')
     end
   end
 


### PR DESCRIPTION
## What
Boolean header value for the custom HTTP header `X-Shopify-API-Request-Failure-Unauthorized` was giving the following error in `cardreader-giveaway` app.
<img width="770" alt="Screen Shot 2020-10-07 at 10 08 51 AM" src="https://user-images.githubusercontent.com/43098692/95358611-3cea3d00-0897-11eb-9091-125172213b00.png">
This was because the webrick handler in the rack gem iterates over the key/values of the HTTP headers in the response and calls `.split(...)` on the values. The value of the `X-Shopify-API-Request-Failure-Unauthorized` is a `TrueClass` instance, thus the above error.

This PR switches the boolean header value to a string. 

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
