### PR TITLE
Packaging for release 17.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+17.0.5 (January 27, 2021)
+----------
+* Fix omniauth strategy not being set correctly for apps using session tokens [#1164](https://github.com/Shopify/shopify_app/pull/1164)
+
 17.0.4 (January 25, 2021)
 ----------
 * Redirect user to login page if shopify domain is not found in the `EnsureAuthenticatedLinks` concern [#1158](https://github.com/Shopify/shopify_app/pull/1158) 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (17.0.4)
+    shopify_app (17.0.5)
       browser_sniffer (~> 1.2.2)
       jwt (~> 2.2.1)
       omniauth-shopify-oauth2 (~> 2.2.2)
@@ -96,7 +96,7 @@ GEM
     faraday-net_http (1.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.12.1)
+    graphql (1.12.3)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
@@ -208,7 +208,7 @@ GEM
       rubocop (~> 1.4)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.4)
-    shopify_api (9.2.0)
+    shopify_api (9.3.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '17.0.4'
+  VERSION = '17.0.5'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "17.0.4",
+  "version": "17.0.5",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
17.0.5 (January 27, 2021)
----------
* Fix omniauth strategy not being set correctly for apps using session tokens [#1164](https://github.com/Shopify/shopify_app/pull/1164)

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
