### PR TITLE
add rspec helper and docs

### DIFF
--- a/docs/shopify_app/testing.md
+++ b/docs/shopify_app/testing.md
@@ -3,6 +3,7 @@
 #### Table of contents
 
 [Using test helpers inside your application](#using-test-helpers-inside-your-application)
+- [Using with RSpec](#using-with-rspec)
 
 [Testing an embedded app outside the Shopify admin](#testing-an-embedded-app-outside-the-shopify-admin)
 
@@ -50,6 +51,36 @@ require 'shopify_app/test_helpers/all'
 ```
 
 With `lib/shopify_app/test_helpers/all'` more tests can be added and will only need to be required in once in your library.
+
+### Using with RSpec
+
+To use the test helper with RSpec, use the RSpec helper.
+
+```ruby
+require 'shopify_app/test_helpers/shopify_rspec_session_helper'
+
+RSpec.describe MyAuthenticatedController, type: :request do
+  include ShopifyApp::TestHelpers::ShopifyRSpecSessionHelper
+
+  describe "index"
+    it "does not redirect when there is a valid shopify session" do
+      shop_domain = "my-shop.myshopify.com"
+      setup_shopify_session(session_id: "1", shop_domain: shop_domain)
+
+      get :index
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end
+```
+
+Similarly to minitest, you can require the `shopify_app/test_helpers/all` file in `spec_helper.rb`,
+which will include the RSpec helper.
+
+```ruby
+require 'shopify_app/test_helpers/all'
+```
 
 ## Testing an embedded app outside the Shopify admin
 

--- a/lib/shopify_app/test_helpers/all.rb
+++ b/lib/shopify_app/test_helpers/all.rb
@@ -2,3 +2,4 @@
 
 require "shopify_app/test_helpers/webhook_verification_helper"
 require "shopify_app/test_helpers/shopify_session_helper"
+require "shopify_app/test_helpers/shopify_rspec_session_helper"

--- a/lib/shopify_app/test_helpers/shopify_rspec_session_helper.rb
+++ b/lib/shopify_app/test_helpers/shopify_rspec_session_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module TestHelpers
+    module ShopifyRSpecSessionHelper
+      def setup_shopify_session(session_id:, shop_domain:)
+        ShopifyAPI::Auth::Session.new(id: session_id, shop: shop_domain).tap do |session|
+          ShopifyApp::SessionRepository.stub(:load_session) { session }
+          ShopifyAPI::Utils::SessionUtils.stub(:current_session_id) { session.id }
+          ShopifyAPI::Context.activate_session(session)
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_app/test_helpers/shopify_rspec_session_helper.rb
+++ b/lib/shopify_app/test_helpers/shopify_rspec_session_helper.rb
@@ -5,8 +5,8 @@ module ShopifyApp
     module ShopifyRSpecSessionHelper
       def setup_shopify_session(session_id:, shop_domain:)
         ShopifyAPI::Auth::Session.new(id: session_id, shop: shop_domain).tap do |session|
-          ShopifyApp::SessionRepository.stub(:load_session) { session }
-          ShopifyAPI::Utils::SessionUtils.stub(:current_session_id) { session.id }
+          allow(ShopifyApp::SessionRepository).to receive(:load_session) { session }
+          allow(ShopifyAPI::Utils::SessionUtils).to receive(:current_session_id) { session.id }
           ShopifyAPI::Context.activate_session(session)
         end
       end


### PR DESCRIPTION
This is my first PR for `shopify_app`. I had an issue using the test helpers with RSpec. Please consider this PR as a suggestion for adding RSpec support. I am happy to work on this farther if there are change requests and if this change might be accepted.

### What this PR does

The current test helper causes an error when used with RSpec.

<img width="645" alt="Screen Shot 2023-02-15 at 09 32 29" src="https://user-images.githubusercontent.com/1907771/219107775-517b3cfc-f5b8-4e7a-8331-2aa3b9a8ad95.png">

This error occurrs in `lib/shopify_app/test_helpers/shopify_session_helper.rb`.

The error is due to a difference in the stubbing syntax between minitest and rspec.
- Minitest: `SomeClass.stubs(:method_name).returns(value)`
- RSpec: `allow(SomeClass).to receive(:method_name) { return_value }`

This PR creates `ShopifyRSpecSessionHelper`, a clone of `ShopifySessionHelper` but that is compatible with RSpec.

### Reviewer's guide to testing

1. Check out a local copy of this branch.
2. Generate a new shopify app (e.g. using the shopify cli)
3. Install RSpec to the new app
4. Switch the new app's Gemfile to use your local branch (e.g. `gem 'shopify_app', path: "/path/to/shopify_app"`)
5. Add `require 'shopify_app/test_helpers/all'` to `spec_helper.rb`
6. Add a spec that uses the helper to authenticate a call to an endpoint.
7. Run the specs.

### Things to focus on

1. Added a new class `ShopifyRSpecSessionHelper` which is almost an exact duplicate of `ShopifySessionHelper` but with a stubbing syntax that is compatible with RSpec.
  - This may not be the most elegant solution.
2. There doesn't seem to be a good way to add tests for this new helper. That would require adding RSpec as a dependency and then probably requiring this project to run RSpec in addition to the current test runner.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
  - I'm not sure if this qualifies as a significant enough change to add to the changelog or not.
- [ ] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.

#### Edit
Updated the RSpec syntax from the old `.stub` to `allow` (thanks @berniechiu)
- RSpec: ~`SomeClass.stub(:method_name) { return_value }`~
- RSpec: `allow(SomeClass).to receive(:method_name) { return_value }`