### PR TITLE
Adds an option to use the Rails built in secret store instead dotenv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ SHOPIFY_API_KEY=<Your Shopify API key>
 SHOPIFY_API_SECRET=<Your Shopify API secret>
 ```
 
+Optionally, use built-in Rails secret store:
+
+Open the secret store by running:
+
+```sh
+EDITOR="vi" rails credentials:edit --environment=development
+```
+
+Add the following to the file:
+
+```sh
+shopify:
+  host: http://localhost:3000
+  api_key: <Your Shopify API key>
+  api_secret: <Your Shopify API secret>
+```
+
 4. Run the default Shopify App generator to create an app that can be embedded in the Shopify Admin:
 
 ```sh

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -10,8 +10,8 @@ ShopifyApp.configure do |config|
   config.log_level = :info
   config.reauth_on_access_scope_changes = true
 
-  config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence
-  config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence
+  config.api_key = Rails.application.credentials.shopify[:api_key] || ENV.fetch('SHOPIFY_API_KEY', '').presence
+  config.secret = Rails.application.credentials.shopify[:api_secret] || ENV.fetch('SHOPIFY_API_SECRET', '').presence
 
   # You may want to charge merchants for using your app. Setting the billing configuration will cause the Authenticated
   # controller concern to check that the session is for a merchant that has an active one-time payment or subscription.


### PR DESCRIPTION
### What this PR does

Allows optionally using Rails secret store instead of .env file.  The api key and api secret can now also be accessed via Rails.application.credentials.shopify[:api_key] and Rails.application.credentials.shopify[:api_secret]

### Reviewer's guide to testing

This does not change functionality. To test, remove the api key and secret from .env, and add the following to the Rails secret store with:

EDITOR="vi" rails credentials:edit --environment=development

shopify:
  host: http://localhost:3000
  api_key: <Your Shopify API key>
  api_secret: <Your Shopify API secret>

### Checklist
- [x] Update `README.md`, if appropriate.
