### PR TITLE
Enforce presence of application key and secret during initialization

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -1,7 +1,7 @@
 ShopifyApp.configure do |config|
   config.application_name = "<%= @application_name %>"
-  config.api_key = ENV.fetch('SHOPIFY_API_KEY')
-  config.secret = ENV.fetch('SHOPIFY_API_SECRET')
+  config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')
+  config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')
   config.old_secret = "<%= @old_secret %>"
   config.scope = "<%= @scope %>" # Consult this page for more scope options:
                                  # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -1,7 +1,7 @@
 ShopifyApp.configure do |config|
   config.application_name = "<%= @application_name %>"
-  config.api_key = ENV['SHOPIFY_API_KEY']
-  config.secret = ENV['SHOPIFY_API_SECRET']
+  config.api_key = ENV.fetch('SHOPIFY_API_KEY')
+  config.secret = ENV.fetch('SHOPIFY_API_SECRET')
   config.old_secret = "<%= @old_secret %>"
   config.scope = "<%= @scope %>" # Consult this page for more scope options:
                                  # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -23,8 +23,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "My Shopify App"', shopify_app
-      assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
-      assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match 'config.api_version = "2019-10"', shopify_app
@@ -39,8 +39,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
                      --api_version unstable --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
-      assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
@@ -52,8 +52,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(--application_name Test Name --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV['SHOPIFY_API_KEY']", shopify_app
-      assert_match "config.secret = ENV['SHOPIFY_API_SECRET']", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match "config.shop_session_repository = 'Shop'", shopify_app

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -23,8 +23,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "My Shopify App"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match 'config.api_version = "2019-10"', shopify_app
@@ -39,8 +39,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
                      --api_version unstable --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
@@ -52,8 +52,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(--application_name Test Name --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match "config.shop_session_repository = 'Shop'", shopify_app

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -23,8 +23,10 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "My Shopify App"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence " \
+        "|| raise('Missing SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence " \
+        "|| raise('Missing SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match 'config.api_version = "2019-10"', shopify_app
@@ -39,8 +41,10 @@ class InstallGeneratorTest < Rails::Generators::TestCase
                      --api_version unstable --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence " \
+        "|| raise('Missing SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence " \
+        "|| raise('Missing SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
@@ -52,8 +56,10 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(--application_name Test Name --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence " \
+        "|| raise('Missing SHOPIFY_API_KEY')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence " \
+        "|| raise('Missing SHOPIFY_API_SECRET')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match "config.shop_session_repository = 'Shop'", shopify_app


### PR DESCRIPTION
Thoughts on making it explicit when the key is not set when it is expected for it to be present so it fail fast?
