### PR TITLE
allow trusted shopify domains when sanitizing

### DIFF
--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -2,14 +2,22 @@
 
 module ShopifyApp
   module Utils
+    TRUSTED_SHOPIFY_DOMAINS = [
+      "shopify.com",
+      "shopify.io",
+      "myshopify.com",
+    ].freeze
+
     def self.sanitize_shop_domain(shop_domain)
       myshopify_domain = ShopifyApp.configuration.myshopify_domain
       name = shop_domain.to_s.downcase.strip
       name += ".#{myshopify_domain}" if !name.include?(myshopify_domain.to_s) && !name.include?(".")
       name.sub!(%r|https?://|, "")
+      trusted_domains = TRUSTED_SHOPIFY_DOMAINS.dup.push(myshopify_domain)
 
       u = URI("http://#{name}")
-      u.host if u.host&.match(/^[a-z0-9][a-z0-9\-]*[a-z0-9]\.#{Regexp.escape(myshopify_domain)}$/)
+      regex = /^[a-z0-9][a-z0-9\-]*[a-z0-9]\.(#{trusted_domains.join("|")})$/
+      u.host if u.host&.match(regex)
     rescue URI::InvalidURIError
       nil
     end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -26,6 +26,10 @@ class UtilsTest < ActiveSupport::TestCase
     assert ShopifyApp::Utils.sanitize_shop_domain("MY-shop.myshopify.com")
   end
 
+  test "unified admin is still trusted as a sanitzed domain" do
+    assert ShopifyApp::Utils.sanitize_shop_domain("admin.shopify.com/some_shope_over_the_rainbow")
+  end
+
   ["myshop.com", "myshopify.com", "shopify.com", "two words", "store.myshopify.com.evil.com",
    "/foo/bar", "foo.myshopify.io.evil.ru", "%0a123.myshopify.io",
    "foo.bar.myshopify.io",].each do |bad_url|


### PR DESCRIPTION
![](https://media.tenor.com/bbTnU1RnQugAAAAd/mod-emre.gif)

### What this PR does

As Shopify rolls out a new unified admin experience, we can expect to see stores use `admin.shopify.com` instead of what they had configured in `myshopify_domain` (which typically defaults to `myshopify.com`).

This PR will trust Shopify domains even if they differ from what the app has configured on their `myshopify_domain` configuration. 


### Reviewer's guide to testing

Should still be able to install app using this gem.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
