### PR TITLE
Upgrade to omniauth 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
-* Support omniauth 2.x
+* Support OmniAuth 2.x 
+  * If your app has custom OmniAuth configuration, please refer to the [OmniAuth 2.0 upgrade guide](https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0).
 
 17.2.1 (April 1, 2021)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     shopify_app (17.2.1)
       browser_sniffer (~> 1.2.2)
-      jwt (~> 2.2.1)
+      jwt (>= 2.2.3)
       omniauth-rails_csrf_protection
       omniauth-shopify-oauth2 (~> 2.3)
       rails (> 5.2.1, < 6.2)

--- a/app/assets/javascripts/shopify_app/post_redirect.js
+++ b/app/assets/javascripts/shopify_app/post_redirect.js
@@ -1,9 +1,0 @@
-(function() {
-  function redirect() {
-    var form = document.getElementById("redirect-form");
-    if (form) {
-      form.submit();
-    }
-  }
-  window.addEventListener("load", redirect);
-})();

--- a/app/views/shopify_app/shared/post_redirect_to_auth_shopify.html.erb
+++ b/app/views/shopify_app/shared/post_redirect_to_auth_shopify.html.erb
@@ -5,7 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
   <title>Redirecting…</title>
-  <%= javascript_include_tag('shopify_app/post_redirect', crossorigin: 'anonymous', integrity: true) %>
+  <script>
+    function redirect() {
+      var form = document.getElementById("redirect-form");
+      if (form) {
+        form.submit();
+      }
+    }
+    document.addEventListener("DOMContentLoaded", redirect);
+  </script>
 </head>
 <body>
   <%= form_tag '/auth/shopify', id: 'redirect-form' %>

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -3,6 +3,7 @@ require 'shopify_app/version'
 
 # deps
 require 'shopify_api'
+require 'omniauth/rails_csrf_protection'
 require 'omniauth-shopify-oauth2'
 require 'redirect_safely'
 

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -17,7 +17,6 @@ module ShopifyApp
     initializer "shopify_app.assets.precompile" do |app|
       app.config.assets.precompile += %w[
         shopify_app/redirect.js
-        shopify_app/post_redirect.js
         shopify_app/top_level.js
         shopify_app/enable_cookies.js
         shopify_app/request_storage_access.js

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rails', '> 5.2.1', '< 6.2')
   s.add_runtime_dependency('shopify_api', '~> 9.4')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.3')
-  s.add_runtime_dependency('jwt', '~> 2.2.1')
+  s.add_runtime_dependency('jwt', '>= 2.2.3')
   s.add_runtime_dependency('redirect_safely', '~> 1.0')
 
   s.add_development_dependency('rake')

--- a/test/shopify_app/session/jwt_test.rb
+++ b/test/shopify_app/session/jwt_test.rb
@@ -50,7 +50,7 @@ module ShopifyApp
 
     test "#shopify_domain and #shopify_user_id are nil if the jwt is unsigned" do
       # The library expects there to be a 3rd segment if we want to verify signature
-      expect_jwt_error(::JWT::DecodeError, 'Not enough or too many segments')
+      expect_jwt_error(::JWT::IncorrectAlgorithm, 'Expected a different algorithm')
 
       t = ::JWT.encode(payload, nil, 'none')
       jwt = JWT.new(t)


### PR DESCRIPTION
### What this PR does

* Makes shopify_app compatible with omniauth 2.x

### Reviewer's guide to testing

* Create a new app or install or
* Install the local checkout of the gem and `bundle install`

### Things to focus on

* [x] Apps created from scratch have omniauth 2.x as a dependency out of the box
* [x] Existing app can update to the new version of `shopify_app` and then update to omniauth 2.x
* [x] Oauth works
  * Actions
    * [x] App install
    * [x] Requesting new scopes
  * Scenarios
    * [x] In Chrome
    * [x] In Safari
    * [x] In an app using Session Tokens
    * [x] In an app using 3P session cookies
    * [x] In an app using only offline tokens
    * [x] In an app using offline and online tokens


### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
