### PR TITLE
Allow ngrok URLs to include a region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Fix "allowed hosts" configuration for ngrok URLs including a region such as `eu`.
+
 19.0.2 (April 27, 2022)
 ----------
 

--- a/lib/generators/shopify_app/install/install_generator.rb
+++ b/lib/generators/shopify_app/install/install_generator.rb
@@ -53,7 +53,7 @@ module ShopifyApp
       def insert_hosts_into_development_config
         inject_into_file(
           "config/environments/development.rb",
-          "  config.hosts = (config.hosts rescue []) << /\[-\\w]+\\.ngrok\\.io/\n",
+          "  config.hosts = (config.hosts rescue []) << /\[-\\w\\.]+\\.ngrok\\.io/\n",
           after: "Rails.application.configure do\n"
         )
       end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -97,7 +97,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "adds host config to development.rb" do
     run_generator
     assert_file "config/environments/development.rb" do |config|
-      assert_match "config.hosts = (config.hosts rescue []) << /\[-\\w]+\\.ngrok\\.io/", config
+      assert_match "config.hosts = (config.hosts rescue []) << /\[-\\w\\.]+\\.ngrok\\.io/", config
     end
   end
 end


### PR DESCRIPTION
### What this PR does

If you're located in Europe, the ngrok URL includes an additonal `.eu`. Example: `https://a368-128-935-524-36.eu.ngrok.io`

The allowed host configuration of ngrok added to `config/environments/development.rb` by the generator does not allow the region (i.e. it does not allow the `.` separating it). This PR fixes the regex of the configuration.

### Reviewer's guide to testing

1. Add gem to Rails project
2. `ngrok http 3000`. Make sure you are somewhere where the ngrok URL includes a region
3. Try to access the URL. You should not receive the Rails exception about allowed hosts.

Alternatively, add `127.0.0.1 a368-128-935-524-36.eu.ngrok.io` to `/etc/hosts`. Access that URL and the Rails/Shopify app should load correctly.

### Things to focus on

Nothing particular.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [-] Update `README.md`, if appropriate.
- [-] Update any relevant pages in `/docs`, if necessary
- [-] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
