### PR TITLE
Add configuration option for user access scopes strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Add configuration option for user access strategy [#1599](https://github.com/Shopify/shopify_app/pull/1599)
 * Fixes a bug with `EnsureAuthenticatedLinks` causing deep links to not work [#1549](https://github.com/Shopify/shopify_app/pull/1549)
 * Ensure online token is properly used when using `current_shopify_session` [#1566](https://github.com/Shopify/shopify_app/pull/1566)
 * Added debug logs, you can read more about logging [here](./docs/logging.md). [#1545](https://github.com/Shopify/shopify_app/pull/1545)

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -83,7 +83,17 @@ module ShopifyApp
       ShopifyApp::AccessScopes::ShopStrategy
     end
 
+    def user_access_scopes_strategy=(class_name)
+      unless class_name.is_a?(String)
+        raise ConfigurationError, "Invalid user access scopes strategy - expected a string"
+      end
+
+      @user_access_scopes_strategy = class_name.safe_constantize
+    end
+
     def user_access_scopes_strategy
+      return @user_access_scopes_strategy if @user_access_scopes_strategy
+
       return ShopifyApp::AccessScopes::NoopStrategy unless reauth_on_access_scope_changes
 
       ShopifyApp::AccessScopes::UserStrategy

--- a/test/shopify_app/configuration_test.rb
+++ b/test/shopify_app/configuration_test.rb
@@ -209,4 +209,23 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal ShopifyApp::AccessScopes::ShopStrategy, ShopifyApp.configuration.shop_access_scopes_strategy
     assert_equal ShopifyApp::AccessScopes::UserStrategy, ShopifyApp.configuration.user_access_scopes_strategy
   end
+
+  test "user access scopes strategy is configurable with a string" do
+    my_strategy = "Object"
+    ShopifyApp.configure do |config|
+      config.user_access_scopes_strategy = my_strategy
+    end
+
+    assert_equal ShopifyApp::AccessScopes::NoopStrategy, ShopifyApp.configuration.shop_access_scopes_strategy
+    assert_equal Object, ShopifyApp.configuration.user_access_scopes_strategy
+  end
+
+  test "user access scopes strategy is not configurable with a constant" do
+    error = assert_raises ShopifyApp::ConfigurationError do
+      ShopifyApp.configure do |config|
+        config.user_access_scopes_strategy = Object
+      end
+    end
+    assert_equal "Invalid user access scopes strategy - expected a string", error.message
+  end
 end


### PR DESCRIPTION
### What this PR does

The gem currently provides two strategies for verifying user scopes:

* ShopifyApp::AccessScopes::NoopStrategy 
* ShopifyApp::AccessScopes::UserStrategy

Some apps (likely only first party apps made by Shopify) may have special requirements and need to use a different strategy. This PR adds a configuration option to allow that.

<!-- Please describe what changes this PR introduces and why they're needed. -->

### Reviewer's guide to testing

Reach out to me on Slack to discuss.

### Things to focus on

1. Is there any way this could break an existing app?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
