### PR TITLE
Packaging for release 21.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+21.4.1 (Feb 21, 2023)
+----------
 * Fixed bug where authentication redirect could still happen even though `reauth_on_access_scope_changes` is set to `false` [#1639](https://github.com/Shopify/shopify_app/pull/1639)
 
 21.4.0 (Jan 5, 2023)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (21.4.0)
+    shopify_app (21.4.1)
       activeresource
       addressable (~> 2.7)
       browser_sniffer (~> 2.0)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "21.4.0"
+  VERSION = "21.4.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "21.4.0",
+  "version": "21.4.1",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
### What this PR does

Bumps version to 21.4.1, which includes a bugfix for `reauth_on_access_scope_changes` (See https://github.com/Shopify/shopify_app/pull/1639)

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
