### PR TITLE
Deduce webhook path from address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 * Fixes bug where webhooks were generated with addresses instead of the [path the Ruby API](https://github.com/Shopify/shopify-api-ruby/blob/7a08ae9d96a7a85abd0113dae4eb76398cba8c64/lib/shopify_api/webhooks/registrations/http.rb#L12) is expecting [#1474](https://github.com/Shopify/shopify_app/pull/1474). The breaking change that was accidentially already shipped was that `address` attribute for webhooks should be paths not addresses with `https://` and the host name. While the `address` attribute name will still work assuming the value is a path, this name is deprecated. Please configure webhooks with the `path` attribute name instead.
+* Deduce webhook path from deprecated webhook address if initializer uses address attribute. This makes this attribute change a non-breaking change for those upgrading.
 
 20.1.0 (August 22, 2022)
 ----------

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module ShopifyApp
   class WebhooksManager
     class CreationFailed < StandardError; end
@@ -38,17 +40,36 @@ module ShopifyApp
         return unless ShopifyApp.configuration.has_webhooks?
 
         ShopifyApp.configuration.webhooks.each do |attributes|
+          webhook_path = path(attributes)
+
           ShopifyAPI::Webhooks::Registry.add_registration(
             topic: attributes[:topic],
             delivery_method: attributes[:delivery_method] || :http,
-            path: attributes[:path] || attributes[:address],
-            handler: webhook_job_klass(attributes[:path]),
+            path: webhook_path,
+            handler: webhook_job_klass(webhook_path),
             fields: attributes[:fields]
           )
         end
       end
 
       private
+
+      def path(webhook_attributes)
+        path = webhook_attributes.dig(:path)
+        address = webhook_attributes.dig(:address)
+        uri = URI(address) if address
+
+        # Fail unless path or address are present
+        if path.nil? && address.nil?
+          raise ShopifyApp::MissingWebhookJobError("The :path attribute is required for webhook registration.")
+        elsif path.present?
+          path
+        elsif uri&.path&.present?
+          uri.path
+        else
+          raise ShopifyApp::MissingWebhookJobError("The :path attribute is required for webhook registration.")
+        end
+      end
 
       def webhook_job_klass(path)
         webhook_job_klass_name(path).safe_constantize || raise(ShopifyApp::MissingWebhookJobError)

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -55,14 +55,11 @@ module ShopifyApp
       private
 
       def path(webhook_attributes)
-        path = webhook_attributes.dig(:path)
-        address = webhook_attributes.dig(:address)
+        path = webhook_attributes[:path]
+        address = webhook_attributes[:address]
         uri = URI(address) if address
 
-        # Fail unless path or address are present
-        if path.nil? && address.nil?
-          raise ShopifyApp::MissingWebhookJobError("The :path attribute is required for webhook registration.")
-        elsif path.present?
+        if path.present?
           path
         elsif uri&.path&.present?
           uri.path

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -33,6 +33,28 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
     ShopifyApp::WebhooksManager.add_registrations
   end
 
+  test "#add_registrations deduces path from address" do
+    expected_hash = {
+      topic: "orders/updated",
+      delivery_method: :http,
+      path: "/webhooks/orders_updated",
+      handler: OrdersUpdatedJob,
+      fields: nil,
+    }
+
+    ShopifyAPI::Webhooks::Registry.expects(:add_registration).with(expected_hash).once
+    ShopifyApp.configure do |config|
+      config.webhooks = [
+        {
+          topic: "orders/updated",
+          address: "https://some.domain.over.the.rainbow.com/webhooks/orders_updated",
+        },
+      ]
+    end
+
+    ShopifyApp::WebhooksManager.add_registrations
+  end
+
   test "#add_registrations does not makes calls to library's add_registration when there are no webhooks" do
     ShopifyAPI::Webhooks::Registry.expects(:add_registration).never
     ShopifyApp.configure do |config|


### PR DESCRIPTION
![](https://c.tenor.com/9QwpLxiyoOkAAAAC/matt-smith-shut-up-im-making-deductions.gif)

### What this PR does

As discussed in #1492 , the Ruby API is [expecting the webhook path](https://github.com/Shopify/shopify-api-ruby/blob/7a08ae9d96a7a85abd0113dae4eb76398cba8c64/lib/shopify_api/webhooks/registrations/http.rb#L12) instead of webhook address.

This will deduce the webhook's path if the engine is configured with the deprecated `address` attribute.

To make the `:address` -> `:path` webhook 

### Reviewer's guide to testing

1. Create a new rails app
2. Install this gem in Gemfile:

```ruby
gem "shopify_app", git: 'https://github.com/shopify/shopify_app.git', branch: 'nelsonwittwer/deduce_path'
```
3. Bundle install
4. run the generator `rails g shopify_app` in the directory of your new app
5. run the generator `rails g shopify_app:add_webhook --topic orders/create --path webhooks/create_orders` to generate a webhook
6. Modify the `config/initializers/shopify_app.rb` webhooks section to use the webhook address instead of path.
7. Boot up rails `rails s`

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
