### PR TITLE
Fixes a typo and passes only the message to StandardError (super)

### DIFF
--- a/lib/shopify_app/controller_concerns/ensure_billing.rb
+++ b/lib/shopify_app/controller_concerns/ensure_billing.rb
@@ -7,7 +7,7 @@ module ShopifyApp
       attr_accessor :errors
 
       def initialize(message, errors)
-        super
+        super(message)
         @message = message
         @errors = errors
       end
@@ -119,7 +119,7 @@ module ShopifyApp
         data = data["data"]["appPurchaseOneTimeCreate"]
       end
 
-      raise BillingError.new("Error while billing the store", data["userErrros"]) unless data["userErrors"].empty?
+      raise BillingError.new("Error while billing the store", data["userErrors"]) unless data["userErrors"].empty?
 
       data["confirmationUrl"]
     end


### PR DESCRIPTION
### What this PR does

1. When configuring the billing in `shopify_app.rb` I noticed in the logs the following message:

![Screenshot 2022-07-06 at 02 33 52](https://user-images.githubusercontent.com/52452/177438441-5bdd9628-2dbe-4aa5-b39e-4eae3a5bd572.png)

The problem is that when calling `super` without any arguments it passes the arguments used in the original call and `StandardError` expects only one argument.

2. Fixes a typo: `userErrros` to `userErrors`

### Reviewer's guide to testing

To test the current behavior:


- Configure billing in `shopify_app.rb`

```ruby
  config.billing = ShopifyApp::BillingConfiguration.new(
    charge_name: "My app billing charge",
    amount: 5,
    interval: ShopifyApp::BillingConfiguration::INTERVAL_ANNUAL,
    currency_code: "USD", # Only supports USD for now
  )
```

- Run the app via `npm run dev` 
- Do not set the distribution of the app to public
- Visit the URL and the error mentioned above should appear

After this fix:

- The error should be rescued with `handle_billing_error`

### Things to focus on

1. ensure_billing.rb
2. tests are passing

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] ~Update `CHANGELOG.md` if the changes would impact users~
- [x] ~Update `README.md`, if appropriate.~
- [x] ~Update any relevant pages in `/docs`, if necessary~
- [x] ~For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.~
