### PR TITLE
WIP - Validate store sessions 

### DIFF
--- a/app/controllers/concerns/shopify_app/ensure_installed.rb
+++ b/app/controllers/concerns/shopify_app/ensure_installed.rb
@@ -17,6 +17,7 @@ module ShopifyApp
 
       before_action :check_shop_domain
       before_action :check_shop_known
+      before_action :validate_emebedded_session_is_active, if: :embedded_param?
     end
 
     def current_shopify_domain
@@ -28,6 +29,10 @@ module ShopifyApp
       @shopify_domain ||= ShopifyApp::Utils.sanitize_shop_domain(params[:shop])
       ShopifyApp::Logger.info("Installed store:  #{@shopify_domain} - deduced from Shopify Admin params")
       @shopify_domain
+    end
+
+    def installed_shop_session
+      @installed_shop_session ||= @shop
     end
 
     private
@@ -57,6 +62,13 @@ module ShopifyApp
       )
 
       url.to_s
+    end
+
+    def validate_emebedded_session_is_active
+      client = ShopifyAPI::Clients::Rest::Admin.new(session: installed_shop_session)
+      client.get(path: "shop")
+    rescue ShopifyAPI::Errors::HttpResponseError
+      redirect_for_embedded
     end
   end
 end


### PR DESCRIPTION
![](https://media.tenor.com/mbniZE9gjV0AAAAC/the-door-barney-gumble.gif)

### What this PR does

When a store uninstalls an app we are currently dependent upon the uninstall webhook to tell our apps that a store should no longer be able to access the API / app resources. This leads to apps getting rejected using our templates as reported in #1591 .  

This PR will do a lightweight API call after it has found the shop session in storage to ensure it is still valid. If it is not, it will redirect to the embedded login url.

### Reviewer's guide to testing

Still figuring out how to test this locally 😅 


### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
