### PR TITLE
Fix omniauth strategy not being set correctly for apps using session tokens

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -65,6 +65,13 @@ module ShopifyApp
       end
     end
 
+    # Override user_session_by_cookie from LoginProtection to bypass allow_cookie_authentication
+    # setting check because session cookies are justified at top level
+    def user_session_by_cookie
+      return unless session[:user_id].present?
+      ShopifyApp::SessionRepository.retrieve_user_session(session[:user_id])
+    end
+
     def start_user_token_flow?
       if jwt_request?
         false

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -113,7 +113,9 @@ module ShopifyApp
       assert_equal 'valid-shop-id', session[:shop_id]
     end
 
-    test '#callback clears a stale shop_id if user session is for a different shop' do
+    test '#callback clears a stale shop_id if user session is for a different shop when using cookie auth' do
+      ShopifyApp.configuration.allow_jwt_authentication = false
+      ShopifyApp.configuration.allow_cookie_authentication = true
       mock_shopify_user_omniauth
       session[:shop_id] = 'valid-shop-id'
       other_shop_session = ShopifyAPI::Session.new(
@@ -311,6 +313,9 @@ module ShopifyApp
     end
 
     test "#callback redirects to the root_url when not using JWT authentication" do
+      ShopifyApp.configuration.allow_jwt_authentication = false
+      ShopifyApp.configuration.allow_cookie_authentication = true
+
       mock_shopify_omniauth
 
       get :callback, params: { shop: 'shop' }

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -9,6 +9,7 @@ class ShopifyAppConfigurer
       config.myshopify_domain = 'myshopify.com'
       config.api_version = :unstable
       config.allow_jwt_authentication = true
+      config.allow_cookie_authentication = false
     end
   end
 end


### PR DESCRIPTION
## What is the issue?
Currently, new apps using `shopify_app` have session tokens enabled and cookies based auth disabled by default. The problem is that even at the top level actions where cookies are accessible and appropriate to use, `LoginProtection` gates it's usage in `user_session_by_cookie` and `shop_session_by_cookie` using the `allow_cookie_authentication` setting. This has led to calls for the `user_session` and `shop_session` resulting in `nil`, leading the app to falsely believe that it doesn't have an offline and/or online token.

### OAuth redirect loops for offline tokens
1. **[/login]** Initiate OAuth to fetch the offline/shop access token
1. Goes through OAuth process
1. **[/callback]** Store the offline access token
1. **[/callback]** Respond with [redirect to login to fetch online token](https://github.com/Shopify/shopify_app/blob/6c5a46ec49044d10940446ae94aac021fd248bea/app/controllers/shopify_app/callback_controller.rb#L28)
1. 🔥 **[/login]** Fails to set `session[:user_tokens]` to true as [`shop_session` check](https://github.com/Shopify/shopify_app/blob/master/app/controllers/shopify_app/sessions_controller.rb#L97) returns [`nil`](https://github.com/Shopify/shopify_app/blob/b478a4204f6dfce1cea549c222575d0ef4514f12/lib/shopify_app/controller_concerns/login_protection.rb#L70)
1. OmniAuth [falsely assumes app requires an offline token](https://github.com/Shopify/shopify_app/blob/master/lib/generators/shopify_app/install/templates/shopify_provider.rb#L19) and starts process to fetch one
1. Repeat steps 1-6 until Shopify stops looping process

### OAuth redirect loops for online tokens
1. **[/login]** Initiate OAuth to fetch the online/user access token
1. Goes through OAuth process
1. **[/callback]** Store the online access token
1. **[/callback]** Checks to see if it needs to [start online token flow](https://github.com/Shopify/shopify_app/blob/6c5a46ec49044d10940446ae94aac021fd248bea/app/controllers/shopify_app/callback_controller.rb#L72)
1. 🔥 **[/callback]** `user_session` results in [`nil`](https://github.com/Shopify/shopify_app/blob/6c5a46ec49044d10940446ae94aac021fd248bea/lib/shopify_app/controller_concerns/login_protection.rb#L54)
1. **[/callback]** Respond with redirect to login to fetch online token
1.  Repeat steps 1-6 until Shopify stops looping process

## What is the fix?

`SessionsController` and `CallbackController` can both operate from the top-level. Use of session cookies are justified in these scenarios.

### OAuth redirect loops for offline tokens
Override the `shop_session_by_cookie` method in `SessionsController` to ensure we are still using session cookies as before on the top level.

### OAuth redirect loops for online tokens
Override the `user_session_by_cookie` method in `CallbackController` to ensure we are still using session cookies as before on the top level.

## 🎩 

### Before

https://user-images.githubusercontent.com/60748788/105908241-f9594180-5ff3-11eb-8b8c-c2fb8fa35481.mov

### After

https://user-images.githubusercontent.com/60748788/105908009-b13a1f00-5ff3-11eb-9c82-7b691ba48653.mov


Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
