### PR TITLE
fix method signature of super

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Unreleased
 ----------
+* Fixes a method signature error bug when raising `BillingError`.  [#1513](https://github.com/Shopify/shopify_app/pull/1513)
+* Fixes bug with Rails 7 and import maps with Safari/Firefox on the HomeController#index view.  [#1506](https://github.com/Shopify/shopify_app/pull/1506)
+* Refactors how default `domain_host` is populated in the CSP header added to responses in the `FrameAncestors` controller concern. [#1504](https://github.com/Shopify/shopify_app/pull/1504)
+* Removes duplicate `;` added in CSP header. [#1500](https://github.com/Shopify/shopify_app/pull/1500)
 
 20.1.1 (September 2, 2022)
 ----------

--- a/lib/shopify_app/controller_concerns/ensure_billing.rb
+++ b/lib/shopify_app/controller_concerns/ensure_billing.rb
@@ -7,7 +7,7 @@ module ShopifyApp
       attr_accessor :errors
 
       def initialize(message, errors)
-        super
+        super(message)
         @message = message
         @errors = errors
       end

--- a/lib/shopify_app/controller_concerns/ensure_billing.rb
+++ b/lib/shopify_app/controller_concerns/ensure_billing.rb
@@ -119,7 +119,7 @@ module ShopifyApp
         data = data["data"]["appPurchaseOneTimeCreate"]
       end
 
-      raise BillingError.new("Error while billing the store", data["userErrros"]) unless data["userErrors"].empty?
+      raise BillingError.new("Error while billing the store", data["userErrors"]) unless data["userErrors"].empty?
 
       data["confirmationUrl"]
     end


### PR DESCRIPTION
![](https://c.tenor.com/gJ5HtN0YuoIAAAAC/autograph-signature.gif)

### What this PR does

Fixes the method signature of `StandardError` when we call `super`

### Reviewer's guide to testing

In a Rails app that uses this branch of the gem (`gem "shopify_app, git: "git@github.com:Shopify/shopify_app.git", "branch: nelsonwittwer/billing_error"`) ensure that you can instantiate a `BillingError`

🎩 
```ruby
irb(main):001:0> ShopifyApp::EnsureBilling::BillingError.new("Error while billing the store", [{"field"=>nil, "message"=>"message"}])
=> #<ShopifyApp::EnsureBilling::BillingError: Error while billing the store>
```

I was able to do instatiate an error without it complaining as reported in [this issue](https://github.com/Shopify/shopify_app/issues/1484)

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
