### PR TITLE
Tests to ensure `current_shopify_session` validates session token using old and new secrets

### DIFF
--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -44,8 +44,28 @@ class LoginProtectionControllerTest < ActionController::TestCase
   tests LoginProtectionController
 
   setup do
+    @shop = "my-shop.myshopify.com"
+    @api_key = "api_key"
+    @secret = "secret"
+    @old_secret = "old_secret"
+
     ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
     ShopifyApp::SessionRepository.user_storage = ShopifyApp::InMemoryUserSessionStore
+
+    @session = ShopifyAPI::Auth::Session.new(shop: @shop)
+    ShopifyApp::SessionRepository.store_shop_session(@session)
+
+    ShopifyAPI::Context.setup(
+      api_key: @api_key,
+      api_secret_key: @secret,
+      old_api_secret_key: @old_secret,
+      api_version: ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION,
+      host_name: "host.example.io",
+      scope: ShopifyApp.configuration.scope,
+      session_storage: ShopifyApp::SessionRepository,
+      is_private: false,
+      is_embedded: true,
+    )
 
     request.env["HTTP_USER_AGENT"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) "\
       "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36"
@@ -60,10 +80,9 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session loads online session if user session expected" do
-    shop = "my-shop.myshopify.com"
     ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
-      .with(shop)
-      .returns(mock_session(shop: shop))
+      .with(@shop)
+      .returns(mock_session(shop: @shop))
 
     cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     request.headers["HTTP_AUTHORIZATION"] = "Bearer token"
@@ -77,7 +96,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
       .returns(nil)
 
     with_application_test_routes do
-      get :index, params: { shop: shop }
+      get :index, params: { shop: @shop }
     end
   end
 
@@ -97,6 +116,44 @@ class LoginProtectionControllerTest < ActionController::TestCase
 
     with_application_test_routes do
       get :index
+    end
+  end
+
+  test "#current_shopify_session loads offline session if token is signed with new secret" do
+    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
+    token = mock_jwt_token(@secret)
+    request.headers["HTTP_AUTHORIZATION"] = "Bearer #{token}"
+
+    ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
+      .with(
+        auth_header: "Bearer #{token}",
+        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => "cookie" },
+        is_online: false
+      )
+      .returns(@session)
+
+    with_application_test_routes do
+      get :index
+      assert_equal @session, @controller.current_shopify_session
+    end
+  end
+
+  test "#current_shopify_session loads offline session if token is signed with old secret" do
+    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
+    token = mock_jwt_token(@old_secret)
+    request.headers["HTTP_AUTHORIZATION"] = "Bearer #{token}"
+
+    ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
+      .with(
+        auth_header: "Bearer #{token}",
+        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => "cookie" },
+        is_online: false
+      )
+      .returns(@session)
+
+    with_application_test_routes do
+      get :index
+      assert_equal @session, @controller.current_shopify_session
     end
   end
 
@@ -166,10 +223,9 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session redirects to login if the loaded session doesn't have enough scope" do
-    shop = "my-shop.myshopify.com"
     ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
-      .with(shop)
-      .returns(mock_session(shop: shop))
+      .with(@shop)
+      .returns(mock_session(shop: @shop))
     ShopifyAPI::Context.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(["scope1", "scope2"]))
 
     cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
@@ -182,11 +238,11 @@ class LoginProtectionControllerTest < ActionController::TestCase
         is_online: true
       )
       .returns(
-        ShopifyAPI::Auth::Session.new(shop: shop, scope: ["scope1"])
+        ShopifyAPI::Auth::Session.new(shop: @shop, scope: ["scope1"])
       )
 
     with_application_test_routes do
-      get :index, params: { shop: shop }
+      get :index, params: { shop: @shop }
 
       assert_redirected_to "/login?shop=my-shop.myshopify.com"
       assert_nil cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME]
@@ -194,10 +250,9 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session does not redirect when sufficient scope" do
-    shop = "my-shop.myshopify.com"
     ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
-      .with(shop)
-      .returns(mock_session(shop: shop))
+      .with(@shop)
+      .returns(mock_session(shop: @shop))
     ShopifyAPI::Context.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(["scope1"]))
 
     cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
@@ -214,7 +269,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
       )
 
     with_application_test_routes do
-      get :index, params: { shop: shop }
+      get :index, params: { shop: @shop }
       assert_response :ok
       assert_equal "cookie", cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME]
     end
@@ -456,16 +511,21 @@ class LoginProtectionControllerTest < ActionController::TestCase
     ShopifyApp.configure { |config| config.login_url = original_url }
   end
 
-  def mock_associated_user
-    ShopifyAPI::Auth::AssociatedUser.new(
-      id: 100,
-      first_name: "John",
-      last_name: "Doe",
-      email: "johndoe@email.com",
-      email_verified: true,
-      account_owner: false,
-      locale: "en",
-      collaborator: true
-    )
+  def mock_jwt_payload
+    {
+      "iss" => "https://#{@shop}/admin",
+      "dest" => "https://#{@shop}",
+      "aud" => @api_key,
+      "sub" => "123",
+      "exp" => 1.day.from_now.to_i,
+      "nbf" => 1.day.ago.to_i,
+      "iat" => Time.now.to_i,
+      "jti" => "abc",
+      "sid" => "abc123",
+    }
+  end
+
+  def mock_jwt_token(secret)
+    ::JWT.encode(mock_jwt_payload, secret, "HS256")
   end
 end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -83,13 +83,12 @@ class LoginProtectionControllerTest < ActionController::TestCase
       .with(@shop)
       .returns(mock_session(shop: @shop))
 
-    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     request.headers["HTTP_AUTHORIZATION"] = "Bearer token"
 
     ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
       .with(
         auth_header: "Bearer token",
-        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => "cookie" },
+        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => nil },
         is_online: true
       )
       .returns(nil)
@@ -102,13 +101,12 @@ class LoginProtectionControllerTest < ActionController::TestCase
   test "#current_shopify_session loads offline session if user session unexpected" do
     ShopifyApp::SessionRepository.user_storage = nil
 
-    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     request.headers["HTTP_AUTHORIZATION"] = "Bearer token"
 
     ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
       .with(
         auth_header: "Bearer token",
-        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => "cookie" },
+        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => nil },
         is_online: false
       )
       .returns(nil)
@@ -119,14 +117,13 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session loads offline session if token is signed with new secret" do
-    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     token = mock_jwt_token(ShopifyApp.configuration.secret)
     request.headers["HTTP_AUTHORIZATION"] = "Bearer #{token}"
 
     ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
       .with(
         auth_header: "Bearer #{token}",
-        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => "cookie" },
+        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => nil },
         is_online: false
       )
       .returns(@session)
@@ -138,14 +135,13 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session loads offline session if token is signed with old secret" do
-    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     token = mock_jwt_token(ShopifyApp.configuration.old_secret)
     request.headers["HTTP_AUTHORIZATION"] = "Bearer #{token}"
 
     ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
       .with(
         auth_header: "Bearer #{token}",
-        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => "cookie" },
+        cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => nil },
         is_online: false
       )
       .returns(@session)
@@ -157,7 +153,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session is nil if token is invalid" do
-    cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"
     request.headers["HTTP_AUTHORIZATION"] = "Bearer invalid"
 
     with_application_test_routes do


### PR DESCRIPTION
### What this PR does

Related #1459 and https://github.com/Shopify/shopify-api-ruby/issues/978

Adds tests to ensure that API key rotation #1459 is supported by passing both old and new secrets in the unit tests. This PR itself has no logic changes as the issue itself was addressed in `shopify-api-ruby` repo (`shopify_api` gem) by https://github.com/Shopify/shopify-api-ruby/issues/978.

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

Run `bundle exec rake test TEST=test/shopify_app/controller_concerns/login_protection_test.rb`.

### Things to focus on

Any concern on adding `ShopifyAPI::Context.setup` call in the unit tests? I believe passing a *real* JWT through `ShopifyAPI::Utils::SessionUtils.load_current_session` gives us extra confidence when upgrading `shopify_api` gem in the future.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users - No changelog is needed as it only adds test cases
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
