### PR TITLE
Fix #1182 | Changed regexp to match standard ngrok urls

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -67,7 +67,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           'config/environments/development.rb',
-          "  config.hosts = (config.hosts rescue []) << /\\w+\\.ngrok\\.io/\n",
+          "  config.hosts = (config.hosts rescue []) << /\[-\w]+\\.ngrok\\.io/\n",
           after: "Rails.application.configure do\n"
         )
       end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -98,7 +98,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "adds host config to development.rb" do
     run_generator
     assert_file "config/environments/development.rb" do |config|
-      assert_match "config.hosts = (config.hosts rescue []) << /\\w+\\.ngrok\\.io/", config
+      assert_match "config.hosts = (config.hosts rescue []) << /\[-\w]+\\.ngrok\\.io/", config
     end
   end
 


### PR DESCRIPTION
### What this PR does

I've changed the regexp used to whitelist requests. By default ngrok urls contains `-` but the regexp used at the moment only allows letters and numbers.

With this change requests to URLs like https://cee0-212-222-187-147.ngrok.io work

This issue was reported in #1182
