### PR TITLE
Update shopify_api to 12.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
-      shopify_api (~> 12.3)
+      shopify_api (~> 12.4)
       sprockets-rails (>= 2.0.0)
 
 GEM

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jwt", ">= 2.2.3")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
-  s.add_runtime_dependency("shopify_api", "~> 12.3")
+  s.add_runtime_dependency("shopify_api", "~> 12.4")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
 
   s.add_development_dependency("byebug")


### PR DESCRIPTION
This PR just bumps the dependency on `shopify_api` to the latest version 12.4.0.