### PR TITLE
Move covered scopes check into strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Move covered scopes check into user access strategy [#1600](https://github.com/Shopify/shopify_app/pull/1600)
 * Add configuration option for user access strategy [#1599](https://github.com/Shopify/shopify_app/pull/1599)
 * Fixes a bug with `EnsureAuthenticatedLinks` causing deep links to not work [#1549](https://github.com/Shopify/shopify_app/pull/1549)
 * Ensure online token is properly used when using `current_shopify_session` [#1566](https://github.com/Shopify/shopify_app/pull/1566)

--- a/lib/shopify_app/access_scopes/noop_strategy.rb
+++ b/lib/shopify_app/access_scopes/noop_strategy.rb
@@ -8,7 +8,7 @@ module ShopifyApp
           false
         end
 
-        def covered_scopes?(*_args)
+        def covers_scopes?(*_args)
           true
         end
       end

--- a/lib/shopify_app/access_scopes/noop_strategy.rb
+++ b/lib/shopify_app/access_scopes/noop_strategy.rb
@@ -7,6 +7,10 @@ module ShopifyApp
         def update_access_scopes?(*_args)
           false
         end
+
+        def covered_scopes?(*_args)
+          true
+        end
       end
     end
   end

--- a/lib/shopify_app/access_scopes/user_strategy.rb
+++ b/lib/shopify_app/access_scopes/user_strategy.rb
@@ -12,6 +12,11 @@ module ShopifyApp
             "#update_access_scopes? requires user_id or shopify_user_id parameter inputs")
         end
 
+        def covered_scopes?(current_shopify_session)
+          # NOTE: this not Ruby's `covers?` method, it is defined in ShopifyAPI::Auth::AuthScopes
+          current_shopify_session.scope.to_a.empty? || current_shopify_session.scope.covers?(ShopifyAPI::Context.scope)
+        end
+
         private
 
         def update_access_scopes_for_user_id?(user_id)

--- a/lib/shopify_app/access_scopes/user_strategy.rb
+++ b/lib/shopify_app/access_scopes/user_strategy.rb
@@ -12,7 +12,7 @@ module ShopifyApp
             "#update_access_scopes? requires user_id or shopify_user_id parameter inputs")
         end
 
-        def covered_scopes?(current_shopify_session)
+        def covers_scopes?(current_shopify_session)
           # NOTE: this not Ruby's `covers?` method, it is defined in ShopifyAPI::Auth::AuthScopes
           current_shopify_session.scope.to_a.empty? || current_shopify_session.scope.covers?(ShopifyAPI::Context.scope)
         end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -29,7 +29,7 @@ module ShopifyApp
         return redirect_to_login
       end
 
-      unless ShopifyApp.configuration.user_access_scopes_strategy.covered_scopes?(current_shopify_session)
+      unless ShopifyApp.configuration.user_access_scopes_strategy.covers_scopes?(current_shopify_session)
         clear_shopify_session
         return redirect_to_login
       end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -29,9 +29,7 @@ module ShopifyApp
         return redirect_to_login
       end
 
-      unless current_shopify_session.scope.to_a.empty? ||
-          current_shopify_session.scope.covers?(ShopifyAPI::Context.scope)
-
+      unless ShopifyApp.configuration.user_access_scopes_strategy.covered_scopes?(current_shopify_session)
         clear_shopify_session
         return redirect_to_login
       end


### PR DESCRIPTION
### What this PR does

There are two places that we check the user's scopes when determining if a re-auth is needed:

* `update_access_scopes?` in the access scopes user strategy.
* in `LoginProtection#activate_shopify_session` 

In #1599 we added an option to set the user strategy. But this has a gap, since only one of the above listed places is within the strategy. To have proper control over these checks, we need both of them to be in the strategy.

This PR aims to not alter any existing behaviour, it only moves code around.

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

### Things to focus on

1. <!-- Focus on a particular file -->
2. <!-- Is the test case correct? -->
3. <!-- Etc. -->

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
