### PR TITLE
Detect controller concern clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Unreleased
 ----------
 * Fixes a bug with `EnsureAuthenticatedLinks` causing deep links to not work [#1549](https://github.com/Shopify/shopify_app/pull/1549)
 * Ensure online token is properly used when using `current_shopify_session` [#1566](https://github.com/Shopify/shopify_app/pull/1566)
-* Detect the use of incompatible controller concerns [#1560](https://github.com/Shopify/shopify_app/pull/1560). Depending on how your app is structured, this may result in an error on startup even though the app was working correctly. However, it is helping exposing an existing flaw that may have caused issues in future.
+* Log a deprecation warning for the use of incompatible controller concerns [#1560](https://github.com/Shopify/shopify_app/pull/1560)
 
 21.2.0 (Oct 25, 2022)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 * Fixes a bug with `EnsureAuthenticatedLinks` causing deep links to not work [#1549](https://github.com/Shopify/shopify_app/pull/1549)
 * Ensure online token is properly used when using `current_shopify_session` [#1566](https://github.com/Shopify/shopify_app/pull/1566)
+* Detect the use of incompatible controller concerns [#1560](https://github.com/Shopify/shopify_app/pull/1560). Depending on how your app is structured, this may result in an error on startup even though the app was working correctly. However, it is helping exposing an existing flaw that may have caused issues in future.
 
 21.2.0 (Oct 25, 2022)
 ----------

--- a/app/controllers/concerns/shopify_app/require_known_shop.rb
+++ b/app/controllers/concerns/shopify_app/require_known_shop.rb
@@ -7,9 +7,11 @@ module ShopifyApp
 
     included do
       if ancestors.include?(ShopifyApp::LoginProtection)
-        raise ConfigurationError,
-          "You are attempting to use both RequireKnownShop and LoginProtection in the same controller. "\
-            "These are not compatible."
+        ActiveSupport::Deprecation.warn(<<~EOS)
+          We detected the use of incompatible concerns (RequireKnownShop and LoginProtection) in #{name},
+          which may lead to unpredictable behavior. In a future release of this library this will raise an error.
+        EOS
+
       end
 
       before_action :check_shop_domain

--- a/app/controllers/concerns/shopify_app/require_known_shop.rb
+++ b/app/controllers/concerns/shopify_app/require_known_shop.rb
@@ -6,6 +6,12 @@ module ShopifyApp
     include ShopifyApp::RedirectForEmbedded
 
     included do
+      if ancestors.include?(ShopifyApp::LoginProtection)
+        raise ConfigurationError,
+          "You are attempting to use both RequireKnownShop and LoginProtection in the same controller. "\
+            "These are not compatible."
+      end
+
       before_action :check_shop_domain
       before_action :check_shop_known
     end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -9,6 +9,12 @@ module ShopifyApp
     include ShopifyApp::SanitizedParams
 
     included do
+      if ancestors.include?(ShopifyApp::RequireKnownShop)
+        raise ConfigurationError,
+          "You are attempting to use both RequireKnownShop and LoginProtection in the same controller. "\
+            "These are not compatible."
+      end
+
       after_action :set_test_cookie
       rescue_from ShopifyAPI::Errors::HttpResponseError, with: :handle_http_error
     end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -10,9 +10,10 @@ module ShopifyApp
 
     included do
       if ancestors.include?(ShopifyApp::RequireKnownShop)
-        raise ConfigurationError,
-          "You are attempting to use both RequireKnownShop and LoginProtection in the same controller. "\
-            "These are not compatible."
+        ActiveSupport::Deprecation.warn(<<~EOS)
+          We detected the use of incompatible concerns (RequireKnownShop and LoginProtection) in #{name},
+          which may lead to unpredictable behavior. In a future release of this library this will raise an error.
+        EOS
       end
 
       after_action :set_test_cookie

--- a/test/controllers/concerns/require_known_shop_test.rb
+++ b/test/controllers/concerns/require_known_shop_test.rb
@@ -60,4 +60,20 @@ class RequireKnownShopTest < ActionController::TestCase
 
     assert_response :ok
   end
+
+  test "detects incompatible controller concerns" do
+    assert_raises ShopifyApp::ConfigurationError do
+      Class.new(ApplicationController) do
+        include ShopifyApp::RequireKnownShop
+        include ShopifyApp::LoginProtection
+      end
+    end
+
+    assert_raises ShopifyApp::ConfigurationError do
+      Class.new(ApplicationController) do
+        include ShopifyApp::RequireKnownShop
+        include ShopifyApp::Authenticated # since this indirectly includes LoginProtection
+      end
+    end
+  end
 end

--- a/test/controllers/concerns/require_known_shop_test.rb
+++ b/test/controllers/concerns/require_known_shop_test.rb
@@ -62,17 +62,27 @@ class RequireKnownShopTest < ActionController::TestCase
   end
 
   test "detects incompatible controller concerns" do
-    assert_raises ShopifyApp::ConfigurationError do
+    assert_deprecated(/incompatible concerns/) do
       Class.new(ApplicationController) do
         include ShopifyApp::RequireKnownShop
         include ShopifyApp::LoginProtection
       end
     end
 
-    assert_raises ShopifyApp::ConfigurationError do
+    assert_deprecated(/incompatible concerns/) do
       Class.new(ApplicationController) do
         include ShopifyApp::RequireKnownShop
         include ShopifyApp::Authenticated # since this indirectly includes LoginProtection
+      end
+    end
+
+    assert_deprecated(/incompatible concerns/) do
+      authenticated_controller = Class.new(ApplicationController) do
+        include ShopifyApp::Authenticated
+      end
+
+      Class.new(authenticated_controller) do
+        include ShopifyApp::RequireKnownShop
       end
     end
   end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  include ShopifyApp::LoginProtection
 end

--- a/test/dummy/app/controllers/home_controller.rb
+++ b/test/dummy/app/controllers/home_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
+  include ShopifyApp::EmbeddedApp
+  include ShopifyApp::RequireKnownShop
+
   def index
     "index"
   end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -466,6 +466,15 @@ class LoginProtectionControllerTest < ActionController::TestCase
     end
   end
 
+  test "detects incompatible controller concerns" do
+    assert_raises ShopifyApp::ConfigurationError do
+      Class.new(ApplicationController) do
+        include ShopifyApp::LoginProtection
+        include ShopifyApp::RequireKnownShop
+      end
+    end
+  end
+
   private
 
   def assert_fullpage_redirected(shop_domain, _response)

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -467,7 +467,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "detects incompatible controller concerns" do
-    assert_raises ShopifyApp::ConfigurationError do
+    assert_deprecated(/incompatible concerns/) do
       Class.new(ApplicationController) do
         include ShopifyApp::LoginProtection
         include ShopifyApp::RequireKnownShop


### PR DESCRIPTION
### What this PR does

Closes https://github.com/Shopify/first-party-library-planning/issues/486

`RequireKnownShop` and `LoginProtection` both have a method `current_shopify_domain` but with different implementations. If both these concerns are included, it can result in unintentional behaviour, since one method will overwrite the other.

<!-- Please describe what changes this PR introduces and why they're needed. -->

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

### Things to focus on

1. <!-- Focus on a particular file -->
2. <!-- Is the test case correct? -->
3. <!-- Etc. -->

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
