### PR TITLE
Allow custom OAuth URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Add the `login_callback_url` config to allow overwriting that route as well, and mount the engine routes based on the configurations. [#1445](https://github.com/Shopify/shopify_app/pull/1445)
+
 19.0.2 (April 27, 2022)
 ----------
 
@@ -27,7 +29,7 @@ BREAKING, please see migration notes.
 18.1.0 (Jan 28, 2022)
 ----------
 * Support Rails 7 [#1354](https://github.com/Shopify/shopify_app/pull/1354)
-* Fix webhooks handling in Ruby 3 [#1342](https://github.com/Shopify/shopify_app/pull/1342) 
+* Fix webhooks handling in Ruby 3 [#1342](https://github.com/Shopify/shopify_app/pull/1342)
 * Update to Ruby 3 and drop support to Ruby 2.5 [#1359](https://github.com/Shopify/shopify_app/pull/1359)
 
 18.0.4 (Jan 27, 2022)
@@ -51,7 +53,7 @@ BREAKING, please see migration notes.
 
 18.0.0 (May 3, 2021)
 ----------
-* Support OmniAuth 2.x 
+* Support OmniAuth 2.x
   * If your app has custom OmniAuth configuration, please refer to the [OmniAuth 2.0 upgrade guide](https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0).
 * Support App Bridge version 2.x in the Embedded App layout. [#1241](https://github.com/Shopify/shopify_app/pull/1241)
 
@@ -81,7 +83,7 @@ BREAKING, please see migration notes.
 
 17.0.4 (January 25, 2021)
 ----------
-* Redirect user to login page if shopify domain is not found in the `EnsureAuthenticatedLinks` concern [#1158](https://github.com/Shopify/shopify_app/pull/1158) 
+* Redirect user to login page if shopify domain is not found in the `EnsureAuthenticatedLinks` concern [#1158](https://github.com/Shopify/shopify_app/pull/1158)
 
 17.0.3 (January 22, 2021)
 ----------

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -44,9 +44,11 @@ module ShopifyApp
     end
 
     def start_oauth
+      callback_url = ShopifyApp.configuration.login_callback_url.gsub(%r{^/}, "")
+
       auth_attributes = ShopifyAPI::Auth::Oauth.begin_auth(
         shop: sanitized_shop_name,
-        redirect_path: ShopifyApp.configuration.login_callback_url,
+        redirect_path: "/#{callback_url}",
         is_online: user_session_expected?
       )
       cookies.encrypted[auth_attributes[:cookie].name] = {

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -46,7 +46,7 @@ module ShopifyApp
     def start_oauth
       auth_attributes = ShopifyAPI::Auth::Oauth.begin_auth(
         shop: sanitized_shop_name,
-        redirect_path: "/auth/shopify/callback",
+        redirect_path: ShopifyApp.configuration.login_callback_url,
         is_online: user_session_expected?
       )
       cookies.encrypted[auth_attributes[:cookie].name] = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,21 @@ ShopifyApp::Engine.routes.draw do
     get login_url => :new, :as => :login
     post login_url => :create, :as => :authenticate
     get "logout" => :destroy, :as => :logout
+
+    # Kept to prevent apps relying on these routes from breaking
+    if login_url.gsub(%r{^/}, "") != "login"
+      get "login" => :new, :as => :default_login
+      post "login" => :create, :as => :default_authenticate
+    end
   end
 
   controller :callback do
     get login_callback_url => :callback
+
+    # Kept to prevent apps relying on these routes from breaking
+    if login_callback_url.gsub(%r{^/}, "") != "auth/shopify/callback"
+      get "auth/shopify/callback" => :default_callback
+    end
   end
 
   namespace :webhooks do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 ShopifyApp::Engine.routes.draw do
+  login_url = ShopifyApp.configuration.login_url.gsub(/^#{ShopifyApp.configuration.root_url}/, "")
+  login_callback_url = ShopifyApp.configuration.login_callback_url.gsub(/^#{ShopifyApp.configuration.root_url}/, "")
+
   controller :sessions do
-    get "login" => :new, :as => :login
-    post "login" => :create, :as => :authenticate
+    get login_url => :new, :as => :login
+    post login_url => :create, :as => :authenticate
     get "logout" => :destroy, :as => :logout
   end
 
   controller :callback do
-    get "auth/shopify/callback" => :callback
+    get login_callback_url => :callback
   end
 
   namespace :webhooks do

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -24,6 +24,7 @@ module ShopifyApp
     # customise urls
     attr_accessor :root_url
     attr_writer :login_url
+    attr_writer :login_callback_url
 
     # customise ActiveJob queue names
     attr_accessor :scripttags_manager_queue_name
@@ -48,6 +49,10 @@ module ShopifyApp
 
     def login_url
       @login_url || File.join(@root_url, "login")
+    end
+
+    def login_callback_url
+      @login_callback_url || File.join(@root_url, "auth/shopify/callback")
     end
 
     def user_session_repository=(klass)

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -52,7 +52,8 @@ module ShopifyApp
     end
 
     def login_callback_url
-      @login_callback_url || File.join(@root_url, "auth/shopify/callback")
+      # Not including @root_url to keep historic behaviour
+      @login_callback_url || File.join("auth/shopify/callback")
     end
 
     def user_session_repository=(klass)

--- a/test/routes/callback_routes_test.rb
+++ b/test/routes/callback_routes_test.rb
@@ -9,7 +9,33 @@ class CallbackRoutesTest < ActionController::TestCase
     ShopifyApp.configuration = nil
   end
 
+  teardown do
+    ShopifyApp.configuration = nil
+  end
+
   test "auth_shopify_callback routes to callback#callback" do
     assert_routing "/auth/shopify/callback", controller: "shopify_app/callback", action: "callback"
+  end
+
+  test "callback route doesn't change with custom root URL because it is in an engine" do
+    ShopifyApp.configuration.root_url = "/new-root"
+    Rails.application.reload_routes!
+
+    assert_routing "/auth/shopify/callback", controller: "shopify_app/callback", action: "callback"
+  end
+
+  test "callback route changes with custom callback URL" do
+    ShopifyApp.configuration.login_callback_url = "/other-callback"
+    Rails.application.reload_routes!
+
+    assert_routing "/other-callback", controller: "shopify_app/callback", action: "callback"
+  end
+
+  test "callback route strips out root URL if both are set since it runs in an engine" do
+    ShopifyApp.configuration.root_url = "/new-root"
+    ShopifyApp.configuration.login_callback_url = "/new-root/other-callback"
+    Rails.application.reload_routes!
+
+    assert_routing "/other-callback", controller: "shopify_app/callback", action: "callback"
   end
 end

--- a/test/routes/sessions_routes_test.rb
+++ b/test/routes/sessions_routes_test.rb
@@ -9,6 +9,10 @@ class SessionsRoutesTest < ActionController::TestCase
     ShopifyApp.configuration = nil
   end
 
+  teardown do
+    ShopifyApp.configuration = nil
+  end
+
   test "login routes to sessions#new" do
     assert_routing "/login", { controller: "shopify_app/sessions", action: "new" }
   end
@@ -19,5 +23,30 @@ class SessionsRoutesTest < ActionController::TestCase
 
   test "logout routes to sessions#destroy" do
     assert_routing "/logout", { controller: "shopify_app/sessions", action: "destroy" }
+  end
+
+  test "login route doesn't change with custom root URL because it is in an engine" do
+    ShopifyApp.configuration.root_url = "/new-root"
+    Rails.application.reload_routes!
+
+    assert_routing "/login", { controller: "shopify_app/sessions", action: "new" }
+    assert_routing({ method: "post", path: "/login" }, { controller: "shopify_app/sessions", action: "create" })
+  end
+
+  test "login route changes with custom login URL" do
+    ShopifyApp.configuration.login_url = "/other-login"
+    Rails.application.reload_routes!
+
+    assert_routing "/other-login", { controller: "shopify_app/sessions", action: "new" }
+    assert_routing({ method: "post", path: "/other-login" }, { controller: "shopify_app/sessions", action: "create" })
+  end
+
+  test "login route strips out root URL if both are set since it runs in an engine" do
+    ShopifyApp.configuration.root_url = "/new-root"
+    ShopifyApp.configuration.login_url = "/new-root/other-login"
+    Rails.application.reload_routes!
+
+    assert_routing "/other-login", { controller: "shopify_app/sessions", action: "new" }
+    assert_routing({ method: "post", path: "/other-login" }, { controller: "shopify_app/sessions", action: "create" })
   end
 end


### PR DESCRIPTION
### What this PR does

In some cases, the Shopify routes might be mounted under a custom `root_url`, when the `Engine` is not mounted at `/`. Assuming that `root_url` is expected to match the root URL for the `Engine`, this PR adds support for customizing both the OAuth login and callback routes so that they can be arbitrarily determined by the app.

The goal here is for this to preserve the current behaviour by default, so I just wanted to make sure that assumption about `root_url` is actually correct.

### Reviewer's guide to testing

Tested via unit tests and by using the gem locally on a CLI-generated app.

### Things to focus on

1. Is this changing any existing behaviour?
2. Are the test cases covering enough scenarios?
3. Is it the right thing to strip out `root_url` from the URLs when setting up the routes? That is where the assumption about `root_url` comes into play.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users