### PR TITLE
Bug fix: lock app-bridge to < 2 for this minor release

### DIFF
--- a/lib/generators/shopify_app/install/templates/embedded_app.html.erb
+++ b/lib/generators/shopify_app/install/templates/embedded_app.html.erb
@@ -24,7 +24,7 @@
 
     <%= render 'layouts/flash_messages' %>
 
-    <script src="https://unpkg.com/@shopify/app-bridge"></script>
+    <script src="https://unpkg.com/@shopify/app-bridge@1"></script>
 
     <%= content_tag(:div, nil, id: 'shopify-app-init', data: {
       api_key: ShopifyApp.configuration.api_key,


### PR DESCRIPTION
### What this PR does

With App Bridge 2.0, we need to lock all existing (for this minor release) app developers to `app-bridge@1` using the CDN. By default, CDN will serve app bridge 2.0, which is breaking.

### Reviewer's guide to testing

* Tophat this by creating a new app (or using an existing app) and ensure you don't get served app-bridge 2.0 in the embedded_app layout

### Things to focus on

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
