### PR TITLE
Adds trial days option to recurring subscriptions

### DIFF
--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -115,12 +115,15 @@ module ShopifyApp
     attr_reader :amount
     attr_reader :currency_code
     attr_reader :interval
+    attr_reader :trial_days
 
-    def initialize(charge_name:, amount:, interval:, currency_code: "USD")
+
+    def initialize(charge_name:, amount:, interval:, currency_code: "USD", trial_days: 0)
       @charge_name = charge_name
       @amount = amount
       @currency_code = currency_code
       @interval = interval
+      @trial_days = trial_days
     end
   end
 

--- a/lib/shopify_app/controller_concerns/ensure_billing.rb
+++ b/lib/shopify_app/controller_concerns/ensure_billing.rb
@@ -143,6 +143,7 @@ module ShopifyApp
           },
           returnUrl: return_url,
           test: !Rails.env.production?,
+          trialDays: ShopifyApp.configuration.billing.trial_days,
         }
       )
 
@@ -215,12 +216,14 @@ module ShopifyApp
         $lineItems: [AppSubscriptionLineItemInput!]!
         $returnUrl: URL!
         $test: Boolean
+        $trialDays: Int
       ) {
         appSubscriptionCreate(
           name: $name
           lineItems: $lineItems
           returnUrl: $returnUrl
           test: $test
+          trialDays: $trialDays
         ) {
           confirmationUrl
           userErrors {


### PR DESCRIPTION
### What this PR does

Allows passing trial_days to the billings config

### Reviewer's guide to testing

Configure billing with a trial:

```ruby
config.billing = ShopifyApp::BillingConfiguration.new(
  charge_name: "My app billing charge",
  amount: 5,
  interval: ShopifyApp::BillingConfiguration::INTERVAL_EVERY_30_DAYS,
  currency_code: "USD", # Only supports USD for now
  trial_days: 7,
)
```

When passing `trial_days`, expected:

![Screenshot 2022-07-06 at 16 55 40](https://user-images.githubusercontent.com/52452/177580437-78b0bd58-2cf3-4391-8f56-98550d7ba742.png)

When _not_ passing `trial_days`, expected:

![Screenshot 2022-07-06 at 16 57 46](https://user-images.githubusercontent.com/52452/177581064-2ff43cc8-e53e-45ff-ac9e-a18568ff8e9a.png)

### Things to focus on

1. Tests are passing
2. Trial in billing

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- ~[x] Update `CHANGELOG.md` if the changes would impact users~
- ~[x] Update `README.md`, if appropriate.~
- ~[x] Update any relevant pages in `/docs`, if necessary~
- ~[x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.~
