### PR TITLE
Remove Logged output for rescued JWT exceptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ----------
-* Remove Logged output for rescued JWT exceptions [#1610](https://github.com/Shopify/shopify_app/pull/1610)
+* Removed Logged output for rescued JWT exceptions [#1610](https://github.com/Shopify/shopify_app/pull/1610)
 
 21.3.1 (Dec 12, 2022)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Remove Logged output for rescued JWT exceptions [#1610](https://github.com/Shopify/shopify_app/pull/1610)
 
 21.3.1 (Dec 12, 2022)
 ----------

--- a/lib/shopify_app/session/jwt.rb
+++ b/lib/shopify_app/session/jwt.rb
@@ -34,8 +34,7 @@ module ShopifyApp
     def set_payload
       payload, _ = parse_token_data(ShopifyApp.configuration&.secret, ShopifyApp.configuration&.old_secret)
       @payload = validate_payload(payload)
-    rescue *WARN_EXCEPTIONS => error
-      ShopifyApp::Logger.warn("Failed to validate JWT: [#{error.class}] #{error}")
+    rescue *WARN_EXCEPTIONS
       nil
     end
 

--- a/test/shopify_app/session/jwt_test.rb
+++ b/test/shopify_app/session/jwt_test.rb
@@ -43,8 +43,6 @@ module ShopifyApp
     end
 
     test "shopify_domain and shopify_user_id are nil if the jwt is invalid" do
-      expect_jwt_error(::JWT::DecodeError, "Not enough or too many segments")
-
       jwt = JWT.new("token")
 
       assert_nil jwt.shopify_domain
@@ -52,9 +50,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if the jwt is unsigned" do
-      # The library expects there to be a 3rd segment if we want to verify signature
-      expect_jwt_error(::JWT::IncorrectAlgorithm, "Expected a different algorithm")
-
       t = ::JWT.encode(payload, nil, "none")
       jwt = JWT.new(t)
 
@@ -63,8 +58,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if the signature is bad" do
-      expect_jwt_error(::JWT::VerificationError, "Signature verification failed")
-
       t = ::JWT.encode(payload, "bad", "HS256")
       jwt = JWT.new(t)
 
@@ -73,8 +66,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if 'aud' claim doesn't match api_key" do
-      expect_jwt_error(::ShopifyApp::InvalidAudienceError, "'aud' claim does not match api_key")
-
       ShopifyApp.configuration.api_key = "other_key"
 
       p = payload
@@ -85,8 +76,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if 'exp' claim is in the past" do
-      expect_jwt_error(::JWT::ExpiredSignature, "Signature has expired")
-
       p = payload(exp: 1.day.ago)
       jwt = JWT.new(token(p))
 
@@ -95,8 +84,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if 'nbf' claim is in the future" do
-      expect_jwt_error(::JWT::ImmatureSignature, "Signature nbf has not been reached")
-
       p = payload(nbf: 1.day.from_now)
       jwt = JWT.new(token(p))
 
@@ -105,8 +92,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if `dest` is not a valid shopify domain" do
-      expect_jwt_error(::ShopifyApp::InvalidDestinationError, "'dest' claim host not a valid shopify host")
-
       p = payload(dest: "https://example.com")
       jwt = JWT.new(token(p))
 
@@ -115,8 +100,6 @@ module ShopifyApp
     end
 
     test "#shopify_domain and #shopify_user_id are nil if `iss` host doesn't match `dest` host" do
-      expect_jwt_error(::ShopifyApp::MismatchedHostsError, "'dest' claim host does not match 'iss' claim host")
-
       p = payload(dest: "https://other.myshopify.io")
       jwt = JWT.new(token(p))
 
@@ -133,11 +116,6 @@ module ShopifyApp
     end
 
     private
-
-    def expect_jwt_error(klass, message)
-      message = "Failed to validate JWT: [#{klass}] #{message}"
-      ShopifyApp::Logger.expects(:warn).with(message)
-    end
 
     def token(payload)
       ::JWT.encode(payload, ShopifyApp.configuration.secret, "HS256")


### PR DESCRIPTION
### What this PR does

fixes: https://github.com/Shopify/shopify_app/issues/1567

We decided to remove this logged output. If we feel like we need it again we should consider putting it in a lower log level like `:debug` or `:info` so it would be easier for devs to turn off.

### Things to focus on

1. Do we like this approach?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
