### PR TITLE
Make EnsureAuthenticatedLinks compatible with AppBridge 2

### DIFF
--- a/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
+++ b/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
@@ -10,9 +10,22 @@ module ShopifyApp
 
     private
 
+    def splash_page
+      splash_page_with_params(
+        return_to: request.fullpath,
+        shop: current_shopify_domain,
+        host: params[:host]
+      )
+    end
+
+    def splash_page_with_params(params)
+      uri = URI(root_path)
+      uri.query = params.compact.to_query
+      uri.to_s
+    end
+
     def redirect_to_splash_page
-      splash_page_path = root_path(return_to: request.fullpath, shop: current_shopify_domain)
-      redirect_to(splash_page_path)
+      redirect_to(splash_page)
     rescue ShopifyApp::LoginProtection::ShopifyDomainNotFound => error
       Rails.logger.warn("[ShopifyApp::EnsureAuthenticatedLinks] Redirecting to login: [#{error.class}] "\
                          "Could not determine current shop domain")

--- a/test/controllers/concerns/ensure_authenticated_links_test.rb
+++ b/test/controllers/concerns/ensure_authenticated_links_test.rb
@@ -44,6 +44,14 @@ class EnsureAuthenticatedLinksTest < ActionController::TestCase
     assert_redirected_to expected_path
   end
 
+  test 'redirects to splash page with a return_to, shop and host params if no session token is present' do
+    get :some_link, params: { shop: @shop_domain, host: 'test-host' }
+
+    expected_path = "/?host=test-host&return_to=#{CGI.escape(request.fullpath)}&shop=#{@shop_domain}"
+
+    assert_redirected_to expected_path
+  end
+
   test 'returns the requested resource if a valid session token exists' do
     request.env['jwt.shopify_domain'] = @shop_domain
 


### PR DESCRIPTION
### What this PR does

`EnsureAuthenticatedLinks` is currently broken and doesn't pass `host` header for `AppBridge 2`. As a result, all deep links in the app are broken.
![CleanShot 2021-06-05 at 20 21 22@2x](https://user-images.githubusercontent.com/839922/120900808-a6e1fe80-c63f-11eb-8996-67449f41bc29.png)

I added the missing "host" header to redirect to the splash page to fix it.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
