### PR TITLE
Update instructions for forceRedirect to reflect new content_tag in embedded_app

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,10 +526,10 @@ With `lib/shopify_app/test_helpers/all'` more tests can be added and will only n
 Testing an embedded app outside the Shopify admin
 -------------------------------------------------
 
-By default, loading your embedded app will redirect to the Shopify admin, with the app view loaded in an `iframe`. If you need to load your app outside of the Shopify admin (e.g., for performance testing), you can change `forceRedirect: true` to `false` in `ShopifyApp.init` block in the `embedded_app` view. To keep the redirect on in production but off in your `development` and `test` environments, you can use:
+By default, loading your embedded app will redirect to the Shopify admin, with the app view loaded in an `iframe`. If you need to load your app outside of the Shopify admin (e.g., for performance testing), you can change `force_redirect: true` to `false` in `<%= content_tag(:div, nil, id: 'shopify-app-init') %>` block in the `embedded_app` view. To keep the redirect on in production but off in your `development` and `test` environments, you can use:
 
 ```javascript
-forceRedirect: <%= Rails.env.development? || Rails.env.test? ? 'false' : 'true' %>
+force_redirect: <%= Rails.env.development? || Rails.env.test? ? 'false' : 'true' %>
 ```
 
 Migrating to 13.0.0

--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -29,7 +29,8 @@
     <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
       api_key: ShopifyApp.configuration.api_key,
       shop_origin: @shop_origin || (@current_shopify_session.domain if @current_shopify_session),
-      debug: Rails.env.development?
+      debug: Rails.env.development?,
+      force_redirect: true,
     } ) %>
 
     <% if content_for?(:javascript) %>

--- a/lib/generators/shopify_app/install/templates/shopify_app.js
+++ b/lib/generators/shopify_app/install/templates/shopify_app.js
@@ -2,9 +2,11 @@ document.addEventListener('DOMContentLoaded', () => {
   var data = document.getElementById('shopify-app-init').dataset;
   var AppBridge = window['app-bridge'];
   var createApp = AppBridge.default;
+  var forceRedirect = (typeof data.forceRedirect === 'undefined' || data.forceRedirect === 'true');
   window.app = createApp({
     apiKey: data.apiKey,
     shopOrigin: data.shopOrigin,
+    forceRedirect,
   });
 
   var actions = AppBridge.actions;


### PR DESCRIPTION
The current instructions for forceRedirect assume ShopifyApp.init, but the template generator uses a method with content_tag and `addEventListener` to add the redirect. This allows for turning off redirects for embedded apps again.