### PR TITLE
Improve OAuth tunnel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,6 @@ This gem requires that you have the following credentials:
 - **Shopify API key:** The API key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations). 
 - **Shopify API secret:** The API secret key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations). 
 
-### OAuth Tunnel in Development
-
-In order to redirect OAuth requests securely to localhost, you'll need to setup a tunnel to redirect from the internet to localhost.
-
-We've validated that [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/trycloudflare/) works with this template.
-
-To do that, you can [install the `cloudflared` CLI tool](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/), and run:
-
-```shell
-# Note that you can also use a different port
-cloudflared tunnel --url http://localhost:3000
-```
-
-You will need to keep this window running to maintain the tunnel during development.
-
 ## Usage
 
 1. To get started, create a new Rails app:
@@ -63,10 +48,9 @@ $ bundle add shopify_app
 
 3. Create a `.env` file in the root of `my_shopify_app` to specify your Shopify API credentials:
 
-```
+```sh
 SHOPIFY_API_KEY=<Your Shopify API key>
 SHOPIFY_API_SECRET=<Your Shopify API secret>
-HOST=<Your SSH tunnel host>
 ```
 
 > In a development environment, you can use a gem like `dotenv-rails` to manage environment variables. 
@@ -83,13 +67,17 @@ $ rails generate shopify_app
 $ rails db:migrate
 ```
 
-6. Run the app:
+6. Setup a SSH tunnel to allow the OAuth redirect to work. See how in the [Setup SSH tunnel for development](/docs/Quickstart.md#setup-ssh-tunnel-for-development) section in [Quickstart](/docs/Quickstart.md)
+
+7. Run the app:
 
 ```sh
 $ rails server
 ```
 
-See [*Quickstart*](/docs/Quickstart.md) to learn how to install your app on a shop.
+8. Install the app by visiting the server's URL (e.g. http://127.0.0.1:3000) and specifying the subdomain of the shop where you want it to be installed to.
+
+9. After the app is installed, you're redirected to the embedded app.
 
 This app implements [OAuth 2.0](https://shopify.dev/tutorials/authenticate-with-oauth) with Shopify to authenticate requests made to Shopify APIs. By default, this app is configured to use [session tokens](https://shopify.dev/concepts/apps/building-embedded-apps-using-session-tokens) to authenticate merchants when embedded in the Shopify Admin.
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -4,24 +4,31 @@ This guide assumes you have completed the steps to create a new Rails app using 
 
 #### Table of contents
 
-[Make your app available to the internet](#make-your-app-available-to-the-internet)
+[Setup SSH tunnel for development](#setup-ssh-tunnel-for-development)
 
 [Use Shopify App Bridge to embed your app in the Shopify Admin](#use-shopify-app-bridge-to-embed-your-app-in-the-shopify-admin)
 
-## Make your app available to the internet
+## Setup SSH tunnel for development
 
 Your local app needs to be accessible from the public Internet in order to install it on a Shopify store, to use the [App Proxy Controller](/lib/generators/shopify_app/app_proxy_controller/templates/app_proxy_controller.rb) or receive [webhooks](/docs/shopify_app/webhooks.md).
 
-Use a tunneling service like [Cloudflare](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/trycloudflare/) to make your development environment accessible to the internet.
+In order to receive requests securely, you'll need to setup a tunnel from the internet to localhost. You can use [Cloudflare](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/trycloudflare/) for this.
 
-To use Cloudflare, [install the `cloudflared` CLI tool](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/), and run:
+To do so, [install the `cloudflared` CLI tool](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/), and run:
 
-```shell
-# Note that you can also use a different port
+```sh
+# The port must be the same as the one you run the Rails app on later. We use the Rails default below.
 cloudflared tunnel --url http://localhost:3000
 ```
 
-See the [*Embed the app in Shopify*](https://shopify.dev/tutorials/build-rails-react-app-that-uses-app-bridge-authentication#embed-the-app-in-shopify) section of [*Build a Shopify app with Rails, React, and App Bridge*](https://shopify.dev/tutorials/build-rails-react-app-that-uses-app-bridge-authentication) to learn more.
+Keep this window running to keep the tunnel and make note of the URL this command prints out. The URL will look like `https://some-random-words.trycloudflare.com`.
+
+Visit the "App Setup" section for your app in the [Shopify Partners dashboard](https://partners.shopify.com/organizations). Set the URL as "App URL" on this settings page and add it to the "Allowed redirection URL(s)", after appending `/auth/shopify/callback` to the end (e.g. `https://some-random-words.trycloudflare.com/auth/shopify/callback`).
+
+Add the same URL as `HOST` in your `.env` file e.g.
+```sh
+HOST='https://some-random-words.trycloudflare.com/'
+```
 
 ## Use Shopify App Bridge to embed your app in the Shopify Admin
 


### PR DESCRIPTION
### What this PR does

This commit removes duplicate sections on how to set up a tunnel to allow OAuth redirect during development, makes the one remaining section clearer and fixes the link it contains to a shopify.dev tutorial.

This gem's docs previously gave instructions to setup a Cloudflared tunnel, but then directed users to follow a section of a shopify.dev tutorial which started with setting up an Ngrok tunnel instead before moving on to adding the redirect URI to the partners dashboard.

After this change, the docs link first to the shopify.dev tutorial section and include a note after for using Cloudflared should the user wish.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
