### PR TITLE
Check for `spin.dev` URLs in shopify domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 * Support Rails 7 [#1354](https://github.com/Shopify/shopify_app/pull/1354)
 * Fix webhooks handling in Ruby 3 [#1342](https://github.com/Shopify/shopify_app/pull/1342) 
 * Update to Ruby 3 and drop support to Ruby 2.5 [#1359](https://github.com/Shopify/shopify_app/pull/1359)
+* Support `spin.dev` domain URLs [#1358](https://github.com/Shopify/shopify_app/pull/1358)
 
 18.0.4 (Jan 27, 2022)
 ----------

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -3,12 +3,17 @@ module ShopifyApp
   module Utils
     def self.sanitize_shop_domain(shop_domain)
       myshopify_domain = ShopifyApp.configuration.myshopify_domain
+      spin_domain = 'spin.dev'
       name = shop_domain.to_s.downcase.strip
       name += ".#{myshopify_domain}" if !name.include?(myshopify_domain.to_s) && !name.include?(".")
       name.sub!(%r|https?://|, '')
 
       u = URI("http://#{name}")
-      u.host if u.host&.match(/^[a-z0-9][a-z0-9\-]*[a-z0-9]\.#{Regexp.escape(myshopify_domain)}$/)
+      result = u.host if u.host&.match(/^[a-z0-9][a-z0-9\-]*[a-z0-9]\.#{Regexp.escape(myshopify_domain)}$/)
+      if result.blank? && u.host&.end_with?(spin_domain)
+        result = u.host
+      end
+      result
     rescue URI::InvalidURIError
       nil
     end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -14,6 +14,12 @@ class UtilsTest < ActiveSupport::TestCase
     end
   end
 
+  ['shop1.shopify.abc1.john-doe.us.spin.dev', 'https://shop1.shopify.def2.jane-doe.us.spin.dev'].each do |good_url|
+    test "sanitize_shop_domain for (#{good_url})" do
+      assert ShopifyApp::Utils.sanitize_shop_domain(good_url)
+    end
+  end
+
   ['my-shop', 'my-shop.myshopify.io', 'https://my-shop.myshopify.io', 'http://my-shop.myshopify.io'].each do |good_url|
     test "sanitize_shop_domain URL (#{good_url}) with custom myshopify_domain" do
       ShopifyApp.configuration.myshopify_domain = 'myshopify.io'


### PR DESCRIPTION
### What this PR does

Launching Shopify Core in spin results in a Shopify domain URL of the style `shop1.shopify.{spin-workspace-id}.{user-name}.us.spin.dev` which is different from the currently expected URLs of type `*.myshopify.com`.

### Reviewer's guide to testing



### Things to focus on

1. Logic change in `lib/shopify_app/utils.rb`

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
