### PR TITLE
Update API repo links (post Editions 2022 tidy-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,15 @@ Unreleased
 ----------
 
 * Fix regression in apps using online tokens. [#1413](https://github.com/Shopify/shopify_app/pull/1413)
-* Bump [Shopify API](https://github.com/Shopify/shopify_api) to version 10.0.3. It includes [these fixes](https://github.com/Shopify/shopify_api/blob/main/CHANGELOG.md#version-1003).
+* Bump [Shopify API](https://github.com/Shopify/shopify-api-ruby) to version 10.0.3. It includes [these fixes](https://github.com/Shopify/shopify-api-ruby/blob/main/CHANGELOG.md#version-1003).
 
 19.0.1 (April 11, 2022)
 ----------
-* Bump Shopify API (https://github.com/Shopify/shopify_api) to version 10.0.2. This update includes patch fixes since the initial v10 release.
+* Bump Shopify API (https://github.com/Shopify/shopify-api-ruby) to version 10.0.2. This update includes patch fixes since the initial v10 release.
 
 19.0.0 (April 6, 2022)
 ----------
-* Use v10 of the Shopify API (https://github.com/Shopify/shopify_api). This update requires changes to an app - please refer to the [migration guide](https://github.com/Shopify/shopify_app/blob/main/docs/Upgrading.md) for details.
+* Use v10 of the Shopify API (https://github.com/Shopify/shopify-api-ruby). This update requires changes to an app - please refer to the [migration guide](https://github.com/Shopify/shopify_app/blob/main/docs/Upgrading.md) for details.
 BREAKING, please see migration notes.
 
 18.1.2 (Mar 3, 2022)

--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ To learn more about how this gem authenticates with Shopify, see [*Authenticatio
 
 [Shopify's API is versioned](https://shopify.dev/concepts/about-apis/versioning). With Shopify App `v1.11.0`, the included Shopify API gem allows developers to specify and update the Shopify API version they want their app or service to use. The Shopify API gem also surfaces warnings to Rails apps about [deprecated endpoints, GraphQL fields and more](https://shopify.dev/concepts/about-apis/versioning#deprecation-practices).
 
-See the [Shopify API gem README](https://github.com/Shopify/shopify_api/) for more information.
+See the [Shopify API gem README](https://github.com/Shopify/shopify-api-ruby/) for more information.

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -18,7 +18,7 @@ This file documents important changes needed to upgrade your app's Shopify App v
 
 ## Upgrading to `v19.0.0`
 
-This update moves API authentication logic from this gem to the [`shopify_api`](https://github.com/Shopify/shopify_api)
+This update moves API authentication logic from this gem to the [`shopify_api`](https://github.com/Shopify/shopify-api-ruby)
 gem.
 
 ### High-level process
@@ -31,7 +31,7 @@ gem.
   `config/initializers/shopify_app.rb` as the decision logic for which authentication method to use is now handled
   internally by the `shopify_api` gem, using the `ShopifyAPI::Context.embedded_app` setting.
 - `v19.0.0` updates the `shopify_api` dependency to `10.0.0`. This version of `shopify_api` has breaking changes. See
-  the documentation for addressing these breaking changes on GitHub [here](https://github.com/Shopify/shopify_api#breaking-change-notice-for-version-1000).
+  the documentation for addressing these breaking changes on GitHub [here](https://github.com/Shopify/shopify-api-ruby#breaking-change-notice-for-version-1000).
 
 ### Specific cases
 
@@ -223,7 +223,7 @@ is changed to
 
 ### ShopifyAPI changes
 
-You will need to also follow the ShopifyAPI [upgrade guide](https://github.com/Shopify/shopify_api/blob/master/README.md#-breaking-change-notice-for-version-700-) to ensure your app is ready to work with API versioning.
+You will need to also follow the ShopifyAPI [upgrade guide](https://github.com/Shopify/shopify-api-ruby/blob/master/README.md#-breaking-change-notice-for-version-700-) to ensure your app is ready to work with API versioning.
 
 [dashboard]: https://partners.shopify.com
 [app-bridge]: https://shopify.dev/apps/tools/app-bridge


### PR DESCRIPTION

### Why is this PR needed

As part of the Shopify API and app template strategy, the public repos were renamed to provide a more consistent naming convention.

### What this PR is doing

Where applicable, this PR renames the following repos to match the new naming convention.
- `Shopify/shopify_api` -> `Shopify/shopify-api-ruby`
- `Shopify/shopify-node-api` -> `Shopify/shopify-api-node`
- `Shopify/shopify-php-api` -> `Shopify/shopify-api-php`
- `Shopify/shopify-app-node` -> `Shopify/shopify-app-template-node`
- `Shopify/shopify-app-php` -> `Shopify/shopify-app-template-php`

