### PR TITLE
Move setup_context to ShopifyAppConfigurer

### DIFF
--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -25,7 +25,7 @@ module ShopifyApp
     setup do
       @routes = ShopifyApp::Engine.routes
       ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
-      setup_context
+      ShopifyAppConfigurer.setup_context
       I18n.locale = :en
 
       request.env["HTTP_USER_AGENT"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6)"\
@@ -142,7 +142,7 @@ module ShopifyApp
 
     test "#callback redirects to the root_url with shop and host parameter for non-embedded" do
       ShopifyApp.configuration.embedded_app = false
-      setup_context # to reset the context, as there's no attr_writer for embedded
+      ShopifyAppConfigurer.setup_context # to reset the context, as there's no attr_writer for embedded
       mock_oauth
 
       get :callback, params: @callback_params # host is required for App Bridge 2.0
@@ -220,19 +220,6 @@ module ShopifyApp
           cookie: ShopifyAPI::Auth::Oauth::SessionCookie.new(value: "", expires: Time.now),
           session: ShopifyAPI::Auth::Session.new(shop: "shop", access_token: "token"),
         })
-    end
-
-    def setup_context
-      ShopifyAPI::Context.setup(
-        api_key: ShopifyApp.configuration.api_key,
-        api_secret_key: ShopifyApp.configuration.secret,
-        api_version: ShopifyApp.configuration.api_version,
-        host_name: "test.host",
-        scope: ShopifyApp.configuration.scope,
-        is_private: false,
-        is_embedded: ShopifyApp.configuration.embedded_app,
-        session_storage: ShopifyApp::SessionRepository,
-      )
     end
   end
 end

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -183,10 +183,6 @@ module ShopifyApp
 
       get :callback, params: @callback_params
       assert_response 302
-
-      ShopifyApp.configure do |config|
-        config.scripttags = nil
-      end
     end
 
     test "#callback performs after_authenticate job after authentication" do

--- a/test/controllers/concerns/ensure_billing_test.rb
+++ b/test/controllers/concerns/ensure_billing_test.rb
@@ -36,17 +36,8 @@ class EnsureBillingTest < ActionController::TestCase
     ShopifyAPI::Utils::SessionUtils.stubs(:load_current_session).returns(@session)
 
     @api_version = ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION
-
-    ShopifyAPI::Context.setup(
-      api_key: "api_key",
-      api_secret_key: "api_secret_key",
-      api_version: @api_version,
-      host_name: "host.example.io",
-      scope: "read_products",
-      session_storage: ShopifyApp::SessionRepository,
-      is_private: false,
-      is_embedded: true,
-    )
+    ShopifyApp.configuration.api_version = @api_version
+    ShopifyAppConfigurer.setup_context
   end
 
   test "requires single payment if none exists and non recurring" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -12,11 +12,10 @@ module ShopifyApp
   class SessionsControllerTest < ActionController::TestCase
     setup do
       @routes = ShopifyApp::Engine.routes
-      ShopifyAppConfigurer.call
       ShopifyApp.configuration.api_version = ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION
       ShopifyApp::SessionRepository.shop_storage = ShopifyApp::InMemoryShopSessionStore
       ShopifyApp::SessionRepository.user_storage = nil
-      setup_context
+      ShopifyAppConfigurer.setup_context  # need to reset context after config changes
 
       I18n.locale = :en
 
@@ -393,19 +392,6 @@ module ShopifyApp
       expected_url = base_embedded_url + "?redirectUri=#{CGI.escape(redirect_uri)}" + "&shop=#{shop_domain}"
 
       assert_redirected_to(expected_url)
-    end
-
-    def setup_context
-      ShopifyAPI::Context.setup(
-        api_key: ShopifyApp.configuration.api_key,
-        api_secret_key: ShopifyApp.configuration.secret,
-        api_version: ShopifyApp.configuration.api_version,
-        host_name: "test.host",
-        scope: ShopifyApp.configuration.scope,
-        is_private: false,
-        is_embedded: ShopifyApp.configuration.embedded_app,
-        session_storage: ShopifyApp::SessionRepository,
-      )
     end
 
     def with_embedded_redirect_url

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -18,7 +18,20 @@ class ShopifyAppConfigurer
       config.after_authenticate_job = false
       config.reauth_on_access_scope_changes = true
     end
+
+    setup_context
+  end
+
+  def self.setup_context
+    ShopifyAPI::Context.setup(
+      api_key: ShopifyApp.configuration.api_key,
+      api_secret_key: ShopifyApp.configuration.secret,
+      api_version: ShopifyApp.configuration.api_version,
+      host_name: "test.host",
+      scope: ShopifyApp.configuration.scope,
+      is_private: false,
+      is_embedded: ShopifyApp.configuration.embedded_app,
+      session_storage: ShopifyApp::SessionRepository,
+    )
   end
 end
-
-ShopifyAppConfigurer.call

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -13,6 +13,7 @@ class ShopifyAppConfigurer
       config.myshopify_domain = "myshopify.com"
       config.api_version = ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION
       config.billing = nil
+      config.scripttags = nil
 
       config.shop_session_repository = ShopifyApp::InMemorySessionStore
       config.after_authenticate_job = false

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -11,7 +11,7 @@ class ShopifyAppConfigurer
       config.user_access_scopes = nil
       config.embedded_app = true
       config.myshopify_domain = "myshopify.com"
-      config.api_version = "unstable"
+      config.api_version = ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION
       config.billing = nil
 
       config.shop_session_repository = ShopifyApp::InMemorySessionStore

--- a/test/generators/home_controller_generator_with_execution_test.rb
+++ b/test/generators/home_controller_generator_with_execution_test.rb
@@ -23,10 +23,10 @@ class HomeControllerGeneratorWithExecutionTest < ActiveSupport::TestCase
     with_home_controller(is_embedded: false) do
       controller = HomeController.new
 
-      stub_request(:get, "https://my-shop/admin/api/2022-01/products.json?limit=10")
+      stub_request(:get, "https://my-shop/admin/api/#{ShopifyApp.configuration.api_version}/products.json?limit=10")
         .to_return(status: 200, body: "{\"products\":[]}", headers: {})
 
-      stub_request(:get, "https://my-shop/admin/api/2022-01/webhooks.json")
+      stub_request(:get, "https://my-shop/admin/api/#{ShopifyApp.configuration.api_version}/webhooks.json")
         .to_return(status: 200, body: "{}", headers: {})
 
       controller.index

--- a/test/generators/products_controller_generator_with_execution_test.rb
+++ b/test/generators/products_controller_generator_with_execution_test.rb
@@ -21,7 +21,7 @@ class ProductsControllerGeneratorWithExecutionTest < ActiveSupport::TestCase
         raise "Invalid JSON provided: #{json}" unless json == { products: [] }
       end
 
-      stub_request(:get, "https://my-shop/admin/api/2022-01/products.json?limit=10")
+      stub_request(:get, "https://my-shop/admin/api/#{ShopifyApp.configuration.api_version}/products.json?limit=10")
         .to_return(status: 200, body: "{\"products\":[]}", headers: {})
 
       controller.index

--- a/test/shopify_app/managers/scripttags_manager_test.rb
+++ b/test/shopify_app/managers/scripttags_manager_test.rb
@@ -12,7 +12,7 @@ class ShopifyApp::ScripttagsManagerTest < ActiveSupport::TestCase
       { event: "onload", src: ->(domain) { "https://example-app.com/#{domain}-123.js" } },
     ]
 
-    ShopifyAPI::Context.load_rest_resources(api_version: "2022-01")
+    ShopifyAPI::Context.load_rest_resources(api_version: ShopifyApp.configuration.api_version)
     ShopifyAPI::Context.activate_session(ShopifyAPI::Auth::Session.new(shop: "some-shop.myshopify.com"))
     @manager = ShopifyApp::ScripttagsManager.new(@scripttags, "example-app.com")
   end

--- a/test/shopify_app/session/user_session_storage_test.rb
+++ b/test/shopify_app/session/user_session_storage_test.rb
@@ -30,7 +30,7 @@ module ShopifyApp
         shopify_user_id: TEST_SHOPIFY_USER_ID,
         shopify_domain: TEST_SHOPIFY_DOMAIN,
         shopify_token: TEST_SHOPIFY_USER_TOKEN,
-        api_version: "2020-01",
+        api_version: ShopifyApp.configuration.api_version,
       )
       UserMockSessionStore.stubs(:find_by).with(shopify_user_id: TEST_SHOPIFY_USER_ID).returns(instance)
 

--- a/test/shopify_app/session/user_session_storage_with_scopes_test.rb
+++ b/test/shopify_app/session/user_session_storage_with_scopes_test.rb
@@ -33,7 +33,7 @@ module ShopifyApp
         shopify_user_id: TEST_SHOPIFY_USER_ID,
         shopify_domain: TEST_SHOPIFY_DOMAIN,
         shopify_token: TEST_SHOPIFY_USER_TOKEN,
-        api_version: "2020-01",
+        api_version: ShopifyApp.configuration.api_version,
         scopes: TEST_MERCHANT_SCOPES
       )
       UserMockSessionStoreWithScopes.stubs(:find_by).with(shopify_user_id: TEST_SHOPIFY_USER_ID).returns(instance)

--- a/test/support/session_store_strategy_test_helpers.rb
+++ b/test/support/session_store_strategy_test_helpers.rb
@@ -5,8 +5,13 @@ module SessionStoreStrategyTestHelpers
     attr_reader :id, :shopify_domain, :shopify_token, :api_version, :access_scopes
     attr_writer :shopify_token, :access_scopes
 
-    def initialize(id: 1, shopify_domain: "example.myshopify.com",
-      shopify_token: "abcd-shop-token", api_version: "unstable", scopes: "read_products")
+    def initialize(
+      id: 1,
+      shopify_domain: "example.myshopify.com",
+      shopify_token: "abcd-shop-token",
+      api_version: ShopifyApp.configuration.api_version,
+      scopes: "read_products"
+    )
       @id = id
       @shopify_domain = shopify_domain
       @shopify_token = shopify_token
@@ -19,8 +24,14 @@ module SessionStoreStrategyTestHelpers
     attr_reader :id, :shopify_user_id, :shopify_domain, :shopify_token, :api_version, :access_scopes
     attr_writer :shopify_token, :shopify_domain, :access_scopes
 
-    def initialize(id: 1, shopify_user_id: 1, shopify_domain: "example.myshopify.com",
-      shopify_token: "1234-user-token", api_version: "unstable", scopes: "read_products")
+    def initialize(
+      id: 1,
+      shopify_user_id: 1,
+      shopify_domain: "example.myshopify.com",
+      shopify_token: "1234-user-token",
+      api_version: ShopifyApp.configuration.api_version,
+      scopes: "read_products"
+    )
       @id = id
       @shopify_user_id = shopify_user_id
       @shopify_domain = shopify_domain

--- a/test/utils/rails_generator_runtime.rb
+++ b/test/utils/rails_generator_runtime.rb
@@ -78,11 +78,11 @@ module Utils
         original_embedded_app = ShopifyApp.configuration.embedded_app
         ShopifyApp.configuration.embedded_app = false unless is_embedded
         ShopifyAPI::Context.setup(
-          api_key: "API_KEY",
-          api_secret_key: "API_SECRET_KEY",
-          api_version: "2022-01",
+          api_key: ShopifyApp.configuration.api_key,
+          api_secret_key: ShopifyApp.configuration.secret,
+          api_version: ShopifyApp.configuration.api_version,
           host_name: "app-address.com",
-          scope: ["scope1", "scope2"],
+          scope: ShopifyApp.configuration.scope,
           is_private: is_private,
           is_embedded: is_embedded,
           session_storage: TestHelpers::FakeSessionStorage.new,


### PR DESCRIPTION
### What this PR does

Moves call to `setup_context` from tests to `ShopifyAppConfigurer`, therefore globally set before each test case.

`setup` in some test suites need to issue a call to `setup_context` if the `ShopifyApp` configuration changes.