### PR TITLE
Update jwt#shopify_user_id to return an integer

### DIFF
--- a/lib/shopify_app/session/jwt.rb
+++ b/lib/shopify_app/session/jwt.rb
@@ -25,7 +25,7 @@ module ShopifyApp
     end
 
     def shopify_user_id
-      @payload && @payload['sub']
+      @payload['sub'].to_i if @payload && @payload['sub']
     end
 
     private

--- a/test/shopify_app/session/jwt_test.rb
+++ b/test/shopify_app/session/jwt_test.rb
@@ -5,7 +5,7 @@ module ShopifyApp
   class JWTTest < ActiveSupport::TestCase
     TEST_SHOPIFY_DOMAIN = 'https://test.myshopify.io'
     TEST_SANITIZED_SHOPIFY_DOMAIN = 'test.myshopify.io'
-    TEST_USER_ID = 'test-user'
+    TEST_USER_ID = '121'
 
     setup do
       ShopifyApp.configuration.api_key = 'api_key'
@@ -19,7 +19,7 @@ module ShopifyApp
       jwt = JWT.new(token(p))
 
       assert_equal TEST_SANITIZED_SHOPIFY_DOMAIN, jwt.shopify_domain
-      assert_equal TEST_USER_ID, jwt.shopify_user_id
+      assert_equal TEST_USER_ID.to_i, jwt.shopify_user_id
     end
 
     test "#shopify_domain and #shopify_user_id are returned using the old secret" do
@@ -28,7 +28,15 @@ module ShopifyApp
       jwt = JWT.new(t)
 
       assert_equal TEST_SANITIZED_SHOPIFY_DOMAIN, jwt.shopify_domain
-      assert_equal TEST_USER_ID, jwt.shopify_user_id
+      assert_equal TEST_USER_ID.to_i, jwt.shopify_user_id
+    end
+
+    test "#shopify_user_id returns nil if sub is nil on token payload" do
+      p = payload
+      p['sub'] = nil
+      jwt = JWT.new(token(p))
+
+      assert_nil jwt.shopify_user_id
     end
 
     test "shopify_domain and shopify_user_id are nil if the jwt is invalid" do


### PR DESCRIPTION
It seems that we've introduced a slight bug for developers who are developing with the shopify_app gem.

Now that core returns the sub field of a jwt as a string, the following validation fails for any app that is developing with online access tokens using shopify_app: https://github.com/Shopify/shopify_app/blob/2401342e466c35f1617ebc541a0093a3ade351aa/app/controllers/shopify_app/callback_controller.rb#L87

In this scenario, the associated_user_id parsed by omniauth remains an Integer, but the jwt_shopify_user_id parsed by our middleware is now a String. There is a type mismatch. The easiest solution for this is to cast the sub field as an integer in our middleware to ensure that everything still works with omniauth as intended (I think this is fine because it's the developer's prerogative to decide what to do with the sub field).

This issue was flagged by Sneha here: https://shopify.slack.com/archives/CG71G24BZ/p1604674034310200

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
