### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This gem includes a Rails engine, generators, modules, and mixins that help crea
 ## Requirements
 
 > **Rails compatibility** 
-> * Rails 6.1 or above is not yet supported due to the new `cookies_same_site_protection` setting. 
 > * Use Shopify App `<= v7.2.8` if you need to work with Rails 4.
 
 To become a Shopify app developer, you will need a [Shopify Partners](https://www.shopify.com/partners) account. Explore the [Shopify dev docs](https://shopify.dev/concepts/shopify-introduction) to learn more about [building Shopify apps](https://shopify.dev/concepts/apps).


### PR DESCRIPTION
Remove the incorrect disclaimer that says Rails 6.1 is not supported

### What this PR does

This PR removes an outdated disclaimer in the README.md file that suggests Rails 6.1 is not supported. This must have been missed in #1221 

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
