### PR TITLE
Bump browser_sniffer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     shopify_app (19.0.2)
       activeresource
-      browser_sniffer (~> 1.4.0)
+      browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
@@ -85,7 +85,7 @@ GEM
     ast (2.4.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    browser_sniffer (1.4.0)
+    browser_sniffer (2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
   s.add_runtime_dependency("activeresource") # TODO: Remove this once all active resource dependencies are removed
-  s.add_runtime_dependency("browser_sniffer", "~> 1.4.0")
+  s.add_runtime_dependency("browser_sniffer", "~> 2.0")
   s.add_runtime_dependency("jwt", ">= 2.2.3")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")


### PR DESCRIPTION
### What this PR does

Bumps `browser_sniffer` to `2.0.0` to receive an update on [POS user agent detection](https://github.com/Shopify/browser_sniffer/pull/38) I've recently published.

Open to suggestions on how I can add a test case for this. Previous gem bumps here added a test to `sessions_controller` [but the test passes regardless of what user-agent is passed through](https://github.com/Shopify/shopify_app/pull/1331/files#diff-0ebf4c65ae927de1d02650f4caa7f2810e14eb64201b7570cb30939f0ee38719). 

A method that checks for POS browser name is [also marked private and not used anywhere](https://github.com/Shopify/shopify_app/blob/main/lib/shopify_app/controller_concerns/itp.rb#L29).