### PR TITLE
Fix destroy_webhooks by adding missing session

### DIFF
--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -18,17 +18,17 @@ module ShopifyApp
       end
 
       def recreate_webhooks!(session:)
-        destroy_webhooks
+        destroy_webhooks(session: session)
         return unless ShopifyApp.configuration.has_webhooks?
         add_registrations
         ShopifyAPI::Webhooks::Registry.register_all(session: session)
       end
 
-      def destroy_webhooks
+      def destroy_webhooks(session:)
         return unless ShopifyApp.configuration.has_webhooks?
 
         ShopifyApp.configuration.webhooks.each do |attributes|
-          ShopifyAPI::Webhooks::Registry.unregister(topic: attributes[:topic])
+          ShopifyAPI::Webhooks::Registry.unregister(topic: attributes[:topic], session: session)
         end
       end
 

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -34,8 +34,10 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
   end
 
   test "#recreate_webhooks! destroys all webhooks and recreates" do
+    session = ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com")
+
     ShopifyAPI::Webhooks::Registry.expects(:register_all)
-    ShopifyAPI::Webhooks::Registry.expects(:unregister).with(topic: "orders/updated")
+    ShopifyAPI::Webhooks::Registry.expects(:unregister).with(topic: "orders/updated", session: session)
     ShopifyApp::WebhooksManager.expects(:add_registrations).twice
 
     ShopifyApp.configure do |config|
@@ -44,7 +46,7 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
       ]
     end
     ShopifyApp::WebhooksManager.add_registrations
-    ShopifyApp::WebhooksManager.recreate_webhooks!(session: ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com"))
+    ShopifyApp::WebhooksManager.recreate_webhooks!(session: session)
   end
 
   test "#recreate_webhooks! does not call unregister if there is no webhook" do


### PR DESCRIPTION
### What this PR does

This PR fixes an issue with the `ShopifyApp::WebhooksManager.destroy_webhooks` method by adding the missing argument `session`.

### Reviewer's guide to testing

1. Open up a console to an app that has passed through the oauth flow
2. `shop = Shop.last`
3. `ShopifyAPI::Auth::Session.temp(shop: shop.shopify_domain, access_token: shop.shopify_token) { |session| ShopifyApp::WebhooksManager.recreate_webhooks!(session: session) }`
4. Webhooks should be recreated

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
