### PR TITLE
Remove stale hard-coded Rails version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [gem]: https://img.shields.io/gem/v/shopify_app.svg
 [gem_url]: https://rubygems.org/gems/shopify_app
-[supported_rails_version]: https://img.shields.io/badge/rails-%3C6.2.0-orange
 
 This gem builds Rails applications that can be embedded in the Shopify Admin.
 


### PR DESCRIPTION
Reported by @lilypustovyk.

The Rails version in the badge is hard-coded in the README and is incorrect.

Keeping this badge up-to-date is a maintenance burden, and I don't think it really adds much value.