### PR TITLE
Allow a more complex customized `myshopify_domain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 * Removed Logged output for rescued JWT exceptions [#1610](https://github.com/Shopify/shopify_app/pull/1610)
 * Fixes a bug with `ShopifyApp::WebhooksManager.destroy_webhooks` causing not passing session arguments to [unregister](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/webhooks/registry.rb#L99) method [#1569](https://github.com/Shopify/shopify_app/pull/1569)
 * Validates shop's offline session token is still valid when using `EnsureInstalled`[#1612](https://github.com/Shopify/shopify_app/pull/1612)
+* Allows use of multiple subdomains with myshopify_domain [#1620](https://github.com/Shopify/shopify_app/pull/1620)
 
 21.3.1 (Dec 12, 2022)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     shopify_app (21.3.1)
       activeresource
+      addressable (~> 2.7)
       browser_sniffer (~> 2.0)
       jwt (>= 2.2.3)
       rails (> 5.2.1)

--- a/app/controllers/concerns/shopify_app/ensure_installed.rb
+++ b/app/controllers/concerns/shopify_app/ensure_installed.rb
@@ -70,6 +70,7 @@ module ShopifyApp
       client = ShopifyAPI::Clients::Rest::Admin.new(session: installed_shop_session)
       client.get(path: "shop")
     rescue ShopifyAPI::Errors::HttpResponseError => error
+      ShopifyApp::Logger.info("Shop offline session no longer valid. Redirecting to OAuth install")
       redirect_to(shop_login) if error.code == 401
       raise error if error.code != 401
     end

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -13,6 +13,7 @@ module ShopifyApp
         deprecate_callback_rescue(error) unless error.class.module_parent == ShopifyAPI::Errors
         return respond_with_error
       end
+      binding.pry
 
       save_session(api_session) if api_session
       update_rails_cookie(api_session, cookie)

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -87,6 +87,7 @@ module ShopifyApp
       sanitized_host = ShopifyApp::Utils.sanitize_shop_domain(URI(decoded_host).host)
       if sanitized_host.nil?
         ShopifyApp::Logger.info("host param from callback is not from a trusted domain")
+        ShopifyApp::Logger.info("redirecting to root as this is likely a phishing attack")
       end
       sanitized_host.nil?
     end

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -5,6 +5,7 @@ require "shopify_app/version"
 # deps
 require "shopify_api"
 require "redirect_safely"
+require "addressable"
 
 module ShopifyApp
   def self.rails6?

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -12,7 +12,7 @@ module ShopifyApp
     def self.sanitize_shop_domain(shop_domain)
       myshopify_domain = ShopifyApp.configuration.myshopify_domain
       name = shop_domain.to_s.downcase.strip
-      name = "https://" + name unless name.include?("http")
+      name = "https://" + name unless name.include?("http://") || name.include?("https://")
       name += ".#{myshopify_domain}" if !name.include?(myshopify_domain.to_s) && !name.include?(".")
       uri = Addressable::URI.parse(name)
 

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -56,7 +56,7 @@ module ShopifyApp
         name += ".#{myshopify_domain}" if !name.include?(myshopify_domain.to_s) && !name.include?(".")
         uri = Addressable::URI.parse(name)
 
-        if uri.host.nil? && uri.scheme.nil?
+        if uri.scheme.nil?
           name = "https://" + name
           uri = Addressable::URI.parse(name)
         end

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -19,9 +19,18 @@ module ShopifyApp
       trusted_domains = TRUSTED_SHOPIFY_DOMAINS.dup
       trusted_domains.push(myshopify_domain) if myshopify_domain
 
-      if trusted_domains.any? { |trusted_domain| trusted_domain == uri.domain }
-        uri.host
+      trusted_domains.each do |trusted_domain|
+        no_shop_name_in_subdomain = uri.host == trusted_domain
+        from_trusted_domain = trusted_domain == uri.domain
+        invalid_characters = uri.host.split("").any? do |character|
+          character !~ /([a-zA-Z]|\d+|-|_|\.)/
+        end
+
+        return nil if no_shop_name_in_subdomain || uri.host.empty? || invalid_characters
+        return uri.host if from_trusted_domain
       end
+
+      nil
     rescue Addressable::URI::InvalidURIError
       nil
     end

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -2,48 +2,69 @@
 
 module ShopifyApp
   module Utils
-    TRUSTED_SHOPIFY_DOMAINS = [
-      "shopify.com",
-      "myshopify.io",
-      "myshopify.com",
-      "spin.dev",
-    ].freeze
+    class << self
+      TRUSTED_SHOPIFY_DOMAINS = [
+        "shopify.com",
+        "myshopify.io",
+        "myshopify.com",
+        "spin.dev",
+      ].freeze
 
-    def self.sanitize_shop_domain(shop_domain)
-      myshopify_domain = ShopifyApp.configuration.myshopify_domain
-      name = shop_domain.to_s.downcase.strip
-      name = "https://" + name unless name.include?("http://") || name.include?("https://")
-      name += ".#{myshopify_domain}" if !name.include?(myshopify_domain.to_s) && !name.include?(".")
-      uri = Addressable::URI.parse(name)
+      def sanitize_shop_domain(shop_domain)
+        uri = uri_from_shop_domain(shop_domain)
+        return nil if uri.nil?
 
-      trusted_domains = TRUSTED_SHOPIFY_DOMAINS.dup
-      trusted_domains.append(myshopify_domain).uniq! if myshopify_domain
+        trusted_domains.each do |trusted_domain|
+          no_shop_name_in_subdomain = uri.host == trusted_domain
+          from_trusted_domain = trusted_domain == uri.domain
 
-      trusted_domains.each do |trusted_domain|
-        no_shop_name_in_subdomain = uri.host == trusted_domain
-        from_trusted_domain = trusted_domain == uri.domain
+          return nil if no_shop_name_in_subdomain || uri.host&.empty?
+          return uri.host if from_trusted_domain
+        end
 
-        return nil if no_shop_name_in_subdomain || uri.host.empty?
-        return uri.host if from_trusted_domain
+        nil
       end
 
-      nil
-    rescue Addressable::URI::InvalidURIError
-      nil
-    end
+      def shop_login_url(shop:, host:, return_to:)
+        return ShopifyApp.configuration.login_url unless shop
 
-    def self.shop_login_url(shop:, host:, return_to:)
-      return ShopifyApp.configuration.login_url unless shop
+        url = URI(ShopifyApp.configuration.login_url)
 
-      url = URI(ShopifyApp.configuration.login_url)
+        url.query = URI.encode_www_form(
+          shop: shop,
+          host: host,
+          return_to: return_to,
+        )
 
-      url.query = URI.encode_www_form(
-        shop: shop,
-        host: host,
-        return_to: return_to,
-      )
+        url.to_s
+      end
 
-      url.to_s
+      private
+
+      def myshopify_domain
+        ShopifyApp.configuration.myshopify_domain
+      end
+
+      def trusted_domains
+        trusted_domains = TRUSTED_SHOPIFY_DOMAINS.dup
+        trusted_domains.append(myshopify_domain).uniq! if myshopify_domain
+        trusted_domains
+      end
+
+      def uri_from_shop_domain(shop_domain)
+        name = shop_domain.to_s.downcase.strip
+        name += ".#{myshopify_domain}" if !name.include?(myshopify_domain.to_s) && !name.include?(".")
+        uri = Addressable::URI.parse(name)
+
+        if uri.host.nil? && uri.scheme.nil?
+          name = "https://" + name
+          uri = Addressable::URI.parse(name)
+        end
+
+        uri
+      rescue Addressable::URI::InvalidURIError
+        nil
+      end
     end
   end
 end

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -17,16 +17,13 @@ module ShopifyApp
       uri = Addressable::URI.parse(name)
 
       trusted_domains = TRUSTED_SHOPIFY_DOMAINS.dup
-      trusted_domains.push(myshopify_domain) if myshopify_domain
+      trusted_domains.append(myshopify_domain).uniq! if myshopify_domain
 
       trusted_domains.each do |trusted_domain|
         no_shop_name_in_subdomain = uri.host == trusted_domain
         from_trusted_domain = trusted_domain == uri.domain
-        invalid_characters = uri.host.split("").any? do |character|
-          character !~ /([a-zA-Z]|\d+|-|_|\.)/
-        end
 
-        return nil if no_shop_name_in_subdomain || uri.host.empty? || invalid_characters
+        return nil if no_shop_name_in_subdomain || uri.host.empty?
         return uri.host if from_trusted_domain
       end
 

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
   s.add_runtime_dependency("shopify_api", "~> 12.3")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
+  s.add_runtime_dependency("addressable", "~> 2.7")
 
   s.add_development_dependency("byebug")
   s.add_development_dependency("minitest")

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class UtilsTest < ActiveSupport::TestCase
   setup do
-    ShopifyApp.configuration = nil
+    ShopifyApp.configuration.stubs(:myshopify_domain).returns("myshopify.com")
   end
 
   ["my-shop", "my-shop.myshopify.com",
@@ -22,20 +22,27 @@ class UtilsTest < ActiveSupport::TestCase
     end
   end
 
+  test "sanitize_shop_domain URL shopify spin.dev custom myshopify_domain" do
+    myshop_domain ="http://shopify.foobar-part-onboard-0d6x.asdf-rygus.us.spin.dev"
+    ShopifyApp.configuration.stubs(:myshopify_domain).returns(myshop_domain)
+    unified_admin_url = myshop_domain + "/store/shop1/apps/cool_app_hansel"
+
+    assert ShopifyApp::Utils.sanitize_shop_domain(unified_admin_url)
+  end
+
   test "sanitize_shop_domain for url with uppercase characters" do
     assert ShopifyApp::Utils.sanitize_shop_domain("MY-shop.myshopify.com")
   end
 
-  test "unified admin is still trusted as a sanitzed domain" do
+  test "unified admin is still trusted as a sanitzed domain ZZZZ" do
     ShopifyApp.configuration.stubs(:myshpoify_domain).returns("totally.cool.domain.com")
     assert ShopifyApp::Utils.sanitize_shop_domain("admin.shopify.com/some_shoppe_over_the_rainbow")
     assert ShopifyApp::Utils.sanitize_shop_domain("some-shoppe-over-the-rainbow.myshopify.com")
     assert ShopifyApp::Utils.sanitize_shop_domain("some-shoppe-over-the-rainbow.myshopify.io")
   end
 
-  ["myshop.com", "myshopify.com", "shopify.com", "two words", "store.myshopify.com.evil.com",
-   "/foo/bar", "foo.myshopify.io.evil.ru", "%0a123.myshopify.io",
-   "foo.bar.myshopify.io",].each do |bad_url|
+  ["myshop.com", "two words", "store.myshopify.com.evil.com",
+   "/foo/bar", "foo.myshopify.io.evil.ru",].each do |bad_url|
     test "sanitize_shop_domain for a non-myshopify URL (#{bad_url})" do
       assert_nil ShopifyApp::Utils.sanitize_shop_domain(bad_url)
     end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -42,7 +42,7 @@ class UtilsTest < ActiveSupport::TestCase
   end
 
   ["myshop.com", "myshopify.com", "shopify.com", "two words", "store.myshopify.com.evil.com",
-   "/foo/bar", "foo.myshopify.io.evil.ru", "%0a123.myshopify.io",].each do |bad_url|
+   "/foo/bar", "foo.myshopify.io.evil.ru",].each do |bad_url|
     test "sanitize_shop_domain for a non-myshopify URL (#{bad_url})" do
       assert_nil ShopifyApp::Utils.sanitize_shop_domain(bad_url)
     end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -34,15 +34,15 @@ class UtilsTest < ActiveSupport::TestCase
     assert ShopifyApp::Utils.sanitize_shop_domain("MY-shop.myshopify.com")
   end
 
-  test "unified admin is still trusted as a sanitzed domain ZZZZ" do
+  test "unified admin is still trusted as a sanitzed domain" do
     ShopifyApp.configuration.stubs(:myshpoify_domain).returns("totally.cool.domain.com")
     assert ShopifyApp::Utils.sanitize_shop_domain("admin.shopify.com/some_shoppe_over_the_rainbow")
     assert ShopifyApp::Utils.sanitize_shop_domain("some-shoppe-over-the-rainbow.myshopify.com")
     assert ShopifyApp::Utils.sanitize_shop_domain("some-shoppe-over-the-rainbow.myshopify.io")
   end
 
-  ["myshop.com", "two words", "store.myshopify.com.evil.com",
-   "/foo/bar", "foo.myshopify.io.evil.ru",].each do |bad_url|
+  ["myshop.com", "myshopify.com", "shopify.com", "two words", "store.myshopify.com.evil.com",
+   "/foo/bar", "foo.myshopify.io.evil.ru", "%0a123.myshopify.io",].each do |bad_url|
     test "sanitize_shop_domain for a non-myshopify URL (#{bad_url})" do
       assert_nil ShopifyApp::Utils.sanitize_shop_domain(bad_url)
     end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -15,7 +15,8 @@ class UtilsTest < ActiveSupport::TestCase
     end
   end
 
-  ["my-shop", "my-shop.myshopify.io", "https://my-shop.myshopify.io", "http://my-shop.myshopify.io"].each do |good_url|
+  ["my-shop", "my-shop.myshopify.io", "http-shop-from-qa-hell.myshopify.com",
+   "https://my-shop.myshopify.io", "http://my-shop.myshopify.io",].each do |good_url|
     test "sanitize_shop_domain URL (#{good_url}) with custom myshopify_domain" do
       ShopifyApp.configuration.myshopify_domain = "myshopify.io"
       assert ShopifyApp::Utils.sanitize_shop_domain(good_url)


### PR DESCRIPTION
![](https://media.tenor.com/84jiesbuPZgAAAAC/and-considerably-more-complex-more-complex.gif)

### What this PR does

1. Fixes bug where using a custom `myshopify_domain` with several subdomains would falsely classify the redirect as a phishing attack. This change replaces the regex with `Addressable::URI` which has far more support for all the variants of parsing a URI in ruby.
2. Adds some logging we forgot with previous PRs

### Reviewer's guide to testing

- Should be able to customize `myshopify_domain` with a domain that includes several subdomains and install the app
- Should still be able to use default `myshopify.com` myshopify_domain and install the app


### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
