### PR TITLE
Fixing online token creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+----------
+* Fix regression in apps using online tokens. [#1413](https://github.com/Shopify/shopify_app/pull/1413)
+
 19.0.1 (April 11, 2022)
 ----------
 * Bump Shopify API (https://github.com/Shopify/shopify_api) to version 10.0.2. This update includes patch fixes since the initial v10 release.

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -56,10 +56,10 @@ module ShopifyApp
     def start_user_token_flow?(shopify_session)
       return false unless ShopifyApp::SessionRepository.user_storage.present?
       return false if shopify_session.online?
-      update_user_access_scopes?(shopify_session)
+      update_user_access_scopes?
     end
 
-    def update_user_access_scopes?(shopify_session)
+    def update_user_access_scopes?
       return true if session[:shopify_user_id].nil?
       user_access_scopes_strategy.update_access_scopes?(shopify_user_id: session[:shopify_user_id])
     end

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -55,7 +55,7 @@ module ShopifyApp
 
     def start_user_token_flow?(shopify_session)
       return false unless ShopifyApp::SessionRepository.user_storage.present?
-      return false if shopify_session.is_online?
+      return false if shopify_session.online?
       update_user_access_scopes?
     end
 

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -55,7 +55,7 @@ module ShopifyApp
 
     def start_user_token_flow?(shopify_session)
       return false unless ShopifyApp::SessionRepository.user_storage.present?
-      return false if shopify_session.online?
+      return false if shopify_session.is_online?
       update_user_access_scopes?
     end
 

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -232,7 +232,13 @@ module ShopifyApp
       current_shopify_session && params[:shop].is_a?(String) && current_shopify_session.shop != params[:shop]
     end
 
+    def shop_session
+      ShopifyApp::SessionRepository.retrieve_shop_session_by_shopify_domain(sanitize_shop_param(params))
+    end
+
     def user_session_expected?
+      return false if shop_session.nil?
+      return false if ShopifyApp.configuration.shop_access_scopes_strategy.update_access_scopes?(shop_session.shop)
       !ShopifyApp.configuration.user_session_repository.blank? && ShopifyApp::SessionRepository.user_storage.present?
     end
   end

--- a/lib/shopify_app/session/session_repository.rb
+++ b/lib/shopify_app/session/session_repository.rb
@@ -46,7 +46,7 @@ module ShopifyApp
       # ShopifyAPI::Auth::SessionStorage override
       def store_session(session)
         if session.online?
-          user_storage.store(session, session.associated_user.id.to_s)
+          user_storage.store(session, session.associated_user)
         else
           shop_storage.store(session)
         end

--- a/lib/shopify_app/session/user_session_storage_with_scopes.rb
+++ b/lib/shopify_app/session/user_session_storage_with_scopes.rb
@@ -11,7 +11,7 @@ module ShopifyApp
 
     class_methods do
       def store(auth_session, user)
-        user = find_or_initialize_by(shopify_user_id: user[:id])
+        user = find_or_initialize_by(shopify_user_id: user.id)
         user.shopify_token = auth_session.access_token
         user.shopify_domain = auth_session.shop
         user.access_scopes = auth_session.scope.to_s

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -113,16 +113,11 @@ module ShopifyApp
     test "#new starts OAuth requesting online token if user session is expected and there is a shop session" do
       shop = "my-shop.myshopify.com"
 
-      mock_session = mock
-      mock_session.stubs(:shop).returns(shop)
-      mock_session.stubs(:access_token).returns("a-new-user_token!")
-      mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new("read_products,write_orders"))
-
       ShopifyApp::SessionRepository.user_storage = ShopifyApp::InMemoryUserSessionStore
       ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
       ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
         .with(shop)
-        .returns(mock_session)
+        .returns(mock_session(shop: shop))
 
       ShopifyAPI::Auth::Oauth.expects(:begin_auth)
         .with(shop: shop, redirect_path: "/auth/shopify/callback", is_online: true)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -97,17 +97,41 @@ module ShopifyApp
       assert_redirected_to "/auth-route"
     end
 
-    test "#new starts OAuth requesting online token if user session is expected" do
+    test "#new starts OAuth requesting offline token if user session is expected but there is no shop session" do
       ShopifyApp::SessionRepository.user_storage = ShopifyApp::InMemoryUserSessionStore
 
       ShopifyAPI::Auth::Oauth.expects(:begin_auth)
-        .with(shop: "my-shop.myshopify.com", redirect_path: "/auth/shopify/callback", is_online: true)
+        .with(shop: "my-shop.myshopify.com", redirect_path: "/auth/shopify/callback", is_online: false)
         .returns({
           cookie: ShopifyAPI::Auth::Oauth::SessionCookie.new(value: "", expires: Time.now),
           auth_route: "/auth-route",
         })
 
       get :new, params: { shop: "my-shop", top_level: true }
+    end
+
+    test "#new starts OAuth requesting online token if user session is expected and there is a shop session" do
+      shop = "my-shop.myshopify.com"
+
+      mock_session = mock
+      mock_session.stubs(:shop).returns(shop)
+      mock_session.stubs(:access_token).returns("a-new-user_token!")
+      mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new("read_products,write_orders"))
+
+      ShopifyApp::SessionRepository.user_storage = ShopifyApp::InMemoryUserSessionStore
+      ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
+      ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
+        .with(shop)
+        .returns(mock_session)
+
+      ShopifyAPI::Auth::Oauth.expects(:begin_auth)
+        .with(shop: shop, redirect_path: "/auth/shopify/callback", is_online: true)
+        .returns({
+          cookie: ShopifyAPI::Auth::Oauth::SessionCookie.new(value: "", expires: Time.now),
+          auth_route: "/auth-route",
+        })
+
+      get :new, params: { shop: shop, top_level: true }
     end
 
     test "#new starts OAuth requesting online token if user session is unexpected" do

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -4,11 +4,18 @@ class ShopifyAppConfigurer
   def self.call
     ShopifyApp.configure do |config|
       config.api_key = "key"
+      config.old_secret = nil
       config.secret = "secret"
       config.scope = "read_orders, read_products"
+      config.shop_access_scopes = nil
+      config.user_access_scopes = nil
       config.embedded_app = true
       config.myshopify_domain = "myshopify.com"
       config.api_version = :unstable
+
+      config.shop_session_repository = ShopifyApp::InMemorySessionStore
+      config.after_authenticate_job = false
+      config.reauth_on_access_scope_changes = true
     end
   end
 end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -63,7 +63,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     shop = "my-shop.myshopify.com"
     ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
       .with(shop)
-      .returns(mock_session(shop))
+      .returns(mock_session(shop: shop))
 
     cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     request.headers["HTTP_AUTHORIZATION"] = "Bearer token"
@@ -169,7 +169,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     shop = "my-shop.myshopify.com"
     ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
       .with(shop)
-      .returns(mock_session(shop))
+      .returns(mock_session(shop: shop))
     ShopifyAPI::Context.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(["scope1", "scope2"]))
 
     cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
@@ -197,7 +197,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     shop = "my-shop.myshopify.com"
     ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
       .with(shop)
-      .returns(mock_session(shop))
+      .returns(mock_session(shop: shop))
     ShopifyAPI::Context.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(["scope1"]))
 
     cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
@@ -452,15 +452,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
     yield
   ensure
     ShopifyApp.configure { |config| config.login_url = original_url }
-  end
-
-  def mock_session(shop = "my-shop.myshopify.com")
-    mock_session = mock
-    mock_session.stubs(:shop).returns(shop)
-    mock_session.stubs(:access_token).returns("a-new-user_token!")
-    mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new("read_products,write_orders"))
-
-    mock_session
   end
 
   def mock_associated_user

--- a/test/shopify_app/session/session_repository_test.rb
+++ b/test/shopify_app/session/session_repository_test.rb
@@ -106,7 +106,7 @@ module ShopifyApp
       user = mock_associated_user
       session.stubs(:associated_user).returns(user)
 
-      InMemoryUserSessionStore.expects(:store).with(session, user.id.to_s)
+      InMemoryUserSessionStore.expects(:store).with(session, user)
 
       SessionRepository.store_session(session)
     end

--- a/test/shopify_app/session/shop_session_storage_test.rb
+++ b/test/shopify_app/session/shop_session_storage_test.rb
@@ -49,6 +49,7 @@ module ShopifyApp
       mock_auth_hash = mock
       mock_auth_hash.stubs(:shop).returns(mock_shop_instance.shopify_domain)
       mock_auth_hash.stubs(:access_token).returns("a-new-token!")
+      mock_auth_hash.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new("read_products,write_orders"))
       saved_id = ShopMockSessionStore.store(mock_auth_hash)
 
       assert_equal "a-new-token!", mock_shop_instance.shopify_token

--- a/test/shopify_app/session/user_session_storage_test.rb
+++ b/test/shopify_app/session/user_session_storage_test.rb
@@ -54,6 +54,7 @@ module ShopifyApp
       mock_auth_hash = mock
       mock_auth_hash.stubs(:shop).returns(mock_user_instance.shopify_domain)
       mock_auth_hash.stubs(:access_token).returns("a-new-user_token!")
+      mock_auth_hash.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new("read_products,write_orders"))
 
       associated_user = {
         id: 100,

--- a/test/shopify_app/session/user_session_storage_with_scopes_test.rb
+++ b/test/shopify_app/session/user_session_storage_with_scopes_test.rb
@@ -57,16 +57,12 @@ module ShopifyApp
 
       UserMockSessionStoreWithScopes.stubs(:find_or_initialize_by).returns(mock_user_instance)
 
-      mock_auth_hash = mock
-      mock_auth_hash.stubs(:shop).returns(mock_user_instance.shopify_domain)
-      mock_auth_hash.stubs(:access_token).returns("a-new-user_token!")
-      mock_auth_hash.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(TEST_MERCHANT_SCOPES))
+      mock_session = mock
+      mock_session.stubs(:shop).returns(mock_user_instance.shopify_domain)
+      mock_session.stubs(:access_token).returns("a-new-user_token!")
+      mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(TEST_MERCHANT_SCOPES))
 
-      associated_user = {
-        id: 100,
-      }
-
-      saved_id = UserMockSessionStoreWithScopes.store(mock_auth_hash, user: associated_user)
+      saved_id = UserMockSessionStoreWithScopes.store(mock_session, mock_associated_user)
 
       assert_equal "a-new-user_token!", mock_user_instance.shopify_token
       assert_equal mock_user_instance.id, saved_id
@@ -98,6 +94,21 @@ module ShopifyApp
       assert_raises NotImplementedError do
         UserMockSessionStoreWithScopes.retrieve(1)
       end
+    end
+
+    private
+
+    def mock_associated_user
+      ShopifyAPI::Auth::AssociatedUser.new(
+        id: 100,
+        first_name: "John",
+        last_name: "Doe",
+        email: "johndoe@email.com",
+        email_verified: true,
+        account_owner: false,
+        locale: "en",
+        collaborator: true
+      )
     end
   end
 end

--- a/test/shopify_app/session/user_session_storage_with_scopes_test.rb
+++ b/test/shopify_app/session/user_session_storage_with_scopes_test.rb
@@ -57,12 +57,13 @@ module ShopifyApp
 
       UserMockSessionStoreWithScopes.stubs(:find_or_initialize_by).returns(mock_user_instance)
 
-      mock_session = mock
-      mock_session.stubs(:shop).returns(mock_user_instance.shopify_domain)
-      mock_session.stubs(:access_token).returns("a-new-user_token!")
-      mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(TEST_MERCHANT_SCOPES))
-
-      saved_id = UserMockSessionStoreWithScopes.store(mock_session, mock_associated_user)
+      saved_id = UserMockSessionStoreWithScopes.store(
+        mock_session(
+          shop: mock_user_instance.shopify_domain,
+          scope: TEST_MERCHANT_SCOPES
+        ),
+        mock_associated_user
+      )
 
       assert_equal "a-new-user_token!", mock_user_instance.shopify_token
       assert_equal mock_user_instance.id, saved_id

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,17 @@ class ActiveSupport::TestCase
     super
     WebMock.disable_net_connect!
     WebMock.stub_request(:get, "https://app.shopify.com/services/apis.json").to_return(body: API_META_TEST_RESPONSE)
+    ShopifyApp::InMemorySessionStore.clear
     ShopifyAppConfigurer.call
     Rails.application.reload_routes!
+  end
+
+  def mock_session(shop: "my-shop.myshopify.com", scope: ShopifyApp.configuration.scope)
+    mock_session = mock
+    mock_session.stubs(:shop).returns(shop)
+    mock_session.stubs(:access_token).returns("a-new-user_token!")
+    mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(scope))
+
+    mock_session
   end
 end


### PR DESCRIPTION
### What this PR does

We unintentionally dropped some important functionality from this gem as part of our updates of `shopify_api`: the OAuth flow was expected to create _both_ an offline and an online tokens when using user storage, but the updated flow was only doing one of them.

This PR walks that back by adding back the behaviour of first getting an offline token, then an online token, then completing the OAuth process, but only in cases where online tokens are required - offline flows remain the same (only a shop is added to the DB).

### Reviewer's guide to testing

1. Create a new app with the CLI
2. Run `rails generate shopify_app:user_model`
3. Add `config.user_session_repository = 'User'` in shopify_app.rb
4. `shopify app serve` => go through login

### Things to focus on

1. Does oauth work for online tokens?
2. Does oauth work for offline tokens?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [X] Update `CHANGELOG.md` if the changes would impact users
