### PR TITLE
Prevent errors caused by CSP frame_ancestors

### DIFF
--- a/lib/shopify_app/controller_concerns/frame_ancestors.rb
+++ b/lib/shopify_app/controller_concerns/frame_ancestors.rb
@@ -7,7 +7,8 @@ module ShopifyApp
     included do
       content_security_policy do |policy|
         policy.frame_ancestors(-> do
-          domain_host = current_shopify_domain || "*.#{::ShopifyApp.configuration.myshopify_domain}"
+          shop_domain = ShopifyApp::Utils.sanitize_shop_domain(params[:shop]) if params[:shop].present?
+          domain_host = shop_domain || "*.#{::ShopifyApp.configuration.myshopify_domain}"
           "#{ShopifyAPI::Context.host_scheme}://#{domain_host} https://admin.shopify.com"
         end)
       end


### PR DESCRIPTION
### What this PR does

<!-- Please describe what changes this PR introduces and why they're needed. -->

- Avoid `FrameAncestors` module to rely on `LoginProtection#current_shopify_domain`. `LoginProtection` depends on cookies and session tokens. If a requested is unauthenticated, for example the session token is expired, this module raises an error instead of returning a proper status code.
- ~~Add `"https://*.#{::ShopifyApp.configuration.myshopify_domain}"` to the frame ancestors directive regardless of whether the `shop` param was passed or not. With this we can enforce the app to always add myshopify.com or another domain name given from the app's configuration (e.g. Shopify's internal cloud-based development environment).~~ Update: the fix like this will be addressed by Shopify's internal module.

Example:
   ```ruby
   ShopifyApp.configure do |config|
     ...
     config.myshopify_domain = ENV.fetch("INTERNAL_DOMAIN", "myshopify.com")
   end
   ```

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

Include this module to your Shopify app and confirm CSP frame-ancestors directives are generated as intended.
 
### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
