### PR TITLE
Only skip environment variables from initializer for generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Amend fix for #1144 to raise on missing API keys only when running the server [#1155](https://github.com/Shopify/shopify_app/pull/1155)
 
 17.0.2 (January 20, 2021)
 ------

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -1,17 +1,20 @@
-unless defined? Rails::Generators
-  ShopifyApp.configure do |config|
-    config.application_name = "<%= @application_name %>"
-    config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence || raise('Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#api-keys')
-    config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence || raise('Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#api-keys')
-    config.old_secret = "<%= @old_secret %>"
-    config.scope = "<%= @scope %>" # Consult this page for more scope options:
-                                   # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
-    config.embedded_app = <%= embedded_app? %>
-    config.after_authenticate_job = false
-    config.api_version = "<%= @api_version %>"
-    config.shop_session_repository = 'Shop'
-    config.allow_jwt_authentication = <%= !with_cookie_authentication? %>
-    config.allow_cookie_authentication = <%= with_cookie_authentication? %>
+ShopifyApp.configure do |config|
+  config.application_name = "<%= @application_name %>"
+  config.old_secret = "<%= @old_secret %>"
+  config.scope = "<%= @scope %>" # Consult this page for more scope options:
+                                  # https://help.shopify.com/en/api/getting-started/authentication/oauth/scopes
+  config.embedded_app = <%= embedded_app? %>
+  config.after_authenticate_job = false
+  config.api_version = "<%= @api_version %>"
+  config.shop_session_repository = 'Shop'
+  config.allow_jwt_authentication = <%= !with_cookie_authentication? %>
+  config.allow_cookie_authentication = <%= with_cookie_authentication? %>
+
+  config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence
+  config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence
+  if defined? Rails::Server
+    raise('Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#api-keys') unless config.api_key
+    raise('Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#api-keys') unless config.secret
   end
 end
 


### PR DESCRIPTION
Once we started skipping the initializer for generators (#1144), we ended up in a situation where the default config generated by the template and the default values in `ShopifyApp` configuration had opposing values, therefore causing new apps to generate an authenticated `home_controller.rb` file rather than its unauthenticated counterpart because cookie auth is still the default.

This PR addresses that by only skipping the values that depend on environment variables when running generators so that the actual config of the app still applies on generator runs and creates consistent apps.

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [X] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
