### PR TITLE
Fix user session storing without scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
 * Refactors how default `domain_host` is populated in the CSP header added to responses in the `FrameAncestors` controller concern. [#1504](https://github.com/Shopify/shopify_app/pull/1504)
 * Removes duplicate `;` added in CSP header. [#1500](https://github.com/Shopify/shopify_app/pull/1500)
 
+* Fixed an issue where `ShopifyApp::UserSessionStorage` was causing an infinite OAuth loop when not checking scopes. [#1516](https://github.com/Shopify/shopify_app/pull/1516)
+
 20.1.1 (September 2, 2022)
 ----------
 

--- a/lib/shopify_app/session/user_session_storage.rb
+++ b/lib/shopify_app/session/user_session_storage.rb
@@ -11,7 +11,7 @@ module ShopifyApp
 
     class_methods do
       def store(auth_session, user)
-        user = find_or_initialize_by(shopify_user_id: user[:id])
+        user = find_or_initialize_by(shopify_user_id: user.id)
         user.shopify_token = auth_session.access_token
         user.shopify_domain = auth_session.shop
         user.save!


### PR DESCRIPTION
### What this PR does

We had updated the `UserSessionStorageWithScopes` class to fix an issue where the type of the `user` param was incorrect, but the same issue was present in `UserSessionStorage`. This PR fixes that to properly call `user.id` to access the `AssociatedUser` property.

### Reviewer's guide to testing

You'll need to create an app with a few conditions:
- It has User sessions (`rails g shopify_app:user_model`)
  - Answer `n` when prompted if you want to add user scopes
- Make sure the `User` model is using the `include ShopifyApp::UserSessionStorage` concern (not `ShopifyApp::UserSessionStorageWithScopes`
- Set `config.reauth_on_access_scope_changes = false` in the `shopify_app` initializer
- Set `config.user_session_repository = "User"`

### Things to focus on

Before this branch, that would lead into an infinite auth loop. With this fix, the app should authenticate normally, and there should be an entry in both the `users` and `shops` tables.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users