### PR TITLE
Add AppBridgeMiddleware

### DIFF
--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -46,6 +46,7 @@ module ShopifyApp
   require 'shopify_app/managers/scripttags_manager'
 
   # middleware
+  require 'shopify_app/middleware/app_bridge_middleware'
   require 'shopify_app/middleware/jwt_middleware'
   require 'shopify_app/middleware/same_site_cookie_middleware'
 

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -27,9 +27,10 @@ module ShopifyApp
 
     initializer "shopify_app.middleware" do |app|
       app.config.middleware.insert_after(::Rack::Runtime, ShopifyApp::SameSiteCookieMiddleware)
+      app.config.middleware.insert_after(ShopifyApp::SameSiteCookieMiddleware, ShopifyApp::AppBridgeMiddleware)
 
       if ShopifyApp.configuration.allow_jwt_authentication
-        app.config.middleware.insert_after(ShopifyApp::SameSiteCookieMiddleware, ShopifyApp::JWTMiddleware)
+        app.config.middleware.insert_after(ShopifyApp::AppBridgeMiddleware, ShopifyApp::JWTMiddleware)
       end
     end
 

--- a/lib/shopify_app/middleware/app_bridge_middleware.rb
+++ b/lib/shopify_app/middleware/app_bridge_middleware.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module ShopifyApp
+  class AppBridgeMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+
+      if request.params.has_key?("shop") && !request.params.has_key?("host")
+        shop = request.params["shop"]
+        host = Base64.urlsafe_encode64("#{shop}/admin", padding: false)
+        request.update_param("host", host)
+      end
+
+      @app.call(env)
+    end
+  end
+end

--- a/test/shopify_app/middleware/app_bridge_middleware_test.rb
+++ b/test/shopify_app/middleware/app_bridge_middleware_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ShopifyApp::AppBridgeMiddlewareTest < ActiveSupport::TestCase
+  def simple_app
+    lambda { |env|
+      [200, { "Content-Type" => "text/plain" }, ["OK"]]
+    }
+  end
+
+  def app
+    Rack::Lint.new(ShopifyApp::AppBridgeMiddleware.new(simple_app))
+  end
+
+  test "adds missing host params" do
+    env = Rack::MockRequest.env_for('https://example.com', params: { shop: "test-shop.myshopify.com" })
+
+    app.call(env)
+
+    assert_equal "dGVzdC1zaG9wLm15c2hvcGlmeS5jb20vYWRtaW4", env["rack.request.query_hash"]["host"]
+  end
+end


### PR DESCRIPTION
### What this PR does

When the app is installed via "Add app" button from the app store listing Shopify redirects the user to the login page without `host` param:
<img width="1094" alt="CleanShot 2022-01-07 at 18 47 36@2x" src="https://user-images.githubusercontent.com/839922/148572832-deebf5cb-56f4-4686-8ae6-e939c1cef0ea.png">

As a result, the app gets `AppBridge2 error` on the frontend and the user is stuck on the Splash screen. I had issues with this on production after AppBridge2.0 upgrade. I was talking with Shopify Partner support about this behavior and they said it's not a bug but the intended behavior 🤷‍♂️ Until this will change we need a middleware that will generate `host` from the `shop` param on the fly.