### PR TITLE
Loosen the `shopify_api` version to allow patches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
-      shopify_api (~> 12.0.0)
+      shopify_api (~> 12.0)
       sprockets-rails (>= 2.0.0)
 
 GEM
@@ -194,7 +194,7 @@ GEM
       rubocop (~> 1.24)
     ruby-progressbar (1.11.0)
     securerandom (0.2.0)
-    shopify_api (12.0.0)
+    shopify_api (12.1.0)
       concurrent-ruby
       hash_diff
       httparty
@@ -204,7 +204,7 @@ GEM
       securerandom
       sorbet-runtime
       zeitwerk (~> 2.5)
-    sorbet-runtime (0.5.10477)
+    sorbet-runtime (0.5.10486)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jwt", ">= 2.2.3")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
-  s.add_runtime_dependency("shopify_api", "~> 12.0.0")
+  s.add_runtime_dependency("shopify_api", "~> 12.0")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
 
   s.add_development_dependency("byebug")


### PR DESCRIPTION
### What this PR does

Currently, the gemspec of the `shopify_app` is pretty strict (maybe on purpose?). As of this, it's not possible to install the latest version of the `shopify_api` and the `shopify_app` together in an app.

This PR loosens the gemspec a bit by allowing minor versions updates of the `shopify_api`. 

### Reviewer's guide to testing

There is not really something to test here.

### Things to focus on

1. See `shopify_app.gemspec`
2. All tests still seem to be passing under `12.1.0`

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
