### PR TITLE
Add Rails 7.0 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       jwt (>= 2.2.3)
       omniauth-rails_csrf_protection
       omniauth-shopify-oauth2 (~> 2.3)
-      rails (> 5.2.1, < 6.2)
+      rails (> 5.2.1)
       redirect_safely (~> 1.0)
       shopify_api (~> 9.4)
 
@@ -281,4 +281,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.22
+   2.2.32

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('browser_sniffer', '~> 1.4.0')
   s.add_runtime_dependency('omniauth-rails_csrf_protection')
-  s.add_runtime_dependency('rails', '> 5.2.1', '< 6.2')
+  s.add_runtime_dependency('rails', '> 5.2.1')
   s.add_runtime_dependency('shopify_api', '~> 9.4')
   s.add_runtime_dependency('omniauth-shopify-oauth2', '~> 2.3')
   s.add_runtime_dependency('jwt', '>= 2.2.3')


### PR DESCRIPTION
Removed upper bound Rails version to make it easier to upgrade in the future. This follows similar changes in `shopify_api` gem: https://github.com/Shopify/shopify_api/pull/891