### PR TITLE
Close Stale Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 730
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            This issue is stale because it has been open for 2 years. It will be closed if no further action occurs in 14 days. 
+          close-issue-message: >
+            This issue was closed because it has been inactive for 14 days since being marked as stale.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations_per_run: 100


### PR DESCRIPTION
### What this PR does
Creates a GitHub action to close stale issues. This will find and close stale issues at 1:30 UTC everyday.

closes [this issue](https://github.com/Shopify/first-party-library-planning/issues/423)

<!-- Please describe what changes this PR introduces and why they're needed. -->

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

Right now we add the label "stale" to any issues that have no activity for two years. After 14 days of being a stale issue it will close.

### Things to focus on

1. Do we like the time frames?
2. Do we like the messages?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
