### PR TITLE
add docs for public controller concerns

### DIFF
--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -1,6 +1,6 @@
 # Controller Concerns
 
-The following are controller concerns designed to be public controller concerns that can be included in your controllers. Concerns defined in `lib/shopify_app/controller_concerns` are designed to be private concerns and are not meant to be included directly into your controllers.
+The following controller concerns are designed to be public and can be included in your controllers. Concerns defined in `lib/shopify_app/controller_concerns` are designed to be private and are not meant to be included directly into your controllers.
 
 ## Authenticated
 Designed for controllers that are designed to handle authenticated actions by ensuring there is a valid session for the request.

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -7,19 +7,19 @@ Designed for controllers that are designed to handle authenticated actions by en
 
 In addition to session management, this concern will also handle localization, CSRF protection, embedded app settings, and billing enforcement.
 
-### Session Management
+#### Session Management
 This concern will setup and teardown the session around the action. If the session cannot be setup for the requested shop the request will be redirected to login.
 
-### Localization
+#### Localization
 I18n localization is saved to the session for consistent translations for the session.
 
-### CSRF Protection
+#### CSRF Protection
 Implements Rails' [protect_from_forgery](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery) unless a valid session token is found for the request.
 
-### Embedded App
+#### Embedded App
 If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P header](https://www.w3.org/P3P/) and [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) are handled for you.
 
-### Billing Enforcement
+#### Billing Enforcement
 If billing is enabled for the app, the active payment for the session is queried and enforced if needed. If billing is required the user will be redirected to a page requesting payment.
 
 ## EnsureAuthenicatedLinks

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -38,7 +38,9 @@ If billing is enabled for the app, the active payment for the session is queried
 Designed to be more of a lightweight session concern specifically for XHR requests. Where `Authenticated` does far more than just session management, this concern will redirect to the splash page of the app if no active session was found.
 
 ## RequireKnownShop
-Designed to handle unauthenticated requests. Rather than using the JWT to determine the requested shop of the request, the `shop` name is expected to be passed in the query string. If `shop` wasn't included in the query string params the request will be redirected to the login_url of the app.
+Designed to handle unauthenticated requests for *embedded apps*. If you are non-embedded app, we recommend using `Authenticated` concern instead of this one.
+
+Rather than using the JWT to determine the requested shop of the request, the `shop` name param is taken from the query string that Shopify Admin provides.
 
 If the shop session cannot be found for the provided `shop` in the query string, the request will be redirected to login or the `embedded_redirect_url`.
 

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -40,7 +40,7 @@ Designed to be more of a lightweight session concern specifically for XHR reques
 ## RequireKnownShop
 Designed to handle unauthenticated requests. Rather than using the JWT to determine the requested shop of the request, the `shop` name is expected to be passed in the query string. If `shop` wasn't included in the query string params the request will be redirected to the login_url of the app.
 
-If the shop session cannot be found for the provided `shop` in the query string, the requrest will be redirected to login or the `embedded_redirect_url`.
+If the shop session cannot be found for the provided `shop` in the query string, the request will be redirected to login or the `embedded_redirect_url`.
 
 ## ShopAccessScopesVerification
 If scopes for the session don't match configuration of scopes defined in `config/initializers/shopify_app.rb` the user will be redirected to login or the `embedded_redirect_url`

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -7,7 +7,7 @@ Designed for controllers that are designed to handle authenticated actions by en
 
 In addition to session management, this concern will also handle localization, CSRF protection, embedded app settings, and billing enforcement.
 
-#### Session Management
+#### LoginProtection - Session Management
 This concern will setup and teardown the session around the action. If the session cannot be setup for the requested shop the request will be redirected to login.
 
 The concern will load sessions depending on your app's configuration:
@@ -25,10 +25,10 @@ Since cookies are available, the concern will load the session directly from the
 #### Localization
 I18n localization is saved to the session for consistent translations for the session.
 
-#### CSRF Protection
+#### CSRFProtection
 Implements Rails' [protect_from_forgery](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery) unless a valid session token is found for the request.
 
-#### Embedded App
+#### EmbeddedApp
 If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P header](https://www.w3.org/P3P/) and [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) are handled for you.
 
 #### EnsureBilling

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -31,7 +31,7 @@ Implements Rails' [protect_from_forgery](https://api.rubyonrails.org/classes/Act
 #### Embedded App
 If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P header](https://www.w3.org/P3P/) and [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) are handled for you.
 
-#### Billing Enforcement
+#### EnsureBilling
 If billing is enabled for the app, the active payment for the session is queried and enforced if needed. If billing is required the user will be redirected to a page requesting payment.
 
 ## EnsureAuthenticatedLinks

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -1,0 +1,34 @@
+# Controller Concerns
+
+The following are controller concerns designed to be public controller concerns that can be included in your controllers. Concerns defined in `lib/shopify_app/controller_concerns` are designed to be private concerns and are not meant to be included directly into your controllers.
+
+## Authenticated
+Designed for controllers that are designed to handle authenticated actions by ensuring there is a valid session for the request.
+
+In addition to session management, this concern will also handle localization, CSRF protection, embedded app settings, and billing enforcement.
+
+### Session Management
+This concern will setup and teardown the session around the action. If the session cannot be setup for the requested shop the request will be redirected to login.
+
+### Localization
+I18n localization is saved to the session for consistent translations for the session.
+
+### CSRF Protection
+Implements Rails' [protect_from_forgery](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery) unless a valid session token is found for the request.
+
+### Embedded App
+If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P header](https://www.w3.org/P3P/) and [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) are handled for you.
+
+### Billing Enforcement
+If billing is enabled for the app, the active payment for the session is queried and enforced if needed. If billing is required the user will be redirected to a page requesting payment.
+
+## EnsureAuthenicatedLinks
+Designed to be more of a lightweight session concern specifically for XHR requests. Where `Authenticated` does far more than just session management, this concern will redirect to the splash page of the app if no active session was found.
+
+## RequireKnownShop
+Designed to handle unauthenticated requests. Rather than using the JWT to determine the requested shop of the request, the `shop` name is expected to be passed in the query string. If `shop` wasn't included in the query string params the request will be redirected to the login_url of the app.
+
+If the shop session cannot be found for the provided `shop` in the query string, the requrest will be redirected to login or the `embedded_redirect_url`.
+
+## ShopAccessScopesVerification
+If scopes for the session don't match configuration of scopes defined in `config/initializers/shopify_app.rb` the user will be redirected to login or the `embedded_redirect_url`

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -34,7 +34,7 @@ If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P
 #### Billing Enforcement
 If billing is enabled for the app, the active payment for the session is queried and enforced if needed. If billing is required the user will be redirected to a page requesting payment.
 
-## EnsureAuthenicatedLinks
+## EnsureAuthenticatedLinks
 Designed to be more of a lightweight session concern specifically for XHR requests. Where `Authenticated` does far more than just session management, this concern will redirect to the splash page of the app if no active session was found.
 
 ## RequireKnownShop

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -10,6 +10,18 @@ In addition to session management, this concern will also handle localization, C
 #### Session Management
 This concern will setup and teardown the session around the action. If the session cannot be setup for the requested shop the request will be redirected to login.
 
+The concern will load sessions depending on your app's configuration:
+
+**Embedded apps**
+
+Cookies are not available for embedded apps because it loads in an iframe, so this concern will load the session from the request's `Authorization` header containing a session token, which can be set using [App Bridge](https://shopify.dev/apps/tools/app-bridge).
+
+Learn more about [using `authenticatedFetch`](https://shopify.dev/apps/auth/oauth/session-tokens/getting-started#step-2-authenticate-your-requests) to create session tokens and authenticate your requests.
+
+**Non-embedded apps**
+
+Since cookies are available, the concern will load the session directly from them, so you can make regular `fetch` requests on your front-end.
+
 #### Localization
 I18n localization is saved to the session for consistent translations for the session.
 


### PR DESCRIPTION
![](https://media.tenor.com/hCZtE5iKltIAAAAd/that-concerns-me-a-little-johnny.gif)

### What this PR does

I'm concerned about the lack of documentation about our controller concerns. :trollface: 

Seeing that there has been a lot of friction with how the `Authenticated` and `RequireKnownShop` controller concern compete with each other to determine the `current_shopify_domain` I felt it would be helpful to document the intents of these concerns so users can know how to best use them.

While I'm [still a fan of renaming these concerns](https://github.com/Shopify/shopify_app/issues/1502) to better match their behavior and intent, I think having docs to explain the intents behind concerns will be helpful even if we rename them in the future.

### Reviewer's guide to testing

Ensure what I have documented matches the intent and functionality of the concerns.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
