### PR TITLE
Remove `Itp` from `LoginProtection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 * Log a deprecation warning for the use of incompatible controller concerns [#1560](https://github.com/Shopify/shopify_app/pull/1560)
 * Fixes bug with expired sessions for embedded apps returning a 500 instead of 401 [#1580](https://github.com/Shopify/shopify_app/pull/1580)
 * Generator properly handles uninstall [#1597](https://github.com/Shopify/shopify_app/pull/1597)
+* Remove `Itp` from `LoginProtection`. See the upgrading docs for more information. [#1604](https://github.com/Shopify/shopify_app/pull/1604)
 
 21.2.0 (Oct 25, 2022)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased
 * Log a deprecation warning for the use of incompatible controller concerns [#1560](https://github.com/Shopify/shopify_app/pull/1560)
 * Fixes bug with expired sessions for embedded apps returning a 500 instead of 401 [#1580](https://github.com/Shopify/shopify_app/pull/1580)
 * Generator properly handles uninstall [#1597](https://github.com/Shopify/shopify_app/pull/1597)
-* Remove `Itp` from `LoginProtection`. See the upgrading docs for more information. [#1604](https://github.com/Shopify/shopify_app/pull/1604)
+* Remove `Itp` from `LoginProtection`. See the [upgrading docs](https://github.com/Shopify/shopify_app/blob/main/docs/Upgrading.md) for more information. [#1604](https://github.com/Shopify/shopify_app/pull/1604)
 
 21.2.0 (Oct 25, 2022)
 ----------

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -38,7 +38,7 @@ We also recommend the use of a staging site which matches your production enviro
 
 If you do run into issues, we recommend looking at our [debugging tips.](https://github.com/Shopify/shopify_app/blob/main/docs/Troubleshooting.md#debugging-tips)
 
-## Unreleased
+## Upgrading to 21.3.0
 The `Itp` controller concern has been removed from `LoginProtection`.
 If any of your controllers are dependant on methods from `Itp` then you can include `ShopifyApp::Itp` directly.
 You may notice a deprecation notice saying, `Itp will be removed in an upcoming version`.

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -6,6 +6,8 @@ This file documents important changes needed to upgrade your app's Shopify App v
 
 [General Advice](#general-advice)
 
+[Unreleased](#unreleased)
+
 [Upgrading to `v20.3.0`](#upgrading-to-v2030)
 
 [Upgrading to `v20.2.0`](#upgrading-to-v2020)
@@ -35,6 +37,12 @@ If you need to upgrade by more than one major version (e.g. from v18 to v20), we
 We also recommend the use of a staging site which matches your production environment as closely as possible.
 
 If you do run into issues, we recommend looking at our [debugging tips.](https://github.com/Shopify/shopify_app/blob/main/docs/Troubleshooting.md#debugging-tips)
+
+## Unreleased
+The `Itp` controller concern has been removed from `LoginProtection`.
+If any of your controllers are dependant on methods from `Itp` then you can include `ShopifyApp::Itp` directly.
+You may notice a deprecation notice saying, `Itp will be removed in an upcoming version`.
+This is because we intend on removing `Itp` completely in `v22.0.0`, but this will work in the meantime.
 
 ## Upgrading to `v20.3.0`
 Calling `LoginProtection#current_shopify_domain` will no longer raise an error if there is no active session. It will now return a nil value. The internal behavior of raising an error on OAuth redirect is still in place, however. If you were calling `current_shopify_domain` in authenticated actions and expecting an error if nil, you'll need to do a presence check and raise that error within your app.

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -39,7 +39,7 @@ We also recommend the use of a staging site which matches your production enviro
 If you do run into issues, we recommend looking at our [debugging tips.](https://github.com/Shopify/shopify_app/blob/main/docs/Troubleshooting.md#debugging-tips)
 
 ## Upgrading to 21.3.0
-The `Itp` controller concern has been removed from `LoginProtection`.
+The `Itp` controller concern has been removed from `LoginProtection` which is included by the `Authenticated` controller concern.
 If any of your controllers are dependant on methods from `Itp` then you can include `ShopifyApp::Itp` directly.
 You may notice a deprecation notice saying, `Itp will be removed in an upcoming version`.
 This is because we intend on removing `Itp` completely in `v22.0.0`, but this will work in the meantime.

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -5,7 +5,6 @@ require "browser_sniffer"
 module ShopifyApp
   module LoginProtection
     extend ActiveSupport::Concern
-    include ShopifyApp::Itp
     include ShopifyApp::SanitizedParams
 
     included do
@@ -17,7 +16,6 @@ module ShopifyApp
         ShopifyApp::Logger.deprecated(message, "22.0.0")
       end
 
-      after_action :set_test_cookie
       rescue_from ShopifyAPI::Errors::HttpResponseError, with: :handle_http_error
     end
 


### PR DESCRIPTION
### What this PR does

`Itp`'s deprecation logs were getting sent when loading `LoginProtection`. 

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
