### PR TITLE
Update ngrok template

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -64,7 +64,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           'config/environments/development.rb',
-          "  config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/\n",
+          "  config.hosts = (config.hosts rescue []) << /\\w+\\.ngrok\\.io/\n",
           after: "Rails.application.configure do\n"
         )
       end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -90,7 +90,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "adds host config to development.rb" do
     run_generator
     assert_file "config/environments/development.rb" do |config|
-      assert_match "config.hosts = (config.hosts rescue []) << /\\h+.ngrok.io/", config
+      assert_match "config.hosts = (config.hosts rescue []) << /\\w+\\.ngrok\\.io/", config
     end
   end
 end


### PR DESCRIPTION
Originally added here: https://github.com/Shopify/shopify_app/pull/802

It took me a long while to understand that \h in ruby is not the same as some other languages.....

> /\h/ - A hexdigit character ([0-9a-fA-F])
https://ruby-doc.org/core-2.7.1/Regexp.html

That being said, paid ngrok account and use more characters in their premium domains.

Also adding some `\.` to make sure we treat them as dots and not wildcards.