### PR TITLE
Packaging for release 20.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 Unreleased
 ----------
 
+20.0.1 (July 6, 2022)
+----------
+
+* Accept extra keyword arguments to WebhooksManagerJob to ease upgrade path from v18 or older (https://github.com/Shopify/shopify_app/pull/1466)
+
 20.0.0 (July 4, 2022)
 ----------
 
 * Bump [Shopify API](https://github.com/Shopify/shopify-api-ruby) to version 11.0.0. It includes [these updates](https://github.com/Shopify/shopify-api-ruby/blob/main/CHANGELOG.md#version-1100).  The breaking change relates to the removal of API version `2021-07` support.
 * Internal update, adding App Bridge 3 for redirect (only). [#1458](https://github.com/Shopify/shopify_app/pull/1458)
-
-19.1.1 (July 6, 2022)
-----------
-
-* Accept extra keyword arguments to WebhooksManagerJob to ease upgrade path from v18 or older (https://github.com/Shopify/shopify_app/pull/1466)
 
 19.1.0 (June 20, 2022)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (20.0.0)
+    shopify_app (20.0.1)
       activeresource
       browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "20.0.0"
+  VERSION = "20.0.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
### What this PR does

Sets up for publishing v20.0.1 which includes:
- Accept extra keyword arguments to WebhooksManagerJob to ease upgrade path from v18 or older (https://github.com/Shopify/shopify_app/pull/1466)

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [X] Update `CHANGELOG.md` if the changes would impact users
