### PR TITLE
Fetch access scope via #dig in callback controller

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -129,8 +129,7 @@ module ShopifyApp
     end
 
     def access_scopes
-      return unless auth_hash['extra']['scope']
-      auth_hash['extra']['scope']
+      auth_hash.dig('extra', 'scope')
     end
 
     def reset_session_options


### PR DESCRIPTION
### Problem

After upgrading to v17.1.0 I noticed that controller tests are not passing. I use OmniAuth mock in controller tests to login as shop:
```ruby
class ActionDispatch::IntegrationTest
  def login(shop)
    OmniAuth.config.test_mode = true
    OmniAuth.config.add_mock(:shopify,
      provider: 'shopify',
      uid: shop.shopify_domain,
      credentials: { token: shop.shopify_token })
    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:shopify]

    get "/auth/shopify"
    follow_redirect!
  end
end
```

This code started raising an error:
<img width="1063" alt="CleanShot 2021-03-11 at 12 48 56@2x" src="https://user-images.githubusercontent.com/839922/110768331-33ab3500-8268-11eb-87be-6c34afc0776b.png">

### What this PR does

Changes the syntax for fetching access_scope in CallbackController to be tolerant to empty `auth_hash['extra']`.
`Hash#dig` is supported since Ruby 2.3 so it shouldn't break anything (since the library requires ruby >= 2.5).
