### PR TITLE
`WebhooksManager` defaults to active session

### DIFF
--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -12,12 +12,12 @@ module ShopifyApp
         )
       end
 
-      def create_webhooks(session:)
+      def create_webhooks(session: ShopifyAPI::Context.active_session)
         return unless ShopifyApp.configuration.has_webhooks?
         ShopifyAPI::Webhooks::Registry.register_all(session: session)
       end
 
-      def recreate_webhooks!(session:)
+      def recreate_webhooks!(session: ShopifyAPI::Context.active_session)
         destroy_webhooks
         return unless ShopifyApp.configuration.has_webhooks?
         add_registrations


### PR DESCRIPTION
### What this PR does

`WebhooksManager` will use `ShopifyAPI::Context.active_session` by default when not provided. This helps manually managing webhooks outside of the `WebhooksManagerJob`.

### Reviewer's guide to testing

PR does not change existing functionality, only provides a default session for two webhook manager methods

### Things to focus on

1. `WebhooksManager.create_webhooks` can be called with no parameters now
2. `WebhooksManager.recreate_webhooks!` can be called with no parameters now

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [X] Update `CHANGELOG.md` if the changes would impact users
- [X] Update `README.md`, if appropriate.
- [X] Update any relevant pages in `/docs`, if necessary
- [X] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
