### PR TITLE
Use actions instead of hub cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,11 @@ jobs:
       run: echo "::set-output name=value::${GITHUB_REF##*/}"
     - uses: actions/checkout@v2
 
-    - name: Create Release # https://hub.github.com/hub-release.1.html
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create ${{ steps.tag.outputs.value }}
+      with:
+        tag_name: ${{ steps.tag.outputs.value }}
+        release_name: ${{ steps.tag.outputs.value }}


### PR DESCRIPTION
Before submitting the PR, please consider if any of the following are needed:
Follow up https://github.com/Shopify/shopify_app/pull/1138 to use the `actions/create-release@v1` instead of the hub cli. 
Forgot this is testable on a fork! https://github.com/mllemango/shopify_app/releases/tag/v17.0.3

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `docs/`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
