### PR TITLE
Fix bug for ShopifyApp::SessionStorage#with_shopify_session

### DIFF
--- a/lib/shopify_app/session/session_storage.rb
+++ b/lib/shopify_app/session/session_storage.rb
@@ -10,8 +10,8 @@ module ShopifyApp
     end
 
     def with_shopify_session(&block)
-      ShopifyAPI::Auth::Session.temp(shop: shopify_domain, access_token: shopify_token) do
-        yield block
+      ShopifyAPI::Auth::Session.temp(shop: shopify_domain, access_token: shopify_token) do |session|
+        block.call session
       end
     end
   end

--- a/test/shopify_app/session/session_storage_test.rb
+++ b/test/shopify_app/session/session_storage_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Shopify
+  class SessionStorageTest < ActiveSupport::TestCase
+    TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
+    TEST_SHOPIFY_TOKEN = "1234567890abcdef"
+
+    test 'proc params of #with_shopify_session should be ShopifyAPI::Auth::Session' do
+      shop_mock = MockShopInstance.new(
+        shopify_domain: TEST_SHOPIFY_DOMAIN,
+        shopify_token: TEST_SHOPIFY_TOKEN,
+      )
+      shop_mock.class_eval do
+        include ActiveModel::Validations
+        include ShopifyApp::SessionStorage
+      end
+
+      shop_mock.with_shopify_session do |session|
+        assert_instance_of ShopifyAPI::Auth::Session, session
+        assert_equal TEST_SHOPIFY_DOMAIN, session.shop
+        assert_equal TEST_SHOPIFY_TOKEN, session.access_token
+      end
+    end
+  end
+end

--- a/test/shopify_app/session/session_storage_test.rb
+++ b/test/shopify_app/session/session_storage_test.rb
@@ -7,7 +7,7 @@ module Shopify
     TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
     TEST_SHOPIFY_TOKEN = "1234567890abcdef"
 
-    test 'proc params of #with_shopify_session should be ShopifyAPI::Auth::Session' do
+    test '#with_shopify_session should be supplied ShopifyAPI::Auth::Session in block argument' do
       shop_mock = MockShopInstance.new(
         shopify_domain: TEST_SHOPIFY_DOMAIN,
         shopify_token: TEST_SHOPIFY_TOKEN,


### PR DESCRIPTION
### What this PR does

`ShopifyApp::SessionStorage#with_shopify_session` is given proc instance in block argument now. But, it should call block and be supplied session instance (ShopifyAPI::Auth::Session) to block. So I modified it and wrote test.

### Reviewer's guide to testing

Run following

```shell
bundle exec rake test TEST=test/shopify_app/session/session_storage_test.rb
```

### Things to focus on

1. lib/shopify_app/session/session_storage.rb
2. test/shopify_app/session/session_storage_test.rb

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
