### PR TITLE
Remove outdated Rails 4 note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 This gem builds Rails applications that can be embedded in the Shopify Admin.
 
-[Introduction](#introduction) | 
-[Requirements](#requirements) | 
-[Usage](#usage) | 
-[Documentation](#documentation) | 
+[Introduction](#introduction) |
+[Requirements](#requirements) |
+[Usage](#usage) |
+[Documentation](#documentation) |
 [Contributing](/CONTRIBUTING.md) |
 [License](/LICENSE)
 
@@ -22,15 +22,12 @@ This gem includes a Rails engine, generators, modules, and mixins that help crea
 <!-- This section is linked to in `templates/shopify_app.rb.tt`. Be careful renaming this heading. -->
 ## Requirements
 
-> **Rails compatibility** 
-> * Use Shopify App `<= v7.2.8` if you need to work with Rails 4.
-
 To become a Shopify app developer, you will need a [Shopify Partners](https://www.shopify.com/partners) account. Explore the [Shopify dev docs](https://shopify.dev/concepts/shopify-introduction) to learn more about [building Shopify apps](https://shopify.dev/concepts/apps).
 
 This gem requires that you have the following credentials:
 
-- **Shopify API key:** The API key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations). 
-- **Shopify API secret:** The API secret key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations). 
+- **Shopify API key:** The API key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations).
+- **Shopify API secret:** The API secret key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations).
 
 ## Usage
 
@@ -54,7 +51,7 @@ SHOPIFY_API_KEY=<Your Shopify API key>
 SHOPIFY_API_SECRET=<Your Shopify API secret>
 ```
 
-> In a development environment, you can use a gem like `dotenv-rails` to manage environment variables. 
+> In a development environment, you can use a gem like `dotenv-rails` to manage environment variables.
 
 4. Run the default Shopify App generator to create an app that can be embedded in the Shopify Admin:
 


### PR DESCRIPTION
It's been over 6 years since Rails 5 was released, so I'd say this notice is no longer necessary.

Also I doubt the old gem version would be usable any more due to all the other changes that have happened.