### PR TITLE
Remove shopify access token from active job parameters

### DIFF
--- a/lib/shopify_app/jobs/webhooks_manager_job.rb
+++ b/lib/shopify_app/jobs/webhooks_manager_job.rb
@@ -6,8 +6,9 @@ module ShopifyApp
       ShopifyApp.configuration.webhooks_manager_queue_name
     end
 
-    def perform(shop_domain:, shop_token:)
-      ShopifyAPI::Auth::Session.temp(shop: shop_domain, access_token: shop_token) do |session|
+    def perform(shop_domain:)
+      shop = Shop.find_by(shopify_domain: shop_domain)
+      ShopifyAPI::Auth::Session.temp(shop: shop_domain, access_token: shop.shopify_token) do |session|
         WebhooksManager.create_webhooks(session: session)
       end
     end

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -7,8 +7,7 @@ module ShopifyApp
     class << self
       def queue(shop_domain, shop_token)
         ShopifyApp::WebhooksManagerJob.perform_later(
-          shop_domain: shop_domain,
-          shop_token: shop_token
+          shop_domain: shop_domain
         )
       end
 


### PR DESCRIPTION
WebhooksManagerJob currently takes a shop_domain and access_token as parameters but this leads to API tokens being exposed to services outside of the web service through whatever infrastructure you're using for ActiveJob queue processing.

This patch changes the behavior so that only the shop_domain is pass and we let the ActiveJob worker look up the access token on its own.  

