### PR TITLE
Indicate safer tagging during release

### DIFF
--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -12,7 +12,7 @@
 1. Checkout and pull from master so you have the latest version of the shopify_app
 1. Tag the HEAD with the version
     ```bash
-    $ git tag -f vX.Y.Z && git push --tags --force
+    $ git tag -f vX.Y.Z && git push origin vX.Y.Z
     ```
 1. Check that Create Release workflow successfully runs
 1. Use Shipit to build and push the gem


### PR DESCRIPTION
### What this PR does
Rather than recommending pushing all tags (with force flag), it's a little safer to push only the tag we are interested in releasing, to avoid overwriting anything and pushing bad local tags.