### PR TITLE
The URL for session tokens doc is out of date

### DIFF
--- a/docs/shopify_app/authentication.md
+++ b/docs/shopify_app/authentication.md
@@ -4,7 +4,7 @@ The Shopify App gem implements [OAuth 2.0](https://shopify.dev/tutorials/authent
 
 By default, the gem generates an embedded app frontend that uses [Shopify App Bridge](https://shopify.dev/tools/app-bridge) to fetch [session tokens](https://shopify.dev/concepts/apps/building-embedded-apps-using-session-tokens). Session tokens are used by the embedded app to make authenticated requests to the app backend. 
 
-See [*Authenticate an embedded app using session tokens*](https://shopify.dev/tutorials/authenticate-your-app-using-session-tokens) to learn more. 
+See [*Authenticate an embedded app using session tokens*](https://shopify.dev/apps/auth/oauth/session-tokens/getting-started) to learn more. 
 
 > ⚠️ Be sure you understand the differences between the types of authentication schemes before reading this guide.
 


### PR DESCRIPTION
### What this PR does

The URL for `Authenticate an embedded app using session tokens` session is broken. I believe https://shopify.dev/apps/auth/oauth/session-tokens/getting-started is the correct path to that doc.

### Reviewer's guide to testing

Make sure the new URL works and points to the right place.

### Things to focus on

N/A

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
