### PR TITLE
Fixes tapioca generate error on uninitialized constant `ActiveJob`.

### DIFF
--- a/lib/shopify_app/jobs/scripttags_manager_job.rb
+++ b/lib/shopify_app/jobs/scripttags_manager_job.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'active_job'
+
 module ShopifyApp
   class ScripttagsManagerJob < ActiveJob::Base
     queue_as do

--- a/lib/shopify_app/jobs/webhooks_manager_job.rb
+++ b/lib/shopify_app/jobs/webhooks_manager_job.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'active_job'
+
 module ShopifyApp
   class WebhooksManagerJob < ActiveJob::Base
     queue_as do


### PR DESCRIPTION

### What this PR does
This commit fixes [this error](https://discourse.shopify.io/t/error-when-running-tapioca-gem-all-uninitialized-constant-shopifyapp-activejob-nameerror/20657) that comes up when running tapioca.

<!-- Please describe what changes this PR introduces and why they're needed. -->

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

### Things to focus on

1. <!-- Focus on a particular file -->
2. <!-- Is the test case correct? -->
3. <!-- Etc. -->

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
