### PR TITLE
make oauth payload available in callback

### DIFF
--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -8,7 +8,7 @@ module ShopifyApp
 
     def callback
       begin
-        api_session, cookie = validated_auth_objects
+        api_session, cookie, oauth_payload = validated_auth_objects
       rescue => error
         deprecate_callback_rescue(error) unless error.class.module_parent == ShopifyAPI::Errors
         return respond_with_error
@@ -51,7 +51,7 @@ module ShopifyApp
       api_session = oauth_payload.dig(:session)
       cookie = oauth_payload.dig(:cookie)
 
-      [api_session, cookie]
+      [api_session, cookie, oauth_payload]
     end
 
     def update_rails_cookie(api_session, cookie)


### PR DESCRIPTION

### What this PR does

Previously callback_controller had *auth_result* variable available. which can be useful for passing data to custom methods. The change adds the variable back to the callback method. It seems like a better default.

### Things to focus on

callback_controller.rb file only.
