### PR TITLE
Bugfix: Pass host param into return address regardless of apps's auth config

### DIFF
--- a/lib/generators/shopify_app/home_controller/templates/home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/home_controller.rb
@@ -3,8 +3,16 @@
 class HomeController < AuthenticatedController
   include ShopifyApp::ShopAccessScopesVerification
 
+  before_action :set_host
+
   def index
     @products = ShopifyAPI::Product.find(:all, params: { limit: 10 })
     @webhooks = ShopifyAPI::Webhook.find(:all)
+  end
+
+  private
+
+  def set_host
+    @host = params[:host]
   end
 end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -223,7 +223,6 @@ module ShopifyApp
     end
 
     def return_address
-      return base_return_address unless ShopifyApp.configuration.allow_jwt_authentication
       return_address_with_params(shop: current_shopify_domain, host: host)
     rescue ShopifyDomainNotFound, ShopifyHostNotFound
       base_return_address

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -325,7 +325,18 @@ module ShopifyApp
       assert_redirected_to '/'
     end
 
-    test "#callback redirects to the root_url with shop parameter when using JWT authentication" do
+    test "#callback redirects to the root_url with shop and host parameter when not using JWT authentication" do
+      ShopifyApp.configuration.allow_jwt_authentication = false
+      ShopifyApp.configuration.allow_cookie_authentication = true
+
+      mock_shopify_omniauth
+
+      get :callback, params: { shop: 'shop', host: 'test-host' }
+
+      assert_redirected_to "/?host=test-host&shop=#{TEST_SHOPIFY_DOMAIN}"
+    end
+
+    test "#callback redirects to the root_url with shop and host parameter when using JWT authentication" do
       ShopifyApp.configuration.allow_jwt_authentication = true
       mock_shopify_omniauth
 


### PR DESCRIPTION
### What this PR does

This PR fixes a bug relating to recent changes to support App Bridge 2.0. For apps that rely on 3p cookies, the `host` parameter is not being passed in, which leads to failure to load App Bridge. This PR ensures that the host parameter is passed after completing the OAuth flow.

### Reviewer's guide to testing

- [x] Ensure that this works for a newly generated app using 3p cookies

### Things to focus on

- The [return address](https://github.com/Shopify/shopify_app/pull/1259/files#diff-d73da7552f28e00cec3da61e695cfe70a8b49c4e2c403bc7062863bbf9fa185cR226) after completing OAuth

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
