### PR TITLE
Ignore extra kwargs on `perform()` in WebhooksManagerJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Unreleased
 * Bump [Shopify API](https://github.com/Shopify/shopify-api-ruby) to version 11.0.0. It includes [these updates](https://github.com/Shopify/shopify-api-ruby/blob/main/CHANGELOG.md#version-1100).  The breaking change relates to the removal of API version `2021-07` support.
 * Internal update, adding App Bridge 3 for redirect (only). [#1458](https://github.com/Shopify/shopify_app/pull/1458)
 
+19.1.1 (July 6, 2022)
+----------
+
+* Accept extra keyword arguments to WebhooksManagerJob to ease upgrade path from v18 or older (https://github.com/Shopify/shopify_app/pull/1466)
+
 19.1.0 (June 20, 2022)
 ----------
 

--- a/lib/shopify_app/jobs/webhooks_manager_job.rb
+++ b/lib/shopify_app/jobs/webhooks_manager_job.rb
@@ -6,7 +6,7 @@ module ShopifyApp
       ShopifyApp.configuration.webhooks_manager_queue_name
     end
 
-    def perform(shop_domain:, shop_token:)
+    def perform(shop_domain:, shop_token:, **)
       ShopifyAPI::Auth::Session.temp(shop: shop_domain, access_token: shop_token) do |session|
         WebhooksManager.create_webhooks(session: session)
       end


### PR DESCRIPTION
### What this PR does

This changes the `perform()` method of `WebhooksManagerJob` to accept-and-ignore additional keyword arguments. 

One of the things we noticed during upgrade from v18 to >=v19 is that https://github.com/Shopify/shopify_app/blob/main/lib/shopify_app/jobs/webhooks_manager_job.rb#L9 used to take a webhooks parameter to the function, but no longer does. This manifests in errors where webhooks that have been registered with Core pre-upgrade include that parameter on delivery, and so error out.

![image](https://user-images.githubusercontent.com/11702/177587549-fe94f280-e857-4a19-85cf-fa6006c508ee.png)

I plan on porting this fix to v19.1 branch and v20 branch along with `main`, since I think it's a useful change and removes a gotcha for upgrades.

### Reviewer's guide to testing

- Install a version of the app that is on an older (v18) version which has webhook(s) registered. For example, a `app/uninstalled` handler;
- Upgrade the application to v19 or v20
- Uninstall the app (assuming `app/uninstalled` webhooks are registered!)
- The webhook should not generate error(s) anymore

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
