### PR TITLE
Create a turbolinks asset file to generate during install

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -47,6 +47,7 @@ module ShopifyApp
           copy_file('shopify_app.js', 'app/javascript/shopify_app/shopify_app.js')
           copy_file('flash_messages.js', 'app/javascript/shopify_app/flash_messages.js')
           copy_file('shopify_app_index.js', 'app/javascript/shopify_app/index.js')
+          copy_file('shopify_app_turbolinks.js', 'app/javascript/shopify_app/shopify_app_turbolinks.js')
           append_to_file('app/javascript/packs/application.js', "require(\"shopify_app\")\n")
         else
           copy_file('shopify_app.js', 'app/assets/javascripts/shopify_app.js')

--- a/lib/generators/shopify_app/install/templates/shopify_app_turbolinks.js
+++ b/lib/generators/shopify_app/install/templates/shopify_app_turbolinks.js
@@ -1,0 +1,1 @@
+// TODO: Determine what the final shape of this file is

--- a/lib/generators/shopify_app/install/templates/shopify_app_turbolinks.js
+++ b/lib/generators/shopify_app/install/templates/shopify_app_turbolinks.js
@@ -1,1 +1,65 @@
-// TODO: Determine what the final shape of this file is
+/*
+ * If your app is a server-side rendered app that uses Turbolinks with session tokens,
+ * require this file at the end of `app/javascript/shopify_app/index.js`:
+ *
+ * >> require('./shopify_app_turbolinks');
+ */
+
+import { getSessionToken } from "@shopify/app-bridge-utils";
+
+const SESSION_TOKEN_REFRESH_INTERVAL = 2000; // Request a new token every 2s
+
+document.addEventListener("turbolinks:request-start", function (event) {
+  var xhr = event.data.xhr;
+  xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+});
+
+document.addEventListener("turbolinks:render", function () {
+  $("form, a[data-method=delete]").on("ajax:beforeSend", function (event) {
+    const xhr = event.detail[0];
+    xhr.setRequestHeader("Authorization", "Bearer " + window.sessionToken);
+  });
+});
+
+document.addEventListener("DOMContentLoaded", async function () {
+  // Wait for a session token before trying to load an authenticated page
+  await retrieveToken(app);
+
+  // Keep retrieving a session token periodically
+  keepRetrievingToken(app);
+
+  // Redirect to the requested page when DOM loads
+  var isInitialRedirect = true;
+  redirectThroughTurbolinks(isInitialRedirect);
+
+  document.addEventListener("turbolinks:load", function (event) {
+    redirectThroughTurbolinks();
+  });
+
+  // Helper functions
+  function redirectThroughTurbolinks(isInitialRedirect = false) {
+    var data = document.getElementById("shopify-app-init").dataset;
+    var validLoadPath = data && data.loadPath;
+    var shouldRedirect = false;
+
+    switch(isInitialRedirect) {
+      case true:
+        shouldRedirect = validLoadPath;
+        break;
+      case false:
+        shouldRedirect = validLoadPath && data.loadPath !== '/home'; // Replace with the app's home_path
+        break;
+    }
+    if (shouldRedirect) Turbolinks.visit(data.loadPath);
+  }
+
+  async function retrieveToken(app) {
+    window.sessionToken = await getSessionToken(app);
+  }
+
+  function keepRetrievingToken(app) {
+    setInterval(() => {
+      retrieveToken(app);
+    }, SESSION_TOKEN_REFRESH_INTERVAL);
+  }
+});

--- a/test/app_templates/app/javascript/packs/application.js
+++ b/test/app_templates/app/javascript/packs/application.js
@@ -1,0 +1,1 @@
+// Test template for application.js

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -119,4 +119,23 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match 'config.allow_cookie_authentication = true', shopify_app
     end
   end
+
+  test "generates javascript assets required when embedded" do
+    ShopifyApp.stubs(:use_webpacker?).returns(false)
+
+    run_generator %w(--embedded)
+    assert_file "app/assets/javascripts/shopify_app.js"
+    assert_file "app/assets/javascripts/flash_messages.js"
+  end
+
+  test "generates javascript assets required for Webpacker if Webpacker is configured when embedded" do
+    ShopifyApp.stubs(:use_webpacker?).returns(true)
+    provide_application_js_file
+
+    run_generator %w(--embedded)
+    assert_file "app/javascript/shopify_app/shopify_app_turbolinks.js"
+    assert_file "app/javascript/shopify_app/shopify_app.js"
+    assert_file "app/javascript/shopify_app/flash_messages.js"
+    assert_file "app/javascript/shopify_app/index.js"
+  end
 end

--- a/test/support/generator_test_helpers.rb
+++ b/test/support/generator_test_helpers.rb
@@ -30,6 +30,10 @@ module GeneratorTestHelpers
     copy_to_generator_root("config/environments", "development.rb")
   end
 
+  def provide_application_js_file
+    copy_to_generator_root("app/javascript/packs", "application.js")
+  end
+
   private
 
   def copy_to_generator_root(destination, template, rename: nil)


### PR DESCRIPTION
### Context

> Builds on https://github.com/Shopify/turbolinks-jwt-sample-app/pull/21

This PR is an attempt to consolidate and version our suggested Turbolinks solution with session tokens. Currently, we don't have a library for this type of work, and it has made iterating our suggestions difficult.

> Example: We recently changed our Turbolinks refresh interval suggestion from 50 seconds to 2 seconds. This was difficult to communicate with partners because we don't have a versioned solution to this outside of our public documents.

### What this change is about

* This PR introduces a new javascript asset file that gets generated on gem install
* Using this file is entirely optional
  * Partners who need Turbolinks + session token capability with their SSR apps can require it in their `index.js` files
  * This file will not automatically be bootstrapped by Webpack, but it will be available to partners
* This move puts us in a position to better communicate our Turbolinks solution with partners in a timely manner
* Now that [Turbolinks is no longer being maintained](https://github.com/turbolinks/turbolinks#turbolinks-is-no-longer-under-active-development), this change also helps us come up with a plan to sunset support for this feature in the near future

### What this change is not about

* This is not a complete solution. Coupling our Turbolinks solution with the Shopify App gem alone is not sufficient for all partners who need this capability and don't use this gem

### Next steps

* It might take a while for us to figure out a "good enough" Turbolinks solution. With this change, we hope to able to iterate and version our suggestions in one place now
* Identify a better vehicle for the behaviour this file provides apps
  * Could this be part of an NPM package? Is there a Shopify library we can introduce this behaviour in?

---

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
