### PR TITLE
Packaging for release v18.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+18.0.4 (Jan 27, 2022)
+----------
+* Use App Bridge client for redirect [#1247](https://github.com/Shopify/shopify_app/pull/1247)
+  * Replaces deprecated EASDK with App Bridge when redirecting out of an embedded iframe.
+
 18.0.3 (Jan 7, 2022)
 ----------
 * Change regexp to match standard ngrok URLs. [#1311](https://github.com/Shopify/shopify_app/pull/1311)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (18.0.3)
+    shopify_app (18.0.4)
       browser_sniffer (~> 1.4.0)
       jwt (>= 2.2.3)
       omniauth-rails_csrf_protection
@@ -281,4 +281,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.22
+   2.2.29

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '18.0.3'
+  VERSION = '18.0.4'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "18.0.3",
+  "version": "18.0.4",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
### What this PR does

This is a patch release that includes the following change:

* Use App Bridge client for redirect [#1247](https://github.com/Shopify/shopify_app/pull/1247)
  * Replaces deprecated EASDK with App Bridge when redirecting out of an embedded iframe.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
