### PR TITLE
Don't run app config for generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Don't attempt to read Shopify environment variables when the generators are running, since they may not be present yet [#1144](https://github.com/Shopify/shopify_app/pull/1144)
+
 17.0.0 (January 13, 2021)
 ------
 * Rails 6.1 is not yet supported [#1134](https://github.com/Shopify/shopify_app/pull/1134)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ SHOPIFY_API_SECRET=your api secret
 ```
 
 These values can be found on the "App Setup" page in the [Shopify Partners Dashboard][dashboard].
-(If you are using [shopify-app-cli](https://github.com/Shopify/) this `.env` file will be created automatically).
+(If you are using [shopify-app-cli](https://github.com/Shopify/shopify-app-cli) this `.env` file will be created automatically).
 If you are checking your code into a code repository, ensure your `.gitignore` prevents your `.env` file from being checked into any publicly accessible code.
 
 ### Default Generator

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Generators
 ----------
 
 ### API Keys
-
+<!-- This anchor name is linked to from  `templates/shopify_app.rb.tt` so beware of changing -->
 Before running the generators, you'll need to ensure your app can read the Shopify environment variables `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`.
 
 A common approach is to use the [dotenv-rails](https://github.com/bkeepers/dotenv) gem, along with an `.env` file in the following format:

--- a/README.md
+++ b/README.md
@@ -76,16 +76,18 @@ Generators
 
 ### API Keys
 <!-- This anchor name `#api-keys` is linked to from user output in `templates/shopify_app.rb.tt` so beware of changing -->
-Before running the generators, you'll need to ensure your app can read the Shopify environment variables `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`.
+Before starting the app, you'll need to ensure it can read the Shopify environment variables `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`.
 
-A common approach is to use the [dotenv-rails](https://github.com/bkeepers/dotenv) gem, along with an `.env` file in the following format:
+In a development environment, a common approach is to use the [dotenv-rails](https://github.com/bkeepers/dotenv) gem, along with an `.env` file in the following format:
 
 ```
 SHOPIFY_API_KEY=your api key
 SHOPIFY_API_SECRET=your api secret
 ```
 
-These values can be found on the "App Setup" page in the [Shopify Partners Dashboard][dashboard]. If you are checking your code into a code repository, ensure your `.gitignore` prevents your `.env` file from being checked into any publicly accessible code.
+These values can be found on the "App Setup" page in the [Shopify Partners Dashboard][dashboard].
+(If you are using [shopify-app-cli](https://github.com/Shopify/) this `.env` file will be created automatically).
+If you are checking your code into a code repository, ensure your `.gitignore` prevents your `.env` file from being checked into any publicly accessible code.
 
 ### Default Generator
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Generators
 ----------
 
 ### API Keys
-<!-- This anchor name is linked to from  `templates/shopify_app.rb.tt` so beware of changing -->
+<!-- This anchor name `#api-keys` is linked to from user output in `templates/shopify_app.rb.tt` so beware of changing -->
 Before running the generators, you'll need to ensure your app can read the Shopify environment variables `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`.
 
 A common approach is to use the [dotenv-rails](https://github.com/bkeepers/dotenv) gem, along with an `.env` file in the following format:

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -1,16 +1,18 @@
-ShopifyApp.configure do |config|
-  config.application_name = "<%= @application_name %>"
-  config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')
-  config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')
-  config.old_secret = "<%= @old_secret %>"
-  config.scope = "<%= @scope %>" # Consult this page for more scope options:
-                                 # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
-  config.embedded_app = <%= embedded_app? %>
-  config.after_authenticate_job = false
-  config.api_version = "<%= @api_version %>"
-  config.shop_session_repository = 'Shop'
-  config.allow_jwt_authentication = <%= !with_cookie_authentication? %>
-  config.allow_cookie_authentication = <%= with_cookie_authentication? %>
+unless defined? Rails::Generators
+  ShopifyApp.configure do |config|
+    config.application_name = "<%= @application_name %>"
+    config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')
+    config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')
+    config.old_secret = "<%= @old_secret %>"
+    config.scope = "<%= @scope %>" # Consult this page for more scope options:
+                                   # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
+    config.embedded_app = <%= embedded_app? %>
+    config.after_authenticate_job = false
+    config.api_version = "<%= @api_version %>"
+    config.shop_session_repository = 'Shop'
+    config.allow_jwt_authentication = <%= !with_cookie_authentication? %>
+    config.allow_cookie_authentication = <%= with_cookie_authentication? %>
+  end
 end
 
 # ShopifyApp::Utils.fetch_known_api_versions                        # Uncomment to fetch known api versions from shopify servers on boot

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -1,8 +1,8 @@
 unless defined? Rails::Generators
   ShopifyApp.configure do |config|
     config.application_name = "<%= @application_name %>"
-    config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY')
-    config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET')
+    config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#api-keys')
+    config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#api-keys')
     config.old_secret = "<%= @old_secret %>"
     config.scope = "<%= @scope %>" # Consult this page for more scope options:
                                    # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -23,10 +23,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "My Shopify App"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence " \
-        "|| raise('Missing SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence " \
-        "|| raise('Missing SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '')", shopify_app
       assert_match 'config.scope = "read_products"', shopify_app
       assert_match "config.embedded_app = true", shopify_app
       assert_match 'config.api_version = "2019-10"', shopify_app
@@ -41,10 +39,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
                      --api_version unstable --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence " \
-        "|| raise('Missing SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence " \
-        "|| raise('Missing SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match 'config.api_version = "unstable"', shopify_app
@@ -56,10 +52,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(--application_name Test Name --scope read_orders write_products)
     assert_file "config/initializers/shopify_app.rb" do |shopify_app|
       assert_match 'config.application_name = "Test Name"', shopify_app
-      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence " \
-        "|| raise('Missing SHOPIFY_API_KEY')", shopify_app
-      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence " \
-        "|| raise('Missing SHOPIFY_API_SECRET')", shopify_app
+      assert_match "config.api_key = ENV.fetch('SHOPIFY_API_KEY', '')", shopify_app
+      assert_match "config.secret = ENV.fetch('SHOPIFY_API_SECRET', '')", shopify_app
       assert_match 'config.scope = "read_orders write_products"', shopify_app
       assert_match 'config.embedded_app = true', shopify_app
       assert_match "config.shop_session_repository = 'Shop'", shopify_app


### PR DESCRIPTION
In https://github.com/Shopify/shopify_app/pull/1097 a change was required that the Shopify environment variables were present. As this code is in an initializer, it also runs when the generators run, but at that point in time the environment variables may not yet be available (e.g. because dotenv-rails hasn't been added yet).

Based on a suggestion in https://stackoverflow.com/a/32789186, we can check if the initializer is running from a generator or not.

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
