### PR TITLE
Remove excess trailing `;` for CSP

### DIFF
--- a/lib/shopify_app/controller_concerns/frame_ancestors.rb
+++ b/lib/shopify_app/controller_concerns/frame_ancestors.rb
@@ -8,7 +8,7 @@ module ShopifyApp
       content_security_policy do |policy|
         policy.frame_ancestors(-> do
           domain_host = current_shopify_domain || "*.myshopify.com"
-          "https://#{domain_host} https://admin.shopify.com;"
+          "https://#{domain_host} https://admin.shopify.com"
         end)
       end
     end


### PR DESCRIPTION
This results in an extra `;`, e.g.:

`frame-ancestors https://*.myshopify.com https://admin.shopify.com;;`

### What this PR does

<!-- Please describe what changes this PR introduces and why they're needed. -->

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

### Things to focus on

1. <!-- Focus on a particular file -->
2. <!-- Is the test case correct? -->
3. <!-- Etc. -->

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
