### PR TITLE
Bump shopify_api to v10.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ gemspec
 
 gem "rails-controller-testing", group: :test
 
-# TODO: remove this when shopify_api is added back to the gemspec
-gem "shopify_api", git: "https://github.com/Shopify/shopify_api.git"
-
 group :rubocop do
   gem "rubocop-shopify", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/Shopify/shopify_api.git
-  revision: 84492422b3e83f1ec51ec7e1f56c43a8e30b357a
-  specs:
-    shopify_api (0.0.1)
-      concurrent-ruby
-      hash_diff
-      httparty
-      jwt
-      oj
-      openssl
-      securerandom
-      sorbet-runtime
-      zeitwerk (~> 2.5)
-
 PATH
   remote: .
   specs:
@@ -22,6 +7,7 @@ PATH
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
+      shopify_api (~> 10.0)
       sprockets-rails (>= 2.0.0)
 
 GEM
@@ -103,7 +89,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -208,7 +194,17 @@ GEM
       rubocop (~> 1.24)
     ruby-progressbar (1.11.0)
     securerandom (0.2.0)
-    sorbet-runtime (0.5.9760)
+    shopify_api (10.0.0)
+      concurrent-ruby
+      hash_diff
+      httparty
+      jwt
+      oj
+      openssl
+      securerandom
+      sorbet-runtime
+      zeitwerk (~> 2.5)
+    sorbet-runtime (0.5.9837)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -244,7 +240,6 @@ DEPENDENCIES
   rake
   rb-readline
   rubocop-shopify
-  shopify_api!
   shopify_app!
   sqlite3 (~> 1.4)
   webmock

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -14,12 +14,12 @@ Gem::Specification.new do |s|
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  s.add_runtime_dependency("browser_sniffer", "~> 1.4.0")
-  s.add_runtime_dependency("rails", "> 5.2.1") # TODO: Remove this upperbound before merging back to main
-  # s.add_runtime_dependency('shopify_api', '~> 9.4') # TODO: Replace this with new gem version when released
   s.add_runtime_dependency("activeresource") # TODO: Remove this once all active resource dependencies are removed
+  s.add_runtime_dependency("browser_sniffer", "~> 1.4.0")
   s.add_runtime_dependency("jwt", ">= 2.2.3")
+  s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
+  s.add_runtime_dependency("shopify_api", "~> 10.0")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
 
   s.add_development_dependency("byebug")


### PR DESCRIPTION
This PR updates the dependency on the `shopify_api` gem to the newly released v10 🎉 