### PR TITLE
WebhookJobKlass.perform_later should add ** for Ruby 3.0 compatibility

### DIFF
--- a/app/controllers/shopify_app/webhooks_controller.rb
+++ b/app/controllers/shopify_app/webhooks_controller.rb
@@ -8,7 +8,7 @@ module ShopifyApp
     def receive
       params.permit!
       job_args = { shop_domain: shop_domain, webhook: webhook_params.to_h }
-      webhook_job_klass.perform_later(job_args)
+      webhook_job_klass.perform_later(**job_args)
       head(:ok)
     end
 


### PR DESCRIPTION
Ruby 3.0 removes the implicit conversion of Hash to kwargs, so we need to add ** to make this explicit.

Previously, all webhook hits would break since it would attempt to pass a positional Hash to a Job that only accepts keywords.