### PR TITLE
Fixed bug in generated products controller.

### DIFF
--- a/lib/generators/shopify_app/products_controller/templates/products_controller.rb
+++ b/lib/generators/shopify_app/products_controller/templates/products_controller.rb
@@ -3,6 +3,6 @@
 class ProductsController < AuthenticatedController
   def index
     @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
-    render(json: { products: @products })
+    render(json: { products: @products.map(&:as_json) })
   end
 end


### PR DESCRIPTION
After generating a new app with Rails 6.0.3.4 and shopify_app 17.0.5 (shopify_api 9.3.0) the example would not work as javascript would throw the following error: `products.forEach is not a function`.

Looking at the response for "/products" it shows a Ruby object instead of JSON.

![Screen Shot 2021-02-03 at 14 47 46](https://user-images.githubusercontent.com/64841/106755914-f92df700-662e-11eb-8429-70644807e9d5.png)
(Test data)

Making sure the products returned are JSON using `as_json` fixes the issue.