### PR TITLE
Reload Rails routes before each engine test

### DIFF
--- a/test/controllers/concerns/ensure_authenticated_links_test.rb
+++ b/test/controllers/concerns/ensure_authenticated_links_test.rb
@@ -36,10 +36,6 @@ class EnsureAuthenticatedLinksTest < ActionController::TestCase
     end
   end
 
-  teardown do
-    Rails.application.reload_routes!
-  end
-
   test 'redirects to splash page with a return_to and shop param if no session token is present' do
     get :some_link, params: { shop: @shop_domain }
 

--- a/test/controllers/concerns/require_known_shop_test.rb
+++ b/test/controllers/concerns/require_known_shop_test.rb
@@ -17,10 +17,6 @@ class RequireKnownShopTest < ActionController::TestCase
     end
   end
 
-  teardown do
-    Rails.application.reload_routes!
-  end
-
   test 'redirects to login if no shop param is present' do
     get :index
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -10,7 +10,6 @@ end
 module ShopifyApp
   class SessionsControllerTest < ActionController::TestCase
     setup do
-      Rails.application.reload_routes!
       @routes = ShopifyApp::Engine.routes
       ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
 

--- a/test/integration/webhooks_controller_test.rb
+++ b/test/integration/webhooks_controller_test.rb
@@ -10,7 +10,6 @@ module ShopifyApp
     include ActiveJob::TestHelper
 
     setup do
-      Rails.application.reload_routes!
       WebhooksController.any_instance.stubs(:verify_request).returns(true)
       WebhooksController.any_instance.stubs(:webhook_namespace).returns(nil)
     end

--- a/test/shopify_app/controller_concerns/csrf_protection_test.rb
+++ b/test/shopify_app/controller_concerns/csrf_protection_test.rb
@@ -25,7 +25,6 @@ class CsrfProtectionTest < ActionDispatch::IntegrationTest
 
   teardown do
     ActionController::Base.allow_forgery_protection = @authenticity_protection
-    Rails.application.reload_routes!
   end
 
   test 'it raises an invalid authenticity token error if a valid session token or csrf token is not provided' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,5 +44,6 @@ class ActiveSupport::TestCase
     WebMock.disable_net_connect!
     WebMock.stub_request(:get, "https://app.shopify.com/services/apis.json").to_return(body: API_META_TEST_RESPONSE)
     ShopifyAppConfigurer.call
+    Rails.application.reload_routes!
   end
 end


### PR DESCRIPTION
### What this PR does

> Fixes (hopefully) https://github.com/Shopify/shopify_app/issues/1218

> This is a follow up to #1225 

There are still intermittently failing tests, but this time on different files than before. See the recent failing build: https://github.com/Shopify/shopify_app/pull/1221/checks?check_run_id=2175638755

The one thing all of these test files have in common is that they invoke `@routes = ShopifyApp::Engine.route` in their setup blocks, similar to the test files in #1225 

This PR adds logic to reload the Rails routes on all such test files.

### Reviewer's guide to testing

Test `bundle exec rake test` on ruby 2.7, 2.6, and 2.5 repeatedly. I've noticed that the files changed in this PR are the ones consistently failing across each ruby version, except with different files failing in 2.6 vs 2.7. 

### Things to focus on

1. I have not yet analyzed how much time reloading routes adds to each test. I can't notice a significant difference on my local computer, but this may not be the case in a CI environment.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
