### PR TITLE
Improve github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
@@ -1,0 +1,9 @@
+---
+name: '📈 Enhancement'
+about: Enhancement to our codebase that isn't a adding or changing a feature
+labels: 'Type: Enhancement 📈'
+---
+
+## Overview/summary
+
+<!-- Write a short description of the enhancement here ↓ -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,63 +1,41 @@
 ---
-name: Bug report
-about: Report a technical issue with the Shopify App gem.
-labels: bug
+name: "🐛 Bug Report"
+about: Something isn't working
+labels: "Type: Bug 🐛"
 ---
+
+# Issue summary
 
 <!--
 
-Do you want to ask a question? Are you looking for support? The Shopify Community forum is the best place for getting support: https://community.shopify.com
+Write a short description of the issue here. Please provide any details or logs that
+can help us debug it.
 
-You can also join the Partners Slack Community group: https://www.shopify.com/partners/community#conversation
+Increase the logs as described in the README by setting log_level to :debug, and paste the relevant portion here.
 
-Authentication Issues: A great deal of the issues surrounding this repo are around authenticating (installing) the generated app with Shopify.
-
-If you are experiencing issues with your app authenticating/installing the best way to get help fast is to create a repo with the minimal amount of code to demonstrate the issue and a clearly documented set of steps you took to arrive there. This will help us solve your problem quicker since we won't need to spend any time figuring out how to reproduce the bug. Please also include your operating system and browser.
+Learn more: https://github.com/Shopify/shopify-api-ruby#setup-shopify-context
 
 -->
 
-### Description
+- `shopify_api` version:
+- `shopify_app` version:
+- Ruby version:
+- Operating system:
 
-<!-- Description of the issue -->
+```
+// Paste any relevant logs here
+```
 
-### Steps to Reproduce
+## Expected behavior
 
-1. <!-- First Step -->
-2. <!-- Second Step -->
-3. <!-- and so on… -->
+<!-- What do you think should happen? -->
 
-**Expected behavior:**
+## Actual behavior
 
-<!-- What you expect to happen -->
+<!-- What actually happens? -->
 
-**Actual behavior:**
+## Steps to reproduce the problem
 
-<!-- What actually happens -->
-
-**Reproduces how often:**
-
-<!-- What percentage of the time does it reproduce? -->
-
-### Browsers
-
-<!-- Please specify the browser(s) you have tested that exhibit this behaviour. -->
-
-### Gem versions
-
-<!-- Please specify which version(s) of the gem exhibit this behaviour. -->
-
-### Additional Information
-
-<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. See common examples of important information below. -->
-
-<!-- - [x] My app relies on third-party cookies -->
-<!-- - [x] My app is intended to be a non-embedded app -->
-<!-- - [x] My app uses session tokens -->
-
-
-### Security
-
-<!-- Please be certain to redact any private information from your logs or code snippets such as Api Keys, Api Secrets, and any authentication tokens such as shop_tokens. -->
-
-- [ ] I have redacted any private information from my logs or code snippets.
-
+1.
+1.
+1.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,33 +1,9 @@
 ---
-name: Feature request
-about: Request new functionality for the Shopify App gem.
-labels: feature request
+name: "🙌 Feature Request"
+about: Suggest a new feature, or changes to an existing one
+labels: "Type: Feature Request :raised_hands:"
 ---
 
-<!--
+## Overview
 
-Do you want to ask a question? Are you looking for support? The Shopify Community forum is the best place for getting support: https://community.shopify.com
-
-You can also join the Partners Slack Community group: https://www.shopify.com/partners/community#conversation
-
----
-
-Please note that the team that maintains this gem has finite resources so it's unlikely that we'll work on feature requests. If we're interested in a particular feature however, we'll follow up and ask for more detail.
-
--->
-
-### Summary
-
-<!-- One paragraph explanation of the feature or suggestions. -->
-
-### Motivation
-
-<!-- Why is this feature or suggestion needed? What is the expected outcome? -->
-
-### Describe alternatives you've considered
-
-<!-- A clear and concise description of the alternative solutions you've considered. -->
-
-### Additional context
-
-<!-- Add any other context or screenshots about the feature request here. -->
+<!-- Write a short description of the request here ↓ -->


### PR DESCRIPTION
Now that we provide better logging capabilities in the library package, we should encourage folks to increase log verboseness before opening an issue, so that we can get as much information as possible upfront.

This PR also tweaks the templates' general wording so they're simpler, and makes the comments actual comments so they don't show up in created issues.