### PR TITLE
Test to see if assets are in the configuration

### DIFF
--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -15,13 +15,15 @@ module ShopifyApp
     isolate_namespace ShopifyApp
 
     initializer "shopify_app.assets.precompile" do |app|
-      app.config.assets.precompile += %w[
-        shopify_app/redirect.js
-        shopify_app/top_level.js
-        shopify_app/enable_cookies.js
-        shopify_app/request_storage_access.js
-        storage_access.svg
-      ]
+      if app.config.respond_to?(:assets)
+        app.config.assets.precompile += %w[
+          shopify_app/redirect.js
+          shopify_app/top_level.js
+          shopify_app/enable_cookies.js
+          shopify_app/request_storage_access.js
+          storage_access.svg
+        ]
+      end
     end
 
     initializer "shopify_app.middleware" do |app|


### PR DESCRIPTION
For installations using webpacker, it's possible to avoid loading sprockets altogether by forgoing the `require 'rails/all'` command and including only the Rails frameworks one needs, e.g.,
```
require 'rails'
# Pick the frameworks you want:
require 'active_model/railtie'
require 'active_job/railtie'
require 'active_record/railtie'
# require 'active_storage/engine'
require 'action_controller/railtie'
# require 'action_mailer/railtie'
# require 'action_mailbox/engine'
# require 'action_text/engine'
require 'action_view/railtie'
# require 'action_cable/engine'
# require 'sprockets/railtie'
# require 'rails/test_unit/railtie'
```
Currently, shopify_app fails on initialize if sprockets is not included.
```
home/jeff/.rvm/gems/ruby-2.6.5/gems/railties-6.0.3.4/lib/rails/railtie/configuration.rb:96:in `method_missing': undefined method `assets' for #<Rails::Application::Configuration:0x000055ababee1fe0> (NoMethodError)     
```

This fix essentially tests for the presence of sprockets before proceeding to add the assets to the precompile list.
Fixes #1105 .