### PR TITLE
Fix the ArgumentError in Ruby 3 in WebhooksController

### DIFF
--- a/app/controllers/shopify_app/webhooks_controller.rb
+++ b/app/controllers/shopify_app/webhooks_controller.rb
@@ -8,7 +8,7 @@ module ShopifyApp
     def receive
       params.permit!
       job_args = { shop_domain: shop_domain, webhook: webhook_params.to_h }
-      webhook_job_klass.perform_later(job_args)
+      webhook_job_klass.perform_later(**job_args)
       head(:ok)
     end
 


### PR DESCRIPTION
### What this PR does

According to the following page;
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

In Ruby 3.0, positional arguments and keyword arguments will be separated.

This PR added a double splash operated in the WebhooksController. 
Here is another discussion on this: https://stackoverflow.com/questions/68449752/argumenterror-after-updating-from-ruby-2-7-to-ruby-3-0-1

### Reviewer's guide to testing

Create a new app on Ruby 3 with `shopify rails create` and Create webhooks with `shopify rails generate webhook`.
There is another issue that it the webhook creation this way adds the following config to `config/initializers/shopify_app.rb`

```
 config.webhooks = [
      {topic: 'products/update', address: 'https://532d-2405-201-3017-2064-dc35-eadf-c815-23d0.ngrok.io/webhooks/products/update', format: 'json'},
    ]
```

This seems to not work as it tries to find `/webhooks/products/update` route (Job name generated is also not correct though, `UpdateJob`)
But changing the above config to following (also changing the Job name to correct one, here `ProductsUpdateJob`) :
```
 config.webhooks = [
      {topic: 'products/update', address: 'https://532d-2405-201-3017-2064-dc35-eadf-c815-23d0.ngrok.io/webhooks/products_update', format: 'json'},
    ]
```

You'll have to have a background processor running to check this, I tested this on Sidekiq and says 
```
ArgumentError: wrong number of arguments (given 1, expected 0; required keywords: shop_domain, webhook)
```

The above error can be fixed with a double-splat operator! The job should work in ruby 3

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
