### PR TITLE
Update arbitrary domain names used in our documentation to a reserved second level domain name

### DIFF
--- a/docs/shopify_app/engine.md
+++ b/docs/shopify_app/engine.md
@@ -15,7 +15,7 @@ While you can customize the login view by creating a `/app/views/shopify_app/ses
 
 ```ruby
 ShopifyApp.configure do |config|
-  config.login_url = 'https://my.domain.com/nested/login'
+  config.login_url = 'https://example.com/nested/login'
 end
 ```
 
@@ -77,6 +77,6 @@ class ReviewsController < ApplicationController
 end
 ```
 
-Create your app proxy URL in the [Shopify Partners dashboard](https://partners.shopify.com/organizations), making sure to point it to `https://your_app_website.com/app_proxy`.
+Create your app proxy URL in the [Shopify Partners dashboard](https://partners.shopify.com/organizations), making sure to point it to `https://example.com/app_proxy`.
 
 ![Creating an App Proxy](/images/app-proxy-screenshot.png)

--- a/docs/shopify_app/script-tags.md
+++ b/docs/shopify_app/script-tags.md
@@ -11,7 +11,7 @@ As with webhooks, ShopifyApp can manage your app's [ScriptTags](https://shopify-
 ```ruby
 ShopifyApp.configure do |config|
   config.scripttags = [
-    {event:'onload', src: 'https://my-shopifyapp.herokuapp.com/fancy.js'},
+    {event:'onload', src: 'https://example.com/fancy.js'},
     {event:'onload', src: ->(domain) { dynamic_tag_url(domain) } }
   ]
 end

--- a/docs/shopify_app/webhooks.md
+++ b/docs/shopify_app/webhooks.md
@@ -12,7 +12,7 @@ ShopifyApp can manage your app's webhooks for you if you set which webhooks you 
 ```ruby
 ShopifyApp.configure do |config|
   config.webhooks = [
-    {topic: 'carts/update', address: 'https://example-app.com/webhooks/carts_update'}
+    {topic: 'carts/update', address: 'https://example.com/webhooks/carts_update'}
   ]
 end
 ```
@@ -34,7 +34,7 @@ If you are only interested in particular fields, you can optionally filter the d
 ```ruby
 ShopifyApp.configure do |config|
   config.webhooks = [
-    {topic: 'products/update', address: 'https://example-app.com/webhooks/products_update', fields: ['title', 'vendor']}
+    {topic: 'products/update', address: 'https://example.com/webhooks/products_update', fields: ['title', 'vendor']}
   ]
 end
 ```


### PR DESCRIPTION
### What this PR does
Our documentation is using arbitrary domain names in its code snippets and to eliminate the risk of having an app developer miss-configuring their application with these, we should use invalid hosts in our examples.

I've used `example.com` which is a reserved domain: https://en.wikipedia.org/wiki/Example.com

### Things to focus on
1. Any typo?
2. Did I miss any other arbitrary domain names that we use in our `.md` files? 
