### PR TITLE
Set status to see_other when request is not GET for fullpage_redirect_to

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -183,7 +183,8 @@ module ShopifyApp
 
     def fullpage_redirect_to(url)
       if ShopifyApp.configuration.embedded_app?
-        render('shopify_app/shared/redirect', layout: false,
+        status = request.get? ? :found : :see_other
+        render('shopify_app/shared/redirect', layout: false, status: status,
                locals: { url: url, current_shopify_domain: current_shopify_domain })
       else
         redirect_to(url)

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -407,6 +407,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     with_application_test_routes do
       example_shop = 'shop.myshopify.com'
       get :redirect, params: { shop: example_shop }
+      assert_equal 302, response.status
       assert_fullpage_redirected(example_shop, response)
     end
   end
@@ -446,6 +447,24 @@ class LoginProtectionControllerTest < ActionController::TestCase
       get :redirect, params: { shop: example_shop }
       rendered_templates = @_templates.keys
       assert_equal(['shopify_app/shared/redirect'], rendered_templates)
+    end
+  end
+
+  test '#fullpage_redirect_to redirects using 303 for post' do
+    with_application_test_routes do
+      example_shop = 'shop.myshopify.com'
+      post :redirect, params: { shop: example_shop }
+      assert_equal 303, response.status
+      assert_fullpage_redirected(example_shop, response)
+    end
+  end
+
+  test '#fullpage_redirect_to redirects using 303 for delete' do
+    with_application_test_routes do
+      example_shop = 'shop.myshopify.com'
+      delete :redirect, params: { shop: example_shop }
+      assert_equal 303, response.status
+      assert_fullpage_redirected(example_shop, response)
     end
   end
 
@@ -502,6 +521,8 @@ class LoginProtectionControllerTest < ActionController::TestCase
         get '/' => 'login_protection#index'
         get '/second_login' => 'login_protection#second_login'
         get '/redirect' => 'login_protection#redirect'
+        post '/redirect' => 'login_protection#redirect'
+        delete '/redirect' => 'login_protection#redirect'
         get '/raise_unauthorized' => 'login_protection#raise_unauthorized'
         get '/index_with_headers' => 'login_protection#index_with_headers'
       end


### PR DESCRIPTION
### What this PR does

This PR changes the HTTP response status to 303 (see other) when using `fullpage_redirect_to` from a method that was not requested via GET. This is useful when using Turbo so that it renders the redirect view instead of returning the error: `Form responses must redirect to another location`.

See: https://github.com/hotwired/turbo/issues/84

### Reviewer's guide to testing

1. Clone this branch
1. In a terminal, use [Shopify CLI](https://shopify.dev/tools/cli) to create and configure a new rails app: `shopify app create rails`
1. In an editor, open the `Gemfile` inside the newly created app
1. Modify the entry to `shopify_app` to point to this branch in your local environment so that it looks similar to this: `gem 'shopify_app', path: '~/src/github.com/Shopify/shopify_app'`
1. In a terminal, start your app server with `shopify app serve`, this will also output a ngrok url
1. In a browser, follow the ngrok url to install the app on a test store. It should look similar to this: `https://1587ef2f72d5.ngrok.io/login?shop=sabotender-shop.myshopify.com`
1. On your local environment, remove the `shop` entry for the store inside the db
1. In a browser, open the installed app. i.e. `https://sabotender-shop.myshopify.com/admin/apps/test-app-1`
1. Ensure that the entire redirect flow takes the browser back to the app.

### Things to focus on

1. Focus on install flow

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
