### PR TITLE
Ensure offline and online tokens are fetched via available auth hash

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -89,6 +89,14 @@ module ShopifyApp
       auth_hash.uid
     end
 
+    def offline_access_token
+      ShopifyApp::SessionRepository.retrieve_shop_session_by_shopify_domain(shop_name)&.token
+    end
+
+    def online_access_token
+      ShopifyApp::SessionRepository.retrieve_user_session_by_shopify_user_id(associated_user_id)&.token
+    end
+
     def associated_user
       return unless auth_hash.dig('extra', 'associated_user').present?
 
@@ -132,7 +140,7 @@ module ShopifyApp
 
       WebhooksManager.queue(
         shop_name,
-        shop_session&.token || user_session.token,
+        offline_access_token || online_access_token,
         ShopifyApp.configuration.webhooks
       )
     end
@@ -142,7 +150,7 @@ module ShopifyApp
 
       ScripttagsManager.queue(
         shop_name,
-        shop_session&.token || user_session.token,
+        offline_access_token || online_access_token,
         ShopifyApp.configuration.scripttags
       )
     end

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -199,7 +199,9 @@ module ShopifyApp
 
     test '#install_webhooks uses the shop token for shop strategy' do
       shop_session = ShopifyAPI::Session.new(domain: 'shop', token: '1234', api_version: '2019-1')
-      ShopifyApp::SessionRepository.expects(:retrieve_shop_session).returns(shop_session)
+      ShopifyApp::SessionRepository
+        .expects(:retrieve_shop_session_by_shopify_domain)
+        .returns(shop_session)
       ShopifyApp.configure do |config|
         config.webhooks = [{ topic: 'carts/update', address: 'example-app.com/webhooks' }]
       end
@@ -212,7 +214,9 @@ module ShopifyApp
 
     test '#install_webhooks still uses the shop token for user strategy' do
       shop_session = ShopifyAPI::Session.new(domain: 'shop', token: '4321', api_version: '2019-1')
-      ShopifyApp::SessionRepository.stubs(:retrieve_shop_session).with('135').returns(shop_session)
+      ShopifyApp::SessionRepository.stubs(:retrieve_shop_session_by_shopify_domain)
+        .with(TEST_SHOPIFY_DOMAIN)
+        .returns(shop_session)
 
       ShopifyApp.configure do |config|
         config.webhooks = [{ topic: 'carts/update', address: 'example-app.com/webhooks' }]
@@ -227,7 +231,8 @@ module ShopifyApp
 
     test '#install_webhooks falls back to user token for user strategy if shop is not in session' do
       user_session = ShopifyAPI::Session.new(domain: 'shop', token: '4321', api_version: '2019-1')
-      ShopifyApp::SessionRepository.expects(:retrieve_user_session).returns(user_session).times(2)
+      ShopifyApp::SessionRepository.expects(:retrieve_shop_session_by_shopify_domain).returns(nil)
+      ShopifyApp::SessionRepository.expects(:retrieve_user_session_by_shopify_user_id).returns(user_session)
       ShopifyApp.configure do |config|
         config.webhooks = [{ topic: 'carts/update', address: 'example-app.com/webhooks' }]
       end


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify_app/issues/1128

We have noticed that the callback controller was fetching a token based on the session object for post perform jobs. This is not necessary as the offline and/or online tokens can be retrieved via the auth hash.

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
