### PR TITLE
Move js for POST redirect back to separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ----------
-* Fix bug causing oauth flow to fail due to CSP violation
+* Fix bug causing OAuth flow to fail due to CSP violation. [#1265](https://github.com/Shopify/shopify_app/pull/1265)
 
 18.0.0 (May 3, 2021)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Fix bug causing oauth flow to fail due to CSP violation
 
 18.0.0 (May 3, 2021)
 ----------

--- a/app/assets/javascripts/shopify_app/post_redirect.js
+++ b/app/assets/javascripts/shopify_app/post_redirect.js
@@ -1,0 +1,9 @@
+(function() {
+  function redirect() {
+    var form = document.getElementById("redirect-form");
+    if (form) {
+      form.submit();
+    }
+  }
+  document.addEventListener("DOMContentLoaded", redirect);
+})();

--- a/app/views/shopify_app/shared/post_redirect_to_auth_shopify.html.erb
+++ b/app/views/shopify_app/shared/post_redirect_to_auth_shopify.html.erb
@@ -5,15 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
   <title>Redirecting…</title>
-  <script>
-    function redirect() {
-      var form = document.getElementById("redirect-form");
-      if (form) {
-        form.submit();
-      }
-    }
-    document.addEventListener("DOMContentLoaded", redirect);
-  </script>
+  <%= javascript_include_tag('shopify_app/post_redirect', crossorigin: 'anonymous', integrity: true) %>
 </head>
 <body>
   <%= form_tag '/auth/shopify', id: 'redirect-form' %>

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -17,6 +17,7 @@ module ShopifyApp
     initializer "shopify_app.assets.precompile" do |app|
       app.config.assets.precompile += %w[
         shopify_app/redirect.js
+        shopify_app/post_redirect.js
         shopify_app/top_level.js
         shopify_app/enable_cookies.js
         shopify_app/request_storage_access.js


### PR DESCRIPTION
This change adopts an earlier implementation we'd explored for the POST redirect page. Rather than embed the JS in an inline `script` tag, we're shipping it in a separate file.

This is an immediate response to an issue that was flagged in 18.0.0. This fix introduces a race condition for local dev environments. We don't love that, but it's more important to us to make sure that:

1. Our latest release doesn't have a feature that might be incompatible with a consumer's CSP
1. We still have a release out there that unblocks devs who want to update to the latest omniauth

### What this PR does

* Move JS for POST redirect back to separate file
* Add file to asset manifest

### Reviewer's guide to testing

* Install the gem on an existing app and verify that the oauth install flow still works
  * NOTE: If your local dev env uses the `cookie_store` session storage strategy, you may encounter 401 errors during oauth due to a race condition between asset requests and `/auth/shopify`. You should be able to work around for local testing by using a different browser or session storage strategy.
* Disabling source mapping in Chrome should eliminate the local dev race condition

### Things to focus on

* Does this change work for apps with Content Security Policies?
* Is the race condition described above acceptable? i.e. is it limited to local dev environments?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
