### PR TITLE
Fixed nested route for `EnsureAuthenticatedLinks`

### DIFF
--- a/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
+++ b/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
@@ -11,8 +11,9 @@ module ShopifyApp
     private
 
     def redirect_to_splash_page
-      splash_page_path = root_path(return_to: request.fullpath, shop: current_shopify_domain)
-      redirect_to(splash_page_path)
+      splash_page_path = URI(ShopifyApp.configuration.root_url)
+      splash_page_path.query = URI.encode_www_form(return_to: request.fullpath, shop: current_shopify_domain)
+      redirect_to(splash_page_path.to_s)
     rescue ShopifyApp::LoginProtection::ShopifyDomainNotFound => error
       Rails.logger.warn("[ShopifyApp::EnsureAuthenticatedLinks] Redirecting to login: [#{error.class}] "\
                          "Could not determine current shop domain")

--- a/test/controllers/concerns/ensure_authenticated_links_test.rb
+++ b/test/controllers/concerns/ensure_authenticated_links_test.rb
@@ -32,14 +32,29 @@ class EnsureAuthenticatedLinksTest < ActionController::TestCase
 
     Rails.application.routes.draw do
       root to: 'ensure_authenticated_links_test/turbolinks_test#root'
+      namespace :app do
+        root to: 'ensure_authenticated_links_test/turbolinks_test#root'
+      end
       get '/some_link', to: 'ensure_authenticated_links_test/turbolinks_test#some_link'
     end
   end
 
   test 'redirects to splash page with a return_to and shop param if no session token is present' do
+    ShopifyApp.configuration.root_url = '/'
+
     get :some_link, params: { shop: @shop_domain }
 
     expected_path = root_path(return_to: request.fullpath, shop: @shop_domain)
+
+    assert_redirected_to expected_path
+  end
+
+  test 'redirects to nested splash page with a return_to and shop param if no session token is present' do
+    ShopifyApp.configuration.root_url = '/app'
+
+    get :some_link, params: { shop: @shop_domain }
+
+    expected_path = app_root_path(return_to: request.fullpath, shop: @shop_domain)
 
     assert_redirected_to expected_path
   end


### PR DESCRIPTION
### What this PR does

<!-- Please describe what changes this PR introduces and why they're needed. -->
When a shopify app is using a nested route the `EnsureAuthenticatedLinks` concern does not redirect the user to the proper url when no session token is present.

This change ensures the `root_url` is used for redirection.

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->
1. Set `root_url` to "/app"
2. Create an `appSubscriptionCreate` mutation with a `returnUrl` for your app and redirect the user to `confirmationUrl`
3. Accept the charge
4. Get redirected back to the root of the Shopify app

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
