### PR TITLE
Packaging for release v18.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+18.1.3 (Jun 2, 2022)
+----------
+* Update browser_sniffer to 2.0.0
+
 18.1.2 (Mar 3, 2022)
 ----------
 * Use the App Bridge 2.0 redirect when attempting to break out of an iframe. This happens when an app is installed, requires new access scopes, or re-authentication because the login session is expired. [#1376](https://github.com/Shopify/shopify_app/pull/1376)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (18.1.2)
+    shopify_app (18.1.3)
       browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
       omniauth-rails_csrf_protection
@@ -94,16 +94,16 @@ GEM
     crass (1.0.6)
     debug_inspector (0.0.3)
     erubi (1.10.0)
-    faraday (2.2.0)
+    faraday (2.3.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (2.0.1)
+    faraday-net_http (2.0.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    graphql (1.13.10)
-    graphql-client (0.17.0)
+    graphql (2.0.9)
+    graphql-client (0.18.0)
       activesupport (>= 3.0)
-      graphql (~> 1.10)
+      graphql
     hashdiff (1.0.1)
     hashie (5.0.0)
     i18n (1.9.1)
@@ -132,9 +132,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (2.0.4)
+    omniauth (2.1.0)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
       rack-protection
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)
@@ -219,7 +219,7 @@ GEM
       activeresource (>= 4.1.0)
       graphql-client
       rack
-    sprockets (4.0.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -259,4 +259,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.5
+   2.3.7

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyApp
-  VERSION = '18.1.2'
+  VERSION = '18.1.3'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "18.1.2",
+  "version": "18.1.3",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
### What this PR does

This is a patch release on the v18 release line that includes the following change that was back-ported from latest main/v19:
* [Bump browser_sniffer](https://github.com/Shopify/shopify_app/pull/1434)

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
