### PR TITLE
[Bug fix] Redirect EnsureAuthenticatedLinks to login page if shop domain not found

### DIFF
--- a/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
+++ b/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
@@ -13,7 +13,9 @@ module ShopifyApp
     def redirect_to_splash_page
       splash_page_path = root_path(return_to: request.fullpath, shop: current_shopify_domain)
       redirect_to(splash_page_path)
-    rescue ShopifyApp::LoginProtection::ShopifyDomainNotFound
+    rescue ShopifyApp::LoginProtection::ShopifyDomainNotFound => error
+      Rails.logger.warn("[ShopifyApp::EnsureAuthenticatedLinks] Redirecting to login: [#{error.class}] "\
+                         "Could not determine current shop domain")
       redirect_to(ShopifyApp.configuration.login_url)
     end
 

--- a/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
+++ b/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
@@ -13,6 +13,8 @@ module ShopifyApp
     def redirect_to_splash_page
       splash_page_path = root_path(return_to: request.fullpath, shop: current_shopify_domain)
       redirect_to(splash_page_path)
+    rescue ShopifyApp::LoginProtection::ShopifyDomainNotFound
+      redirect_to(ShopifyApp.configuration.login_url)
     end
 
     def missing_expected_jwt?

--- a/test/controllers/concerns/ensure_authenticated_links_test.rb
+++ b/test/controllers/concerns/ensure_authenticated_links_test.rb
@@ -55,4 +55,12 @@ class EnsureAuthenticatedLinksTest < ActionController::TestCase
 
     assert_response :ok
   end
+
+  test 'redirects to login page if current shopify domain is not found' do
+    @controller.expects(:current_shopify_domain).raises(ShopifyApp::LoginProtection::ShopifyDomainNotFound)
+
+    get :some_link
+
+    assert_redirected_to ShopifyApp.configuration.login_url
+  end
 end

--- a/test/controllers/concerns/ensure_authenticated_links_test.rb
+++ b/test/controllers/concerns/ensure_authenticated_links_test.rb
@@ -58,9 +58,17 @@ class EnsureAuthenticatedLinksTest < ActionController::TestCase
 
   test 'redirects to login page if current shopify domain is not found' do
     @controller.expects(:current_shopify_domain).raises(ShopifyApp::LoginProtection::ShopifyDomainNotFound)
+    expect_redirect_error(ShopifyApp::LoginProtection::ShopifyDomainNotFound, "Could not determine current shop domain")
 
     get :some_link
 
     assert_redirected_to ShopifyApp.configuration.login_url
+  end
+
+  private
+
+  def expect_redirect_error(klass, message)
+    expected_message = "[ShopifyApp::EnsureAuthenticatedLinks] Redirecting to login: [#{klass}] #{message}"
+    Rails.logger.expects(:warn).once.with(expected_message)
   end
 end


### PR DESCRIPTION
> Fixes the issue brought up by a partner https://github.com/Shopify/shopify_app/pull/1118#issuecomment-765350708

In a world without cookies, an embedded app needs to handle attempted access to protected resources both in an embedded and non-embedded state. This PR fixes the scenario where `ShopifyApp::LoginProtection::ShopifyDomainNotFound` is raised when:
* The app is in a non-embedded state
* No shop parameter is passed in
* The app is unauthenticated
* The browser does not support 3p cookies (and subsequently does not have a 1p cookie saved on its domain with a sample `shop` domain)

In this scenario, rather than raise an exception, we should redirect to the app's `login_url`.

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
