### PR TITLE
Update app proxy verification to support Old Secret

### DIFF
--- a/lib/shopify_app/controller_concerns/app_proxy_verification.rb
+++ b/lib/shopify_app/controller_concerns/app_proxy_verification.rb
@@ -20,17 +20,20 @@ module ShopifyApp
       return false if signature.nil?
 
       ActiveSupport::SecurityUtils.secure_compare(
-        calculated_signature(query_hash),
+        calculated_signature(query_hash, ShopifyApp.configuration.secret),
+        signature
+      ) || ActiveSupport::SecurityUtils.secure_compare(
+        calculated_signature(query_hash, ShopifyApp.configuration.old_secret),
         signature
       )
     end
 
-    def calculated_signature(query_hash_without_signature)
+    def calculated_signature(query_hash_without_signature, secret)
       sorted_params = query_hash_without_signature.collect { |k, v| "#{k}=#{Array(v).join(',')}" }.sort.join
 
       OpenSSL::HMAC.hexdigest(
         OpenSSL::Digest.new('sha256'),
-        ShopifyApp.configuration.secret,
+        secret,
         sorted_params
       )
     end


### PR DESCRIPTION
Currently app proxy does not properly verify if the app has an old secret. 
Implemented this fix to make it support Old Secret.
For me just replacing ShopifyApp.configuration.secret with ShopifyApp.configuration.old_secret in calculated_signature worked, but it might not work for all.

### What this PR does

This PR checks both new and old secret keys while doing app proxy verification.

### Reviewer's guide to testing

Create a new Shopify app, set it up to use app proxy, issue a new secret, in the app proxy verification the current secret does not work. But the old secret works. This looks more like an issue for the the Shopify system than the gem but this fix gets things working.

