### PR TITLE
Fix config.hosts to use a regex that matches ngrok.io subdomains

### DIFF
--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -67,7 +67,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           'config/environments/development.rb',
-          "  config.hosts = (config.hosts rescue []) << /\\w+\\.ngrok\\.io/\n",
+          "  config.hosts = (config.hosts rescue []) << /.+\\.ngrok\\.io/\n",
           after: "Rails.application.configure do\n"
         )
       end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -98,7 +98,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "adds host config to development.rb" do
     run_generator
     assert_file "config/environments/development.rb" do |config|
-      assert_match "config.hosts = (config.hosts rescue []) << /\\w+\\.ngrok\\.io/", config
+      assert_match "config.hosts = (config.hosts rescue []) << /.+\\.ngrok\\.io/", config
     end
   end
 


### PR DESCRIPTION
### What this PR does

Allows one to use ngrok's free tier with embedded apps. 

### Reviewer's guide to testing


- Create embedded app
- `rails s`
- `ngrok http 3000`

Without my change host validation fails. Per [the Rails guide (6.1)](https://guides.rubyonrails.org/v6.1/configuring.html#configuring-middleware): 

    The provided regexp will be wrapped with both anchors (\A and \z) so it must match the entire hostname. /product.com/, for example, once anchored, would fail to match www.product.com.

ngrok hosnames include hyphens, e.g., `1a07-138-51-91-7.ngrok.io`. Prior to my change `\w` was used which includes `[0-9a-zA-Z_]` **not hyphen** (`-`). 

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users 
- [ ] Update `README.md`, if appropriate.

(This should not be done by PR author but by maintainer IMHO)
