### PR TITLE
Add App Foundations as code owners of shopify_app

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @shopify/platform-dev-tools-education
+*       @shopify/app-foundations


### PR DESCRIPTION
### What this PR does

Add App Foundations team as code owners

### Why this change is being made

The responsibility of maintaining the Shopify App gem has also been added to the App Foundations team.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
