### PR TITLE
Remove `OmniAuth` from the Docs

### DIFF
--- a/docs/shopify_app/engine.md
+++ b/docs/shopify_app/engine.md
@@ -27,11 +27,12 @@ The engine may also be mounted at a nested route, for example:
 mount ShopifyApp::Engine, at: '/nested'
 ```
 
-This will create the Shopify engine routes under the specified subpath. You'll also need to make some updates to your `shopify_app.rb`. Update the shopify_app initializer to include a custom `root_url` e.g.:
+This will create the Shopify engine routes under the specified subpath. You'll also need to make some updates to your `shopify_app.rb`. Update the shopify_app initializer to include a custom `root_url` and `login_callback_url` e.g.:
 
 ```ruby
 ShopifyApp.configure do |config|
   config.root_url = '/nested'
+  config.login_callback_url = '/nested/auth/shopify/callback'
 end
 ```
 

--- a/docs/shopify_app/engine.md
+++ b/docs/shopify_app/engine.md
@@ -27,22 +27,12 @@ The engine may also be mounted at a nested route, for example:
 mount ShopifyApp::Engine, at: '/nested'
 ```
 
-This will create the Shopify engine routes under the specified subpath. You'll also need to make some updates to your `shopify_app.rb` and `omniauth.rb` initializers. First, update the shopify_app initializer to include a custom `root_url` e.g.:
+This will create the Shopify engine routes under the specified subpath. You'll also need to make some updates to your `shopify_app.rb`. Update the shopify_app initializer to include a custom `root_url` e.g.:
 
 ```ruby
 ShopifyApp.configure do |config|
   config.root_url = '/nested'
 end
-```
-
-then update the omniauth initializer to include a custom `callback_path` e.g.:
-
-```ruby
-provider :shopify,
-  ShopifyApp.configuration.api_key,
-  ShopifyApp.configuration.secret,
-  scope: ShopifyApp.configuration.scope,
-  callback_path: '/nested/auth/shopify/callback'
 ```
 
 You may also need to change your `config/routes.rb` to render a view for `/nested`, since this is what will be rendered in the Shopify Admin of any shops that have installed your app.  The engine itself doesn't have a view for this, so you'll need something like this:

--- a/docs/shopify_app/session-repository.md
+++ b/docs/shopify_app/session-repository.md
@@ -74,7 +74,6 @@ end
 2. Ensure that both your `Shop` model and `User` model includes the necessary concerns `ShopifyApp::ShopSessionStorage` and `ShopifyApp::UserSessionStorage`.
 3. Make changes to the `shopify_app.rb` initializer file as shown below:
 ```ruby
-# In the `shopify_app.rb` initializer:
 config.shop_session_repository = {YOUR_SHOP_MODEL_CLASS}
 config.user_session_repository = {YOUR_USER_MODEL_CLASS}
 ```

--- a/docs/shopify_app/session-repository.md
+++ b/docs/shopify_app/session-repository.md
@@ -74,6 +74,7 @@ end
 2. Ensure that both your `Shop` model and `User` model includes the necessary concerns `ShopifyApp::ShopSessionStorage` and `ShopifyApp::UserSessionStorage`.
 3. Make changes to the `shopify_app.rb` initializer file as shown below:
 ```ruby
+# In the `shopify_app.rb` initializer:
 config.shop_session_repository = {YOUR_SHOP_MODEL_CLASS}
 config.user_session_repository = {YOUR_USER_MODEL_CLASS}
 ```

--- a/docs/shopify_app/session-repository.md
+++ b/docs/shopify_app/session-repository.md
@@ -72,17 +72,8 @@ end
 
 1. Run the `user_model` generator as mentioned above.
 2. Ensure that both your `Shop` model and `User` model includes the necessary concerns `ShopifyApp::ShopSessionStorage` and `ShopifyApp::UserSessionStorage`.
-3. Make changes to 2 initializer files as shown below:
+3. Make changes to the `shopify_app.rb` initializer file as shown below:
 ```ruby
-# In the `omniauth.rb` initializer:
-provider :shopify,
-  ...
-  setup: lambda { |env|
-    configuration = ShopifyApp::OmniAuthConfiguration.new(env['omniauth.strategy'], Rack::Request.new(env))
-    configuration.build_options
-  }
-
-# In the `shopify_app.rb` initializer:
 config.shop_session_repository = {YOUR_SHOP_MODEL_CLASS}
 config.user_session_repository = {YOUR_USER_MODEL_CLASS}
 ```


### PR DESCRIPTION
### What this PR does

<!-- Please describe what changes this PR introduces and why they're needed. -->
This removes all reference to the `omniauth.rb`. We aren't generating this file anymore so we should be safe to remove this documentation. We originally stopped generating `omniauth.rb` [here](https://github.com/Shopify/shopify_app/commit/6f1d779cfce7aec7e0b3a15b7ec64601aeec130b#diff-0c8ed94603ea781e0532daf48ed4389f23be762f6cbcc849ef7032ab8148fb89).

address: https://github.com/Shopify/shopify_app/issues/1541

### Reviewer's guide to testing

1. I need to go through the steps in each of the docs I edited. If the docs work as expected we should be good to ship.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
