### PR TITLE
Add Ruby 3.0 compatibility to WebhooksController

### DIFF
--- a/app/controllers/shopify_app/webhooks_controller.rb
+++ b/app/controllers/shopify_app/webhooks_controller.rb
@@ -8,7 +8,7 @@ module ShopifyApp
     def receive
       params.permit!
       job_args = { shop_domain: shop_domain, webhook: webhook_params.to_h }
-      webhook_job_klass.perform_later(job_args)
+      (RUBY_VERSION.to_i >= 3) ? webhook_job_klass.perform_later(**job_args) : webhook_job_klass.perform_later(job_args)
       head(:ok)
     end
 


### PR DESCRIPTION
Adding mandatory double splat operators to args when Ruby 3.0 or later is detected.

### What this PR does

Webhooks fail when updating to Ruby 3.0, this is because Ruby now demands `**` prefix to args when passing in a hash to `.perform_later`.

[More info here](https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments)

### Reviewer's guide to testing

[Setup a webhook with generators](https://github.com/Shopify/shopify_app/blob/master/docs/shopify_app/webhooks.md), then test receiving webhooks with both Ruby 2.7.1 and Ruby 3.0.2 set in your .ruby-version file and Gemfile.

### Things to focus on

1. Without this change, on Ruby 3 an error message starting with the below should appear.
`wrong number of arguments (given 1, expected 0; required keywords: shop_domain, webhook)`
2. With this change it should not.
3. It looks like the `RUBY_VERSION` global variable is available on all Rails setups, however, this is my first time using it. It would be good to make sure this is always available and not coming from RVM. I can do some more research if this isn't known.

