### PR TITLE
Fix typo of ShopifyApp::OmniAuthConfiguration in docs/shopify_app/session-repository.md

### DIFF
--- a/docs/shopify_app/session-repository.md
+++ b/docs/shopify_app/session-repository.md
@@ -78,7 +78,7 @@ end
 provider :shopify,
   ...
   setup: lambda { |env|
-    configuration = ShopifyApp::OmniauthConfiguration.new(env['omniauth.strategy'], Rack::Request.new(env))
+    configuration = ShopifyApp::OmniAuthConfiguration.new(env['omniauth.strategy'], Rack::Request.new(env))
     configuration.build_options
   }
 


### PR DESCRIPTION
### What this PR does

Fix typo of `ShopifyApp::OmniAuthConfiguration` in [docs/shopify_app/session-repository.md](https://github.com/Shopify/shopify_app/blob/974f294a12789b8bb24ddc0e2476e9b7ef7ecdb8/docs/shopify_app/session-repository.md#migrating-from-shop-based-to-user-based-token-strategy).

The correct class name is [here](https://github.com/Shopify/shopify_app/blob/974f294a12789b8bb24ddc0e2476e9b7ef7ecdb8/lib/shopify_app/omniauth/omniauth_configuration.rb#L4).

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
