### PR TITLE
Fix rubocop error

### DIFF
--- a/lib/shopify_app/session/jwt.rb
+++ b/lib/shopify_app/session/jwt.rb
@@ -2,7 +2,9 @@
 module ShopifyApp
   class JWT
     class InvalidDestinationError < StandardError; end
+
     class MismatchedHostsError < StandardError; end
+
     class InvalidAudienceError < StandardError; end
 
     WARN_EXCEPTIONS = [


### PR DESCRIPTION
New Github Actions for the CI introduces an updated version of Rubocop. Originally the Rubocop check used (I think) 0.93.1, but now we're using 1.5.2. 