### PR TITLE
Use access scopes strategies to handle changes to scopes requested by app

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can find documentation on gem usage, concepts, mixins, installation, and mor
   * [Generators](/docs/shopify_app/generators.md)
   * [ScriptTags](/docs/shopify_app/script-tags.md)
   * [Session repository](/docs/shopify_app/session-repository.md)
+  * [Handling changes in access scopes](/docs/shopify_app/handling-access-scopes-changes.md)
   * [Testing](/docs/shopify_app/testing.md)
   * [Webhooks](/docs/shopify_app/webhooks.md)
 

--- a/app/controllers/concerns/shopify_app/shop_access_scopes_verification.rb
+++ b/app/controllers/concerns/shopify_app/shop_access_scopes_verification.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module ShopAccessScopesVerification
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :login_on_scope_changes
+    end
+
+    protected
+
+    def login_on_scope_changes
+      redirect_to(shop_login) if scopes_mismatch?
+    end
+
+    private
+
+    def scopes_mismatch?
+      ShopifyApp.configuration.shop_access_scopes_strategy.update_access_scopes?(current_shopify_domain)
+    end
+
+    def current_shopify_domain
+      return if params[:shop].blank?
+      ShopifyApp::Utils.sanitize_shop_domain(params[:shop])
+    end
+
+    def shop_login
+      ShopifyApp::Utils.shop_login_url(shop: params[:shop], return_to: request.fullpath)
+    end
+  end
+end

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -76,8 +76,18 @@ module ShopifyApp
       if jwt_request?
         false
       else
-        ShopifyApp::SessionRepository.user_storage.present? && user_session.blank?
+        return false unless ShopifyApp::SessionRepository.user_storage.present?
+        update_user_access_scopes?
       end
+    end
+
+    def update_user_access_scopes?
+      return true if user_session.blank?
+      user_access_scopes_strategy.update_access_scopes?(user_id: session[:user_id])
+    end
+
+    def user_access_scopes_strategy
+      ShopifyApp.configuration.user_access_scopes_strategy
     end
 
     def jwt_request?

--- a/docs/shopify_app/handling-access-scopes-changes.md
+++ b/docs/shopify_app/handling-access-scopes-changes.md
@@ -1,0 +1,8 @@
+# Handling changes in access scopes
+The Shopify App gem provides handling changes to scopes for both shop/offline and user/online tokens. To enable your app to login via OAuth on scope changes, you can set the following configuration flag:
+```ruby
+ShopifyApp.configuration.reauth_on_access_scope_changes = true
+```
+
+## ShopAccessScopesVerification
+The `ShopifyApp::ShopAccessScopesVerification` concern helps merchants grant new access scopes requested by the app. The concern compares the current access scopes granted by the shop and compares them with the scopes requested by the app. If there is a mismatch in configuration, the merchant is redirected to login via OAuth and grant the net new scopes.

--- a/docs/shopify_app/session-repository.md
+++ b/docs/shopify_app/session-repository.md
@@ -78,10 +78,8 @@ end
 provider :shopify,
   ...
   setup: lambda { |env|
-    ...
-    # Add this line
-    strategy.options[:per_user_permissions] = strategy.session[:user_tokens]
-    ...
+    configuration = ShopifyApp::OmniauthConfiguration.new(env['omniauth.strategy'], Rack::Request.new(env))
+    configuration.build_options
   }
 
 # In the `shopify_app.rb` initializer:

--- a/lib/generators/shopify_app/home_controller/templates/home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/home_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HomeController < AuthenticatedController
+  include ShopifyApp::ShopAccessScopesVerification
+
   def index
     @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
     @webhooks = ShopifyAPI::Webhook.find(:all)

--- a/lib/generators/shopify_app/home_controller/templates/unauthenticated_home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/unauthenticated_home_controller.rb
@@ -3,6 +3,7 @@
 class HomeController < ApplicationController
   include ShopifyApp::EmbeddedApp
   include ShopifyApp::RequireKnownShop
+  include ShopifyApp::ShopAccessScopesVerification
 
   def index
     @shop_origin = current_shopify_domain

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -7,6 +7,9 @@ ShopifyApp.configure do |config|
   config.after_authenticate_job = false
   config.api_version = "<%= @api_version %>"
   config.shop_session_repository = 'Shop'
+
+  config.reauth_on_access_scope_changes = true
+
   config.allow_jwt_authentication = <%= !with_cookie_authentication? %>
   config.allow_cookie_authentication = <%= with_cookie_authentication? %>
 

--- a/lib/generators/shopify_app/install/templates/shopify_provider.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_provider.rb.tt
@@ -3,16 +3,6 @@
       ShopifyApp.configuration.secret,
       scope: ShopifyApp.configuration.scope,
       setup: lambda { |env|
-        strategy = env['omniauth.strategy']
-
-        shopify_auth_params = strategy.session['shopify.omniauth_params']&.with_indifferent_access
-        shop = if shopify_auth_params.present?
-          "https://#{shopify_auth_params[:shop]}"
-        else
-          ''
-        end
-
-        strategy.options[:client_options][:site] = shop
-        strategy.options[:old_client_secret] = ShopifyApp.configuration.old_secret
-        strategy.options[:per_user_permissions] = strategy.session[:user_tokens]
+        configuration = ShopifyApp::OmniAuthConfiguration.new(env['omniauth.strategy'], Rack::Request.new(env))
+        configuration.build_options
       }

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -61,6 +61,11 @@ module ShopifyApp
   require 'shopify_app/session/user_session_storage'
   require 'shopify_app/session/user_session_storage_with_scopes'
 
+  # access scopes strategies
+  require 'shopify_app/access_scopes/shop_strategy'
+  require 'shopify_app/access_scopes/user_strategy'
+  require 'shopify_app/access_scopes/noop_strategy'
+
   # omniauth_configuration
   require 'shopify_app/omniauth/omniauth_configuration'
 end

--- a/lib/shopify_app/access_scopes/noop_strategy.rb
+++ b/lib/shopify_app/access_scopes/noop_strategy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module AccessScopes
+    class NoopStrategy
+      class << self
+        def update_access_scopes?(*_args)
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_app/access_scopes/shop_strategy.rb
+++ b/lib/shopify_app/access_scopes/shop_strategy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module AccessScopes
+    class ShopStrategy
+      class << self
+        def update_access_scopes?(shop_domain)
+          shop_access_scopes = shop_access_scopes(shop_domain)
+          configuration_access_scopes != shop_access_scopes
+        end
+
+        private
+
+        def shop_access_scopes(shop_domain)
+          ShopifyApp::SessionRepository.retrieve_shop_session_by_shopify_domain(shop_domain)&.access_scopes
+        end
+
+        def configuration_access_scopes
+          ShopifyAPI::ApiAccess.new(ShopifyApp.configuration.shop_access_scopes)
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_app/access_scopes/user_strategy.rb
+++ b/lib/shopify_app/access_scopes/user_strategy.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module AccessScopes
+    class UserStrategy
+      class InvalidInput < StandardError; end
+
+      class << self
+        def update_access_scopes?(user_id: nil, shopify_user_id: nil)
+          return update_access_scopes_for_user_id?(user_id) if user_id
+          return update_access_scopes_for_shopify_user_id?(shopify_user_id) if shopify_user_id
+          raise(InvalidInput, '#update_access_scopes? requires user_id or shopify_user_id parameter inputs')
+        end
+
+        private
+
+        def update_access_scopes_for_user_id?(user_id)
+          user_access_scopes = user_access_scopes_by_user_id(user_id)
+          configuration_access_scopes != user_access_scopes
+        end
+
+        def update_access_scopes_for_shopify_user_id?(shopify_user_id)
+          user_access_scopes = user_access_scopes_by_shopify_user_id(shopify_user_id)
+          configuration_access_scopes != user_access_scopes
+        end
+
+        def user_access_scopes_by_user_id(user_id)
+          ShopifyApp::SessionRepository.retrieve_user_session(user_id)&.access_scopes
+        end
+
+        def user_access_scopes_by_shopify_user_id(shopify_user_id)
+          ShopifyApp::SessionRepository.retrieve_user_session_by_shopify_user_id(shopify_user_id)&.access_scopes
+        end
+
+        def configuration_access_scopes
+          ShopifyAPI::ApiAccess.new(ShopifyApp.configuration.user_access_scopes)
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -18,6 +18,8 @@ module ShopifyApp
     attr_accessor :after_authenticate_job
     attr_accessor :api_version
 
+    attr_accessor :reauth_on_access_scope_changes
+
     # customise urls
     attr_accessor :root_url
     attr_writer :login_url
@@ -70,6 +72,16 @@ module ShopifyApp
 
     def shop_session_repository
       ShopifyApp::SessionRepository.shop_storage
+    end
+
+    def shop_access_scopes_strategy
+      return ShopifyApp::AccessScopes::NoopStrategy unless reauth_on_access_scope_changes
+      ShopifyApp::AccessScopes::ShopStrategy
+    end
+
+    def user_access_scopes_strategy
+      return ShopifyApp::AccessScopes::NoopStrategy unless reauth_on_access_scope_changes
+      ShopifyApp::AccessScopes::UserStrategy
     end
 
     def has_webhooks?

--- a/lib/shopify_app/omniauth/omniauth_configuration.rb
+++ b/lib/shopify_app/omniauth/omniauth_configuration.rb
@@ -50,7 +50,7 @@ module ShopifyApp
     end
 
     def update_shop_scopes?
-      false
+      ShopifyApp.configuration.shop_access_scopes_strategy.update_access_scopes?(shop_domain)
     end
 
     def shop_domain

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -20,5 +20,17 @@ module ShopifyApp
     rescue ActiveResource::ConnectionError
       logger.error("[ShopifyAPI::ApiVersion] Unable to fetch api_versions from Shopify")
     end
+
+    def self.shop_login_url(shop:, return_to:)
+      return ShopifyApp.configuration.login_url unless shop
+      url = URI(ShopifyApp.configuration.login_url)
+
+      url.query = URI.encode_www_form(
+        shop: shop,
+        return_to: return_to,
+      )
+
+      url.to_s
+    end
   end
 end

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -20,6 +20,8 @@ module ShopifyApp
       @routes = ShopifyApp::Engine.routes
       ShopifyApp.configuration = nil
       ShopifyApp.configuration.embedded_app = true
+      ShopifyApp.configuration.reauth_on_access_scope_changes = true
+      mock_user_scopes_match_strategy
 
       I18n.locale = :en
 
@@ -372,6 +374,16 @@ module ShopifyApp
 
       get :callback
       assert_response :ok
+    end
+
+    test "#callback redirects to login for user token flow if user session access scopes mismatch by user_id" do
+      mock_user_scopes_mismatch_strategy
+      mock_shopify_user_omniauth
+      _session = mock_user_session
+
+      get :callback
+
+      assert_redirected_to ShopifyApp.configuration.login_url
     end
 
     private

--- a/test/controllers/concerns/shop_access_scopes_verification_test.rb
+++ b/test/controllers/concerns/shop_access_scopes_verification_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ScopesVerificationController < ActionController::Base
+  include ShopifyApp::ShopAccessScopesVerification
+
+  def index
+    render(plain: "OK")
+  end
+end
+
+class ShopAccessScopesVerificationControllertest < ActionController::TestCase
+  tests ScopesVerificationController
+
+  setup do
+    ShopifyApp.configuration.reauth_on_access_scope_changes = true
+    @shopify_domain = 'test-shop.myshopify.com'
+
+    Rails.application.routes.draw do
+      get '/', to: 'scopes_verification#index'
+    end
+  end
+
+  test '#login_on_scope_changes does nothing if shop scopes match' do
+    mock_shop_scopes_match_strategy
+
+    get :index, params: { shop: @shopify_domain }
+
+    assert_response :ok
+  end
+
+  test '#login_on_scope_changes redirects to login when scopes do not match' do
+    mock_shop_scopes_mismatch_strategy
+
+    get :index, params: { shop: @shopify_domain }
+
+    assert_redirected_to expected_redirect_url
+  end
+
+  private
+
+  def expected_redirect_url
+    login_url = URI(ShopifyApp.configuration.login_url)
+    login_url.query = URI.encode_www_form(
+      shop: @shopify_domain,
+      return_to: request.fullpath,
+    )
+    login_url.to_s
+  end
+end

--- a/test/generators/home_controller_generator_test.rb
+++ b/test/generators/home_controller_generator_test.rb
@@ -20,14 +20,22 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
   test "creates the default unauthenticated home controller with home index view" do
     run_generator
 
-    assert_file "app/controllers/home_controller.rb", /HomeController < ApplicationController/
+    assert_file "app/controllers/home_controller.rb" do |file|
+      assert_match "HomeController < ApplicationController", file
+      assert_match "include ShopifyApp::ShopAccessScopesVerification", file
+      assert_match "include ShopifyApp::EmbeddedApp", file
+      assert_match "include ShopifyApp::RequireKnownShop", file
+    end
     assert_file "app/views/home/index.html.erb"
   end
 
   test "creates authenticated home controller with home index view given --with_cookie_authentication option" do
     run_generator %w(--with_cookie_authentication)
 
-    assert_file "app/controllers/home_controller.rb", /HomeController < AuthenticatedController/
+    assert_file "app/controllers/home_controller.rb" do |file|
+      assert_match "HomeController < AuthenticatedController", file
+      assert_match "include ShopifyApp::ShopAccessScopesVerification", file
+    end
     assert_file "app/views/home/index.html.erb"
     assert_no_file "app/controllers/products_controller.rb"
   end
@@ -36,7 +44,10 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
     ShopifyApp.configuration.embedded_app = nil
     run_generator %w(--embedded false)
 
-    assert_file "app/controllers/home_controller.rb", /HomeController < AuthenticatedController/
+    assert_file "app/controllers/home_controller.rb" do |file|
+      assert_match "HomeController < AuthenticatedController", file
+      assert_match "include ShopifyApp::ShopAccessScopesVerification", file
+    end
     assert_file "app/views/home/index.html.erb"
     assert_no_file "app/controllers/products_controller.rb"
   end
@@ -45,7 +56,10 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
     ShopifyApp.configuration.embedded_app = false
     run_generator
 
-    assert_file "app/controllers/home_controller.rb", /HomeController < AuthenticatedController/
+    assert_file "app/controllers/home_controller.rb" do |file|
+      assert_match "HomeController < AuthenticatedController", file
+      assert_match "include ShopifyApp::ShopAccessScopesVerification", file
+    end
     assert_file "app/views/home/index.html.erb"
   end
 

--- a/test/shopify_app/access_scopes/noop_strategy_test.rb
+++ b/test/shopify_app/access_scopes/noop_strategy_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyApp
+  module AccessScopes
+    class NoopStrategyTest < Minitest::Test
+      attr_reader :shopify_domain
+      attr_reader :user_id
+      attr_reader :shopify_user_id
+
+      def setup
+        @shopify_domain = "shop.myshopify.com"
+        @user_id = 1
+        @shopify_user_id = 2
+      end
+
+      def test_scope_update_is_never_required_for_shopify_domain
+        refute ShopifyApp::AccessScopes::NoopStrategy.update_access_scopes?(shopify_domain)
+      end
+
+      def test_scope_update_is_never_required_for_user_id
+        refute ShopifyApp::AccessScopes::NoopStrategy.update_access_scopes?(user_id: user_id)
+      end
+
+      def test_scope_update_is_never_required_for_shopify_user_id
+        refute ShopifyApp::AccessScopes::NoopStrategy.update_access_scopes?(shopify_user_id: shopify_user_id)
+      end
+    end
+  end
+end

--- a/test/shopify_app/access_scopes/shop_strategy_test.rb
+++ b/test/shopify_app/access_scopes/shop_strategy_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyApp
+  module AccessScopes
+    class ShopStrategyTest < Minitest::Test
+      attr_reader :shopify_domain
+
+      def setup
+        @shopify_domain = "shop.myshopify.com"
+      end
+
+      def test_scopes_dont_mismatch_if_configuration_and_stored_scope_are_same
+        ShopifyApp.configuration.shop_access_scopes = "read_products"
+        ShopifyApp::SessionRepository
+          .stubs(:retrieve_shop_session_by_shopify_domain)
+          .with(shopify_domain)
+          .returns(mock_shop_session('read_products'))
+
+        refute ShopifyApp::AccessScopes::ShopStrategy.update_access_scopes?(shopify_domain)
+      end
+
+      def test_scopes_mismatch_if_configuration_and_stored_scopes_are_not_the_same
+        ShopifyApp.configuration.shop_access_scopes = "write_products"
+        ShopifyApp::SessionRepository
+          .stubs(:retrieve_shop_session_by_shopify_domain)
+          .with(shopify_domain)
+          .returns(mock_shop_session('read_products'))
+
+        assert ShopifyApp::AccessScopes::ShopStrategy.update_access_scopes?(shopify_domain)
+      end
+
+      private
+
+      def mock_shop_session(scopes)
+        ShopifyAPI::Session.new(
+          domain: shopify_domain,
+          token: 'access_token',
+          api_version: '2021-02',
+          access_scopes: scopes
+        )
+      end
+    end
+  end
+end

--- a/test/shopify_app/access_scopes/user_strategy_test.rb
+++ b/test/shopify_app/access_scopes/user_strategy_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyApp
+  module AccessScopes
+    class UserStrategyTest < Minitest::Test
+      attr_reader :user_id
+      attr_reader :shopify_user_id
+      attr_reader :shopify_domain
+
+      def setup
+        @user_id = 1
+        @shopify_user_id = 2
+        @shopify_domain = 'test-shop.myshopify.com'
+      end
+
+      def test_scopes_match_for_db_generated_user_id
+        ShopifyApp.configuration.user_access_scopes = "read_products"
+        ShopifyApp::SessionRepository
+          .stubs(:retrieve_user_session).with(user_id)
+          .returns(mock_user_session('read_products'))
+
+        refute ShopifyApp::AccessScopes::UserStrategy.update_access_scopes?(user_id: user_id)
+      end
+
+      def test_scopes_mismatch_for_db_generated_user_id
+        ShopifyApp.configuration.user_access_scopes = "write_products"
+        ShopifyApp::SessionRepository
+          .stubs(:retrieve_user_session).with(user_id)
+          .returns(mock_user_session('read_products'))
+
+        assert ShopifyApp::AccessScopes::UserStrategy.update_access_scopes?(user_id: user_id)
+      end
+
+      def test_scopes_match_for_shopify_user_id
+        ShopifyApp.configuration.user_access_scopes = "write_orders, read_products"
+        ShopifyApp::SessionRepository
+          .stubs(:retrieve_user_session_by_shopify_user_id)
+          .with(shopify_user_id)
+          .returns(mock_user_session('write_orders, read_products'))
+
+        refute ShopifyApp::AccessScopes::UserStrategy.update_access_scopes?(shopify_user_id: shopify_user_id)
+      end
+
+      def test_scopes_mismatch_for_shopify_user_id
+        ShopifyApp.configuration.user_access_scopes = "write_orders, read_customers"
+        ShopifyApp::SessionRepository
+          .stubs(:retrieve_user_session_by_shopify_user_id)
+          .with(shopify_user_id)
+          .returns(mock_user_session('write_orders, read_products'))
+
+        assert ShopifyApp::AccessScopes::UserStrategy.update_access_scopes?(shopify_user_id: shopify_user_id)
+      end
+
+      def test_assert_invalid_input_error_when_no_parameters_passed_in
+        assert_raises ShopifyApp::AccessScopes::UserStrategy::InvalidInput do
+          assert ShopifyApp::AccessScopes::UserStrategy.update_access_scopes?
+        end
+      end
+
+      private
+
+      def mock_user_session(scopes)
+        ShopifyAPI::Session.new(
+          domain: shopify_domain,
+          token: 'access_token',
+          api_version: '2021-02',
+          access_scopes: scopes
+        )
+      end
+    end
+  end
+end

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -201,4 +201,58 @@ class ConfigurationTest < ActiveSupport::TestCase
     Rails.env.expects(:test?).returns(false)
     assert ShopifyApp.configuration.enable_same_site_none
   end
+
+  test "user_access_scopes resolves to scope if user_access_scopes are undefined" do
+    ShopifyApp.configure do |config|
+      config.scope = 'read_products'
+    end
+
+    assert_equal ShopifyApp.configuration.scope, ShopifyApp.configuration.user_access_scopes
+  end
+
+  test "shop_access_scopes resolves to scope if shop_access_scopes are undefined" do
+    ShopifyApp.configure do |config|
+      config.scope = 'write_orders'
+    end
+
+    assert_equal ShopifyApp.configuration.scope, ShopifyApp.configuration.shop_access_scopes
+  end
+
+  test "shop_access_scopes are set correctly" do
+    ShopifyApp.configure do |config|
+      config.scope = 'write_orders'
+      config.shop_access_scopes = 'read_orders'
+    end
+
+    assert_equal ShopifyApp.configuration.shop_access_scopes, 'read_orders'
+    assert_equal ShopifyApp.configuration.scope, 'write_orders'
+  end
+
+  test "user_access_scopes are set correctly" do
+    ShopifyApp.configure do |config|
+      config.scope = 'write_orders'
+      config.user_access_scopes = 'read_orders'
+    end
+
+    assert_equal ShopifyApp.configuration.user_access_scopes, 'read_orders'
+    assert_equal ShopifyApp.configuration.scope, 'write_orders'
+  end
+
+  test "noop access scope strategies defined when reauth_on_access_scope_changes is false" do
+    ShopifyApp.configure do |config|
+      config.reauth_on_access_scope_changes = false
+    end
+
+    assert_equal ShopifyApp::AccessScopes::NoopStrategy, ShopifyApp.configuration.shop_access_scopes_strategy
+    assert_equal ShopifyApp::AccessScopes::NoopStrategy, ShopifyApp.configuration.user_access_scopes_strategy
+  end
+
+  test "shop and user access scope strategies defined when reauth_on_access_scope_changes is true" do
+    ShopifyApp.configure do |config|
+      config.reauth_on_access_scope_changes = true
+    end
+
+    assert_equal ShopifyApp::AccessScopes::ShopStrategy, ShopifyApp.configuration.shop_access_scopes_strategy
+    assert_equal ShopifyApp::AccessScopes::UserStrategy, ShopifyApp.configuration.user_access_scopes_strategy
+  end
 end

--- a/test/support/access_scopes_strategy_test_helpers.rb
+++ b/test/support/access_scopes_strategy_test_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module AccessScopesStrategyHelpers
+  def mock_shop_scopes_mismatch_strategy
+    ShopifyApp::AccessScopes::ShopStrategy.stubs(:update_access_scopes?).returns(true)
+  end
+
+  def mock_shop_scopes_match_strategy
+    ShopifyApp::AccessScopes::ShopStrategy.stubs(:update_access_scopes?).returns(false)
+  end
+
+  def mock_user_scopes_match_strategy
+    ShopifyApp::AccessScopes::UserStrategy.stubs(:update_access_scopes?).returns(false)
+  end
+
+  def mock_user_scopes_mismatch_strategy
+    ShopifyApp::AccessScopes::UserStrategy.stubs(:update_access_scopes?).returns(true)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 class ActiveSupport::TestCase
   include GeneratorTestHelpers
   include SessionStoreStrategyTestHelpers
+  include AccessScopesStrategyHelpers
 
   API_META_TEST_RESPONSE = <<~JSON
     {


### PR DESCRIPTION
## Problem
Embedded apps using session tokens do not automatically handle changes in access scopes for offline and online tokens. In order to handle changes to access scopes requested, we need to determine when to trigger OAuth to grant new scopes.

## What does this PR do?
This PR introduces access scopes strategies, which will be used in the gem to determine whether new scopes need to be granted for a shop and/or user. The following strategies are set by default as part of our `ShopifyApp::Configuration`:

```ruby
ShopifyApp.configuration.shop_access_scopes_strategy = ShopifyApp::AccessScopes::ShopStrategy
ShopifyApp.configuration.user_access_scopes_strategy = ShopifyApp::AccessScopes::UserStrategy
```

It should be noted that `shop_access_scopes_strategy` and `user_access_scopes_strategy` are read-only.

These strategies are currently used to determine whether scopes are mismatched in three scenarios.

### When loading the app
We use the `ShopifyApp::ShopAccessScopesVerification` concern at the `HomeController` to check whether a shop has all the expected access scopes as in the configuration. It will redirect to OAuth if scopes are mismatched and request the updated list of scopes.

![handle-scopes-on-app-load](https://user-images.githubusercontent.com/60748788/109201389-c8de0200-776f-11eb-95c3-50157f0bc405.png)

### In the OmniAuth request middleware
When building the OmniAuth strategy, we need to determine whether the shop/offline token needs to be updated based on changes in scopes.

![omniauth-middleware-scope-handling](https://user-images.githubusercontent.com/60748788/109201607-0b9fda00-7770-11eb-964d-5e263349edc8.png)

### In the callback controller if a user/online token needs to be updated
After completing the OAuth flow to get a shop/offline token, an app may have a valid user/online token that doesn't have the appropriate scopes. Based on the `ShopifyApp::AccessScopes::UserStrategy`, we trigger OAuth to update the user's access scopes on mismatches.

![handle-user-access-scopes-in-callback-controller](https://user-images.githubusercontent.com/60748788/109201977-76511580-7770-11eb-94e3-807605a5a08f.png)


### 🎩  Tophatting
#### For app using offline tokens only
1. Run `rails server` and load app for the first time with the first set of access scopes.
2. Shut down `rails server`
3. In `shopify_app.rb` on the app, change `config.scope` or `config.shop_access_scopes` to new set of scopes
4. Run `rails server` and load app
5. You will sent through to the OAuth flow before coming back to the app with updated scopes

#### For app using offline and online tokens
1. Run `rails server` and load app for the first time with the first set of access scopes.
2. Shut down `rails server`
3. In `shopify_app.rb` on the app, change `config.scope` or `config.user_access_scopes` to new set of scopes
4. Run `rails server` and load app
5. You will sent through to the OAuth flow before coming back to the app with updated scopes
6. If you change both `config.shop_access_scopes` and `config.user_access_scopes` it will go through OAuth twice for offline and online tokens

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `docs/`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
