### PR TITLE
Enable CI build GitHub Action to run on pull requests on a fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: CI
 
-on: 
+on:
   push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
This wasn't running for external contributors, e.g. https://github.com/Shopify/shopify_app/pull/1187