### PR TITLE
Don't redirect on mismatching scopes if configuration is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Fixed bug where authentication redirect could still happen even though `reauth_on_access_scope_changes` is set to `false` [#1639](https://github.com/Shopify/shopify_app/pull/1639)
+
 21.4.0 (Jan 5, 2023)
 ----------
 * Updated shopify_api to 12.4.0 [#1633](https://github.com/Shopify/shopify_app/pull/1633)

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -30,7 +30,8 @@ module ShopifyApp
         return redirect_to_login
       end
 
-      unless ShopifyApp.configuration.user_access_scopes_strategy.covers_scopes?(current_shopify_session)
+      if ShopifyApp.configuration.reauth_on_access_scope_changes &&
+          !ShopifyApp.configuration.user_access_scopes_strategy.covers_scopes?(current_shopify_session)
         clear_shopify_session
         return redirect_to_login
       end


### PR DESCRIPTION
### What this PR does

This skips the redirect-to-reauthenticate block in `LoginProtection` 

We had an incident earlier this week where we were doing a scope upgrade and despite us disabling [`reauth_on_access_scope_changes`](https://github.com/Shopify/shopify_app/blob/main/lib/shopify_app/configuration.rb#L22) ahead of time.

The scopes were updated/backfilled on the Shopify Core side, but since the cached scopes in `user` and `shop` models were a subset of the actually-approved scopes in Core requests were rejected with a `401` response without even sending them to Core.

This was surprising behaviour to us since we'd disabled the feature intentionally ahead of time.

### Reviewer's guide to testing

1. Have an existing set of scopes cached on the `user` and `shop` models
2. Add a new scope c (ie: in `config.scope`)
3. Set `reauth_on_access_scope_changes = false` in your app's `shopify_app` initializer
4. Try and use the app; you'll get a 401 response from XHR requests, and a redirect for regular document requests.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
