### PR TITLE
Packaging for release 20.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+20.0.0 (July 4, 2022)
+----------
+
+* Bump [Shopify API](https://github.com/Shopify/shopify-api-ruby) to version 11.0.0. It includes [these updates](https://github.com/Shopify/shopify-api-ruby/blob/main/CHANGELOG.md#version-1100)
 * Internal update, adding App Bridge 3 for redirect (only). [#1458](https://github.com/Shopify/shopify_app/pull/1458)
 
 19.1.0 (June 20, 2022)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    shopify_app (19.1.0)
+    shopify_app (20.0.0)
       activeresource
       browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
-      shopify_api (~> 10.0)
+      shopify_api (~> 11.0)
       sprockets-rails (>= 2.0.0)
 
 GEM
@@ -124,7 +124,7 @@ GEM
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    oj (3.13.14)
+    oj (3.13.15)
     openssl (3.0.0)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -194,7 +194,7 @@ GEM
       rubocop (~> 1.24)
     ruby-progressbar (1.11.0)
     securerandom (0.2.0)
-    shopify_api (10.1.0)
+    shopify_api (11.0.0)
       concurrent-ruby
       hash_diff
       httparty
@@ -204,8 +204,8 @@ GEM
       securerandom
       sorbet-runtime
       zeitwerk (~> 2.5)
-    sorbet-runtime (0.5.10101)
-    sprockets (4.0.3)
+    sorbet-runtime (0.5.10139)
+    sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -224,7 +224,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "19.1.0"
+  VERSION = "20.0.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "19.1.0",
+  "version": "20.0.0",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = "This gem is used to get quickly started with the Shopify API"
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jwt", ">= 2.2.3")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
-  s.add_runtime_dependency("shopify_api", "~> 10.0")
+  s.add_runtime_dependency("shopify_api", "~> 11.0")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
 
   s.add_development_dependency("byebug")


### PR DESCRIPTION
### What this PR does

Sets up for publishing v20.0.0 which includes:
- Support for Shopify API library v11 (adds `2022-07`, removes `2021-07`)
- App Bridge 3 for OAuth redirect

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [X] Update `CHANGELOG.md` if the changes would impact users
