### PR TITLE
use online tokens when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 * Fixes a bug with `EnsureAuthenticatedLinks` causing deep links to not work [#1549](https://github.com/Shopify/shopify_app/pull/1549)
+* Ensure online token is properly used when using `current_shopify_session` [#1566](https://github.com/Shopify/shopify_app/pull/1566)
 
 21.2.0 (Oct 25, 2022)
 ----------

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -42,7 +42,7 @@ module ShopifyApp
         ShopifyAPI::Utils::SessionUtils.load_current_session(
           auth_header: request.headers["HTTP_AUTHORIZATION"],
           cookies: { cookie_name => cookies.encrypted[cookie_name] },
-          is_online: user_session_expected?,
+          is_online: online_token_configured?,
         )
       rescue ShopifyAPI::Errors::CookieNotFoundError
         nil
@@ -232,11 +232,15 @@ module ShopifyApp
       ShopifyApp::SessionRepository.retrieve_shop_session_by_shopify_domain(sanitize_shop_param(params))
     end
 
+    def online_token_configured?
+      !ShopifyApp.configuration.user_session_repository.blank? && ShopifyApp::SessionRepository.user_storage.present?
+    end
+
     def user_session_expected?
       return false if shop_session.nil?
       return false if ShopifyApp.configuration.shop_access_scopes_strategy.update_access_scopes?(shop_session.shop)
 
-      !ShopifyApp.configuration.user_session_repository.blank? && ShopifyApp::SessionRepository.user_storage.present?
+      online_token_configured?
     end
   end
 end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -79,10 +79,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
   end
 
   test "#current_shopify_session loads online session if user session expected" do
-    ShopifyApp::SessionRepository.shop_storage.stubs(:retrieve_by_shopify_domain)
-      .with(@shop)
-      .returns(mock_session(shop: @shop))
-
     request.headers["HTTP_AUTHORIZATION"] = "Bearer token"
 
     ShopifyAPI::Utils::SessionUtils.expects(:load_current_session)
@@ -116,7 +112,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     end
   end
 
-  test "#current_shopify_session loads offline session if token is signed with new secret" do
+  test "#current_shopify_session loads session if token is signed with new secret" do
     token = mock_jwt_token(ShopifyApp.configuration.secret)
     request.headers["HTTP_AUTHORIZATION"] = "Bearer #{token}"
 
@@ -124,7 +120,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
       .with(
         auth_header: "Bearer #{token}",
         cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => nil },
-        is_online: false,
+        is_online: true,
       )
       .returns(@session)
 
@@ -134,7 +130,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
     end
   end
 
-  test "#current_shopify_session loads offline session if token is signed with old secret" do
+  test "#current_shopify_session loads session if token is signed with old secret" do
     token = mock_jwt_token(ShopifyApp.configuration.old_secret)
     request.headers["HTTP_AUTHORIZATION"] = "Bearer #{token}"
 
@@ -142,7 +138,7 @@ class LoginProtectionControllerTest < ActionController::TestCase
       .with(
         auth_header: "Bearer #{token}",
         cookies: { ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME => nil },
-        is_online: false,
+        is_online: true,
       )
       .returns(@session)
 


### PR DESCRIPTION
### What this PR does

Related to https://github.com/Shopify/shopify-graphiql-app/issues/1069

There is currently logic on when to retrieve an online or offline session token where `current_shopify_session` in the `LoginProtection` concern makes an incorrect assumption on checking if a shop session exists when determining to pass in `is_online` to load the session from the API gem. This check is required for the original OAuth request but any subsequent requests after OAuth should just check if a User session is configured.

### Reviewer's guide to testing

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
