### PR TITLE
Store access scopes after successful OAuth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       omniauth-shopify-oauth2 (~> 2.2.2)
       rails (> 5.2.1, < 6.1)
       redirect_safely (~> 1.0)
-      shopify_api (~> 9.1)
+      shopify_api (~> 9.4)
 
 GEM
   remote: https://rubygems.org/
@@ -96,7 +96,7 @@ GEM
     faraday-net_http (1.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.12.3)
+    graphql (1.12.5)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
@@ -121,7 +121,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nio4r (2.5.4)
+    nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -208,7 +208,7 @@ GEM
       rubocop (~> 1.4)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.4)
-    shopify_api (9.3.0)
+    shopify_api (9.4.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack

--- a/README.md
+++ b/README.md
@@ -263,6 +263,38 @@ The current Shopify user will be stored in the rails session at `session[:shopif
 
 Read more about Online vs. Offline access [here](https://help.shopify.com/api/getting-started/authentication/oauth).
 
+### Access Scopes
+
+If you want to customize how access scopes are stored for shops and users, you can implement the `access_scopes` getters and setters in the models that include `ShopifyApp::ShopSessionStorageWithScopes` and `ShopifyApp::UserSessionStorageWithScopes` as shown:
+
+#### `ShopifyApp::ShopSessionStorageWithScopes`
+```ruby
+class Shop < ActiveRecord::Base
+  include ShopifyApp::ShopSessionStorageWithScopes
+
+  def access_scopes=(scopes)
+    # Store access scopes
+  end
+  def access_scopes
+    # Find access scopes
+  end
+end
+```
+
+#### `ShopifyApp::UserSessionStorageWithScopes`
+```ruby
+class User < ActiveRecord::Base
+  include ShopifyApp::UserSessionStorageWithScopes
+
+  def access_scopes=(scopes)
+    # Store access scopes
+  end
+  def access_scopes
+    # Find access scopes
+  end
+end
+```
+
 #### Migrating from shop-based to user-based token strategy
 1. Run the `user_model` generator as mentioned above.
 2. Ensure that both your `Shop` model and `User` model includes the necessary concerns `ShopifyApp::ShopSessionStorage` and `ShopifyApp::UserSessionStorage`.

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -118,6 +118,11 @@ module ShopifyApp
       auth_hash['credentials']['token']
     end
 
+    def access_scopes
+      return unless auth_hash['extra']['scope']
+      auth_hash['extra']['scope']
+    end
+
     def reset_session_options
       request.session_options[:renew] = true
       session.delete(:_csrf_token)
@@ -127,7 +132,8 @@ module ShopifyApp
       session_store = ShopifyAPI::Session.new(
         domain: shop_name,
         token: token,
-        api_version: ShopifyApp.configuration.api_version
+        api_version: ShopifyApp.configuration.api_version,
+        access_scopes: access_scopes
       )
 
       session[:shopify_user] = associated_user

--- a/lib/generators/shopify_app/shop_model/templates/shop.rb
+++ b/lib/generators/shopify_app/shop_model/templates/shop.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Shop < ActiveRecord::Base
-  include ShopifyApp::ShopSessionStorage
+  include ShopifyApp::ShopSessionStorageWithScopes
 
   def api_version
     ShopifyApp.configuration.api_version

--- a/lib/generators/shopify_app/user_model/templates/user.rb
+++ b/lib/generators/shopify_app/user_model/templates/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class User < ActiveRecord::Base
-  include ShopifyApp::UserSessionStorage
+  include ShopifyApp::UserSessionStorageWithScopes
 
   def api_version
     ShopifyApp.configuration.api_version

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -57,7 +57,9 @@ module ShopifyApp
   require 'shopify_app/session/session_repository'
   require 'shopify_app/session/session_storage'
   require 'shopify_app/session/shop_session_storage'
+  require 'shopify_app/session/shop_session_storage_with_scopes'
   require 'shopify_app/session/user_session_storage'
+  require 'shopify_app/session/user_session_storage_with_scopes'
 
   # omniauth_configuration
   require 'shopify_app/omniauth/omniauth_configuration'

--- a/lib/shopify_app/session/in_memory_shop_session_store.rb
+++ b/lib/shopify_app/session/in_memory_shop_session_store.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 module ShopifyApp
   class InMemoryShopSessionStore < InMemorySessionStore
-    def self.store(session, *args)
-      id = super
-      repo[session.domain] = session
-      id
-    end
+    class << self
+      def store(session, *args)
+        id = super
+        repo[session.domain] = session
+        id
+      end
 
-    def self.retrieve_by_shopify_domain(shopify_domain)
-      repo[shopify_domain]
+      def retrieve_by_shopify_domain(shopify_domain)
+        repo[shopify_domain]
+      end
     end
   end
 end

--- a/lib/shopify_app/session/in_memory_user_session_store.rb
+++ b/lib/shopify_app/session/in_memory_user_session_store.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 module ShopifyApp
   class InMemoryUserSessionStore < InMemorySessionStore
-    def self.store(session, user)
-      id = super
-      repo[user.shopify_user_id] = session
-      id
-    end
+    class << self
+      def store(session, user)
+        id = super
+        repo[user.shopify_user_id] = session
+        id
+      end
 
-    def self.retrieve_by_shopify_user_id(user_id)
-      repo[user_id]
+      def retrieve_by_shopify_user_id(user_id)
+        repo[user_id]
+      end
     end
   end
 end

--- a/lib/shopify_app/session/shop_session_storage_with_scopes.rb
+++ b/lib/shopify_app/session/shop_session_storage_with_scopes.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module ShopSessionStorageWithScopes
+    extend ActiveSupport::Concern
+    include ::ShopifyApp::SessionStorage
+
+    included do
+      validates :shopify_domain, presence: true, uniqueness: { case_sensitive: false }
+    end
+
+    class_methods do
+      def store(auth_session, *_args)
+        shop = find_or_initialize_by(shopify_domain: auth_session.domain)
+        shop.shopify_token = auth_session.token
+        shop.access_scopes = auth_session.access_scopes
+
+        shop.save!
+        shop.id
+      end
+
+      def retrieve(id)
+        shop = find_by(id: id)
+        construct_session(shop)
+      end
+
+      def retrieve_by_shopify_domain(domain)
+        shop = find_by(shopify_domain: domain)
+        construct_session(shop)
+      end
+
+      private
+
+      def construct_session(shop)
+        return unless shop
+
+        ShopifyAPI::Session.new(
+          domain: shop.shopify_domain,
+          token: shop.shopify_token,
+          api_version: shop.api_version,
+          access_scopes: shop.access_scopes
+        )
+      end
+    end
+
+    def access_scopes=(scopes)
+      super(scopes)
+    rescue NotImplementedError, NoMethodError
+      raise NotImplementedError, "#access_scopes= must be defined to handle storing access scopes: #{scopes}"
+    end
+
+    def access_scopes
+      super
+    rescue NotImplementedError, NoMethodError
+      raise NotImplementedError, "#access_scopes= must be defined to hook into stored access scopes"
+    end
+  end
+end

--- a/lib/shopify_app/session/user_session_storage_with_scopes.rb
+++ b/lib/shopify_app/session/user_session_storage_with_scopes.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module ShopifyApp
+  module UserSessionStorageWithScopes
+    extend ActiveSupport::Concern
+    include ::ShopifyApp::SessionStorage
+
+    included do
+      validates :shopify_domain, presence: true
+    end
+
+    class_methods do
+      def store(auth_session, user)
+        user = find_or_initialize_by(shopify_user_id: user[:id])
+        user.shopify_token = auth_session.token
+        user.shopify_domain = auth_session.domain
+        user.access_scopes = auth_session.access_scopes
+
+        user.save!
+        user.id
+      end
+
+      def retrieve(id)
+        user = find_by(id: id)
+        construct_session(user)
+      end
+
+      def retrieve_by_shopify_user_id(user_id)
+        user = find_by(shopify_user_id: user_id)
+        construct_session(user)
+      end
+
+      private
+
+      def construct_session(user)
+        return unless user
+
+        ShopifyAPI::Session.new(
+          domain: user.shopify_domain,
+          token: user.shopify_token,
+          api_version: user.api_version,
+          access_scopes: user.access_scopes
+        )
+      end
+    end
+
+    def access_scopes=(scopes)
+      super(scopes)
+    rescue NotImplementedError, NoMethodError
+      raise NotImplementedError, "#access_scopes= must be defined to handle storing access scopes: #{scopes}"
+    end
+
+    def access_scopes
+      super
+    rescue NotImplementedError, NoMethodError
+      raise NotImplementedError, "#access_scopes= must be defined to hook into stored access scopes"
+    end
+  end
+end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.2.2')
   s.add_runtime_dependency('rails', '> 5.2.1', '< 6.1')
-  s.add_runtime_dependency('shopify_api', '~> 9.1')
+  s.add_runtime_dependency('shopify_api', '~> 9.4')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.2.2')
   s.add_runtime_dependency('jwt', '~> 2.2.1')
   s.add_runtime_dependency('redirect_safely', '~> 1.0')

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -386,13 +386,20 @@ module ShopifyApp
         token: '1234',
         domain: TEST_SHOPIFY_DOMAIN,
         api_version: ShopifyApp.configuration.api_version,
+        access_scopes: "read_products"
       )
     end
 
     def mock_shopify_omniauth
       ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
       ShopifyApp::SessionRepository.user_storage = nil
-      OmniAuth.config.add_mock(:shopify, provider: :shopify, uid: TEST_SHOPIFY_DOMAIN, credentials: { token: '1234' })
+      OmniAuth.config.add_mock(
+        :shopify,
+        provider: :shopify,
+        uid: TEST_SHOPIFY_DOMAIN,
+        credentials: { token: '1234' },
+        extra: { scope: "read_products" }
+      )
       request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:shopify] if request
       request.env['omniauth.params'] = { shop: TEST_SHOPIFY_DOMAIN } if request
     end

--- a/test/generators/shop_model_generator_test.rb
+++ b/test/generators/shop_model_generator_test.rb
@@ -15,7 +15,7 @@ class ShopModelGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "app/models/shop.rb" do |shop|
       assert_match "class Shop < ActiveRecord::Base", shop
-      assert_match "include ShopifyApp::ShopSessionStorage", shop
+      assert_match "include ShopifyApp::ShopSessionStorageWithScopes", shop
       assert_match(/def api_version\n\s*ShopifyApp\.configuration\.api_version\n\s*end/, shop)
     end
   end

--- a/test/generators/user_model_generator_test.rb
+++ b/test/generators/user_model_generator_test.rb
@@ -15,7 +15,7 @@ class UserModelGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "app/models/user.rb" do |user|
       assert_match "class User < ActiveRecord::Base", user
-      assert_match "include ShopifyApp::UserSessionStorage", user
+      assert_match "include ShopifyApp::UserSessionStorageWithScopes", user
       assert_match(/def api_version\n\s*ShopifyApp\.configuration\.api_version\n\s*end/, user)
     end
   end

--- a/test/shopify_app/session/session_repository_test.rb
+++ b/test/shopify_app/session/session_repository_test.rb
@@ -45,47 +45,40 @@ module ShopifyApp
     test '.retrieve_user_session_by_shopify_user_id retrieves a user session by JWT' do
       SessionRepository.user_storage = InMemoryUserSessionStore
 
-      user_id = 'abra'
-      InMemoryUserSessionStore.expects(:retrieve_by_shopify_user_id).with(user_id)
+      InMemoryUserSessionStore.expects(:retrieve_by_shopify_user_id).with(mock_shopify_user_id)
 
-      SessionRepository.retrieve_user_session_by_shopify_user_id(user_id)
+      SessionRepository.retrieve_user_session_by_shopify_user_id(mock_shopify_user_id)
     end
 
     test '.retrieve_shop_session_by_shopify_domain retrieves a shop session by JWT' do
       SessionRepository.shop_storage = InMemoryShopSessionStore
 
-      shopify_domain = 'abra-shop'
-      InMemoryShopSessionStore.expects(:retrieve_by_shopify_domain).with(shopify_domain)
+      InMemoryShopSessionStore.expects(:retrieve_by_shopify_domain).with(mock_shopify_domain)
 
-      SessionRepository.retrieve_shop_session_by_shopify_domain(shopify_domain)
+      SessionRepository.retrieve_shop_session_by_shopify_domain(mock_shopify_domain)
     end
 
     test '.retrieve_user_session retrieves a user session' do
       SessionRepository.user_storage = InMemoryUserSessionStore
 
-      user_id = 'abra'
-      InMemoryUserSessionStore.expects(:retrieve).with(user_id)
+      InMemoryUserSessionStore.expects(:retrieve).with(mock_shopify_user_id)
 
-      SessionRepository.retrieve_user_session(user_id)
+      SessionRepository.retrieve_user_session(mock_shopify_user_id)
     end
 
     test '.retrieve_shop_session retrieves a shop session' do
       SessionRepository.shop_storage = InMemoryShopSessionStore
 
-      shop_id = 'abra-shop'
-      InMemoryShopSessionStore.expects(:retrieve).with(shop_id)
+      mock_shop_id = 'abra-shop'
+      InMemoryShopSessionStore.expects(:retrieve).with(mock_shop_id)
 
-      SessionRepository.retrieve_shop_session(shop_id)
+      SessionRepository.retrieve_shop_session(mock_shop_id)
     end
 
     test '.store_shop_session stores a shop session' do
       SessionRepository.shop_storage = InMemoryShopSessionStore
 
-      session = ShopifyAPI::Session.new(
-        domain: 'shop.myshopify.com',
-        token: 'abracadabra',
-        api_version: :unstable
-      )
+      session = mock_shopify_session
       InMemoryShopSessionStore.expects(:store).with(session)
 
       SessionRepository.store_shop_session(session)
@@ -94,15 +87,30 @@ module ShopifyApp
     test '.store_user_session stores a user session' do
       SessionRepository.user_storage = InMemoryUserSessionStore
 
-      session = ShopifyAPI::Session.new(
-        domain: 'shop.myshopify.com',
-        token: 'abracadabra',
-        api_version: :unstable
-      )
+      session = mock_shopify_session
       user = { 'id' => 'abra' }
       InMemoryUserSessionStore.expects(:store).with(session, user)
 
       SessionRepository.store_user_session(session, user)
+    end
+
+    private
+
+    def mock_shopify_domain
+      'shop.myshopify.com'
+    end
+
+    def mock_shopify_user_id
+      'abra'
+    end
+
+    def mock_shopify_session
+      ShopifyAPI::Session.new(
+        domain: mock_shopify_domain,
+        token: 'abracadabra',
+        api_version: :unstable,
+        access_scopes: 'read_products'
+      )
     end
   end
 end

--- a/test/shopify_app/session/shop_session_storage_with_scopes_test.rb
+++ b/test/shopify_app/session/shop_session_storage_with_scopes_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ShopMockSessionStoreWithScopes < ActiveRecord::Base
+  include ShopifyApp::ShopSessionStorageWithScopes
+end
+
+module ShopifyApp
+  class ShopSessionStorageWithScopesTest < ActiveSupport::TestCase
+    TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
+    TEST_SHOPIFY_TOKEN = "1234567890qwertyuiop"
+    TEST_MERCHANT_SCOPES = 'read_products, write_orders'
+
+    test ".retrieve can retrieve shop session records by ID" do
+      ShopMockSessionStoreWithScopes.stubs(:find_by).returns(MockShopInstance.new(
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_TOKEN,
+        scopes: TEST_MERCHANT_SCOPES
+      ))
+
+      session = ShopMockSessionStoreWithScopes.retrieve(1)
+      assert_equal TEST_SHOPIFY_DOMAIN, session.domain
+      assert_equal TEST_SHOPIFY_TOKEN, session.token
+      assert_equal ShopifyAPI::ApiAccess.new(TEST_MERCHANT_SCOPES), session.access_scopes
+    end
+
+    test ".retrieve_by_shopify_domain can retrieve shop session records by JWT" do
+      instance = MockShopInstance.new(
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_TOKEN,
+        api_version: '2020-01',
+        scopes: TEST_MERCHANT_SCOPES
+      )
+      ShopMockSessionStoreWithScopes.stubs(:find_by).with(shopify_domain: TEST_SHOPIFY_DOMAIN).returns(instance)
+
+      expected_session = ShopifyAPI::Session.new(
+        domain: instance.shopify_domain,
+        token: instance.shopify_token,
+        api_version: instance.api_version,
+        access_scopes: instance.access_scopes
+      )
+      shopify_domain = TEST_SHOPIFY_DOMAIN
+
+      session = ShopMockSessionStoreWithScopes.retrieve_by_shopify_domain(shopify_domain)
+      assert_equal expected_session.domain, session.domain
+      assert_equal expected_session.token, session.token
+      assert_equal expected_session.api_version, session.api_version
+      assert_equal expected_session.access_scopes, session.access_scopes
+    end
+
+    test ".store can store shop session records" do
+      mock_shop_instance = MockShopInstance.new(id: 12345)
+      mock_shop_instance.stubs(:save!).returns(true)
+
+      ShopMockSessionStoreWithScopes.stubs(:find_or_initialize_by).returns(mock_shop_instance)
+
+      mock_auth_hash = mock
+      mock_auth_hash.stubs(:domain).returns(mock_shop_instance.shopify_domain)
+      mock_auth_hash.stubs(:token).returns("a-new-token!")
+      mock_auth_hash.stubs(:access_scopes).returns(ShopifyAPI::ApiAccess.new(TEST_MERCHANT_SCOPES))
+      saved_id = ShopMockSessionStoreWithScopes.store(mock_auth_hash)
+
+      assert_equal "a-new-token!", mock_shop_instance.shopify_token
+      assert_equal mock_shop_instance.id, saved_id
+    end
+
+    test '.retrieve returns nil for non-existent shop' do
+      shop_id = 'non-existent-id'
+      ShopMockSessionStoreWithScopes.stubs(:find_by).with(id: shop_id).returns(nil)
+
+      refute ShopMockSessionStoreWithScopes.retrieve(shop_id)
+    end
+
+    test '.retrieve_by_shopify_domain returns nil for non-existent shop' do
+      shop_domain = 'non-existent-id'
+
+      ShopMockSessionStoreWithScopes.stubs(:find_by).with(shopify_domain: shop_domain).returns(nil)
+
+      refute ShopMockSessionStoreWithScopes.retrieve_by_shopify_domain(shop_domain)
+    end
+
+    test '.retrieve throws NotImplementedError when access_scopes getter is not implemented' do
+      mock_shop = MockShopInstance.new(
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_TOKEN
+      )
+      mock_shop.stubs(:access_scopes).raises(NotImplementedError)
+      ShopMockSessionStoreWithScopes.stubs(:find_by).returns(mock_shop)
+
+      assert_raises NotImplementedError do
+        ShopMockSessionStoreWithScopes.retrieve(1)
+      end
+    end
+  end
+end

--- a/test/shopify_app/session/user_session_storage_with_scopes_test.rb
+++ b/test/shopify_app/session/user_session_storage_with_scopes_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class UserMockSessionStoreWithScopes < ActiveRecord::Base
+  include ShopifyApp::UserSessionStorageWithScopes
+end
+
+module ShopifyApp
+  class UserSessionStorageWithScopesTest < ActiveSupport::TestCase
+    TEST_SHOPIFY_USER_ID = 42
+    TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
+    TEST_SHOPIFY_USER_TOKEN = "some-user-token-42"
+    TEST_MERCHANT_SCOPES = "read_orders, write_products"
+
+    test ".retrieve returns user session by id" do
+      UserMockSessionStoreWithScopes.stubs(:find_by).returns(MockUserInstance.new(
+        shopify_user_id: TEST_SHOPIFY_USER_ID,
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_USER_TOKEN,
+        scopes: TEST_MERCHANT_SCOPES
+      ))
+
+      session = UserMockSessionStoreWithScopes.retrieve(shopify_user_id: TEST_SHOPIFY_USER_ID)
+
+      assert_equal TEST_SHOPIFY_DOMAIN, session.domain
+      assert_equal TEST_SHOPIFY_USER_TOKEN, session.token
+      assert_equal ShopifyAPI::ApiAccess.new(TEST_MERCHANT_SCOPES), session.access_scopes
+    end
+
+    test ".retrieve_by_shopify_user_id returns user session by shopify_user_id" do
+      instance = MockUserInstance.new(
+        shopify_user_id: TEST_SHOPIFY_USER_ID,
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_USER_TOKEN,
+        api_version: '2020-01',
+        scopes: TEST_MERCHANT_SCOPES
+      )
+      UserMockSessionStoreWithScopes.stubs(:find_by).with(shopify_user_id: TEST_SHOPIFY_USER_ID).returns(instance)
+
+      expected_session = ShopifyAPI::Session.new(
+        domain: instance.shopify_domain,
+        token: instance.shopify_token,
+        api_version: instance.api_version,
+        access_scopes: TEST_MERCHANT_SCOPES
+      )
+
+      user_id = TEST_SHOPIFY_USER_ID
+      session = UserMockSessionStoreWithScopes.retrieve_by_shopify_user_id(user_id)
+      assert_equal expected_session.domain, session.domain
+      assert_equal expected_session.token, session.token
+      assert_equal expected_session.api_version, session.api_version
+      assert_equal expected_session.access_scopes, session.access_scopes
+    end
+
+    test ".store can store user session record" do
+      mock_user_instance = MockUserInstance.new(shopify_user_id: 100)
+      mock_user_instance.stubs(:save!).returns(true)
+
+      UserMockSessionStoreWithScopes.stubs(:find_or_initialize_by).returns(mock_user_instance)
+
+      mock_auth_hash = mock
+      mock_auth_hash.stubs(:domain).returns(mock_user_instance.shopify_domain)
+      mock_auth_hash.stubs(:token).returns("a-new-user_token!")
+      mock_auth_hash.stubs(:access_scopes).returns(ShopifyAPI::ApiAccess.new(TEST_MERCHANT_SCOPES))
+
+      associated_user = {
+        id: 100,
+      }
+
+      saved_id = UserMockSessionStoreWithScopes.store(mock_auth_hash, user: associated_user)
+
+      assert_equal "a-new-user_token!", mock_user_instance.shopify_token
+      assert_equal mock_user_instance.id, saved_id
+    end
+
+    test '.retrieve returns nil for non-existent user' do
+      user_id = 'non-existent-user'
+      UserMockSessionStoreWithScopes.stubs(:find_by).with(id: user_id).returns(nil)
+
+      refute UserMockSessionStoreWithScopes.retrieve(user_id)
+    end
+
+    test '.retrieve_by_user_id returns nil for non-existent user' do
+      user_id = 'non-existent-user'
+      UserMockSessionStoreWithScopes.stubs(:find_by).with(shopify_user_id: user_id).returns(nil)
+
+      refute UserMockSessionStoreWithScopes.retrieve_by_shopify_user_id(user_id)
+    end
+
+    test '.retrieve throws NotImplementedError when access_scopes getter is not implemented' do
+      mock_user = MockUserInstance.new(
+        shopify_user_id: TEST_SHOPIFY_USER_ID,
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_USER_TOKEN
+      )
+      mock_user.stubs(:access_scopes).raises(NotImplementedError)
+      UserMockSessionStoreWithScopes.stubs(:find_by).returns(mock_user)
+
+      assert_raises NotImplementedError do
+        UserMockSessionStoreWithScopes.retrieve(1)
+      end
+    end
+  end
+end

--- a/test/support/session_store_strategy_test_helpers.rb
+++ b/test/support/session_store_strategy_test_helpers.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 module SessionStoreStrategyTestHelpers
   class MockShopInstance
-    attr_reader :id, :shopify_domain, :shopify_token, :api_version
-    attr_writer :shopify_token
+    attr_reader :id, :shopify_domain, :shopify_token, :api_version, :access_scopes
+    attr_writer :shopify_token, :access_scopes
     def initialize(id: 1, shopify_domain: 'example.myshopify.com',
-      shopify_token: 'abcd-shop-token', api_version: 'unstable')
+      shopify_token: 'abcd-shop-token', api_version: 'unstable', scopes: "read_products")
       @id = id
       @shopify_domain = shopify_domain
       @shopify_token = shopify_token
       @api_version = api_version
+      @access_scopes = scopes
     end
   end
 
   class MockUserInstance
-    attr_reader :id, :shopify_user_id, :shopify_domain, :shopify_token, :api_version
-    attr_writer :shopify_token, :shopify_domain
+    attr_reader :id, :shopify_user_id, :shopify_domain, :shopify_token, :api_version, :access_scopes
+    attr_writer :shopify_token, :shopify_domain, :access_scopes
 
     def initialize(id: 1, shopify_user_id: 1, shopify_domain: 'example.myshopify.com',
-      shopify_token: '1234-user-token', api_version: 'unstable')
+      shopify_token: '1234-user-token', api_version: 'unstable', scopes: "read_products")
       @id = id
       @shopify_user_id = shopify_user_id
       @shopify_domain = shopify_domain
       @shopify_token = shopify_token
       @api_version = api_version
+      @access_scopes = scopes
     end
   end
 end


### PR DESCRIPTION
### Problem
Embedded apps using session tokens do not automatically handle changes in access scopes for offline and online tokens. In order to handle changes to access scopes requested, we need to store the access scopes after successfully completing OAuth flows.

### What does this PR do?
On successful completion of OAuth, apps will now store the access scopes of an access token in `ShopifyApp::ShopSessionStorageWithScopes` and `ShopifyApp::UserSessionStorageWithScopes`.

### 🎩  Tophatting
#### Go through OAuth for offline/shop tokens
- Appropriate Shop record should have `access_scopes` with the expected values

#### Go through OAuth for online/user tokens
- Appropriate User record should have `access_scopes` with the expected values

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
