### PR TITLE
Add access scopes to Shop and User model generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ $ rails generate shopify_app:shop_model
 ```
 This will generate a shop model which will be the storage for the tokens necessary for authentication.
 
+This will also generate a database migration for storing and accessing access scopes for shops. If you already have access scopes for shops stored, you can decline this option.
+
 #### User-based token storage
 A more granular control over the level of access per user on an app might be necessary, to which the shop-based token strategy is not sufficient. Shopify supports a user-based token storage strategy where a unique token to each user can be managed. Shop tokens must still be maintained if you are running background jobs so that you can make use of them when necessary.
 ```sh
@@ -254,6 +256,8 @@ $ rails generate shopify_app:shop_model
 $ rails generate shopify_app:user_model
 ```
 This will generate a shop model and user model, which will be the storage for the tokens necessary for authentication.
+
+This will also generate a database migration for storing and accessing access scopes for users. If you already have access scopes for users stored, you can decline this option.
 
 The current Shopify user will be stored in the rails session at `session[:shopify_user]`
 

--- a/lib/generators/shopify_app/shop_model/shop_model_generator.rb
+++ b/lib/generators/shopify_app/shop_model/shop_model_generator.rb
@@ -8,12 +8,35 @@ module ShopifyApp
       include Rails::Generators::Migration
       source_root File.expand_path('../templates', __FILE__)
 
+      class_option :force_access_scopes_migration, type: :boolean, default: false
+
       def create_shop_model
         copy_file('shop.rb', 'app/models/shop.rb')
       end
 
       def create_shop_migration
         migration_template('db/migrate/create_shops.erb', 'db/migrate/create_shops.rb')
+      end
+
+      def create_shop_with_access_scopes_migration
+        scopes_column_prompt = <<~PROMPT
+          It is highly recommended that apps record the access scopes granted by \
+          merchants during app installation. See app/models/shop.rb to modify how \
+          access scopes are stored and retrieved.
+
+          [WARNING] You will need to update the access_scopes accessors in the Shop model \
+          to allow shopify_app to store and retrieve scopes when going through OAuth.
+
+          The following migration will add an `access_scopes` column to the Shop model. \
+          Do you want to include this migration? [y/n]
+        PROMPT
+
+        if force_access_scopes_migration? || Rails.env.test? || yes?(scopes_column_prompt)
+          migration_template(
+            'db/migrate/add_shop_access_scopes_column.erb',
+            'db/migrate/add_shop_access_scopes_column.rb'
+          )
+        end
       end
 
       def update_shopify_app_initializer
@@ -25,6 +48,10 @@ module ShopifyApp
       end
 
       private
+
+      def force_access_scopes_migration?
+        options['force_access_scopes_migration']
+      end
 
       def rails_migration_version
         Rails.version.match(/\d\.\d/)[0]

--- a/lib/generators/shopify_app/shop_model/templates/db/migrate/add_shop_access_scopes_column.erb
+++ b/lib/generators/shopify_app/shop_model/templates/db/migrate/add_shop_access_scopes_column.erb
@@ -1,0 +1,5 @@
+class AddShopAccessScopesColumn < ActiveRecord::Migration[<%= rails_migration_version %>]
+  def change
+    add_column :shops, :access_scopes, :string
+  end
+end

--- a/lib/generators/shopify_app/user_model/templates/db/migrate/add_user_access_scopes_column.erb
+++ b/lib/generators/shopify_app/user_model/templates/db/migrate/add_user_access_scopes_column.erb
@@ -1,0 +1,5 @@
+class AddUserAccessScopesColumn < ActiveRecord::Migration[<%= rails_migration_version %>]
+  def change
+    add_column :users, :access_scopes, :string
+  end
+end

--- a/lib/generators/shopify_app/user_model/user_model_generator.rb
+++ b/lib/generators/shopify_app/user_model/user_model_generator.rb
@@ -8,12 +8,35 @@ module ShopifyApp
       include Rails::Generators::Migration
       source_root File.expand_path('../templates', __FILE__)
 
+      class_option :force_access_scopes_migration, type: :boolean, default: false
+
       def create_user_model
         copy_file('user.rb', 'app/models/user.rb')
       end
 
       def create_user_migration
         migration_template('db/migrate/create_users.erb', 'db/migrate/create_users.rb')
+      end
+
+      def create_scopes_storage_in_user_model
+        scopes_column_prompt = <<~PROMPT
+          It is highly recommended that apps record the access scopes granted by \
+          merchants during app installation. See app/models/user.rb to modify how \
+          access scopes are stored and retrieved.
+
+          [WARNING] You will need to update the access_scopes accessors in the User model \
+          to allow shopify_app to store and retrieve scopes when going through OAuth.
+
+          The following migration will add an `access_scopes` column to the User model. \
+          Do you want to include this migration? [y/n]
+        PROMPT
+
+        if force_access_scopes_migration? || Rails.env.test? || yes?(scopes_column_prompt)
+          migration_template(
+            'db/migrate/add_user_access_scopes_column.erb',
+            'db/migrate/add_user_access_scopes_column.rb'
+          )
+        end
       end
 
       def update_shopify_app_initializer
@@ -25,6 +48,10 @@ module ShopifyApp
       end
 
       private
+
+      def force_access_scopes_migration?
+        options['force_access_scopes_migration']
+      end
 
       def rails_migration_version
         Rails.version.match(/\d\.\d/)[0]

--- a/test/generators/shop_model_generator_test.rb
+++ b/test/generators/shop_model_generator_test.rb
@@ -27,6 +27,13 @@ class ShopModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "create shop with access_scopes migration in a test environment" do
+    run_generator
+    assert_migration "db/migrate/add_shop_access_scopes_column.rb" do |migration|
+      assert_match "add_column :shops, :access_scopes, :string", migration
+    end
+  end
+
   test "updates the shopify_app initializer" do
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |file|

--- a/test/generators/user_model_generator_test.rb
+++ b/test/generators/user_model_generator_test.rb
@@ -27,6 +27,13 @@ class UserModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "create access_scopes migration for User model" do
+    run_generator
+    assert_migration "db/migrate/add_user_access_scopes_column.rb" do |migration|
+      assert_match "add_column :users, :access_scopes, :string", migration
+    end
+  end
+
   test "updates the shopify_app initializer to use User to store session" do
     run_generator
     assert_file "config/initializers/shopify_app.rb" do |file|


### PR DESCRIPTION
### Problem
Embedded apps using session tokens do not automatically handle changes in access scopes for offline and online tokens. In order to handle changes to access scopes requested, we need to store the access scopes of access tokens.

### What does this PR do?
This PR creates optional database migrations in the generators to allow apps to store access scopes in the Shop and User models.  

### 🎩 
#### Run `rails g shopify_app:shop_model` 
  - You should be prompted to add `AddShopAccessScopesColumn` migration
  - Prompt yes to generate migration
  - Run `rails db:migrate` to successfully add new column to Shop model
#### Run `rails g shopify_app:user_model` 
  - You should be prompted to add `AddUserAccessScopesColumn` migration
  - Prompt yes to generate migration
  - Run `rails db:migrate` to successfully add new column to User model

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
