### PR TITLE
Support Unified Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 
+* Support Unified Admin [#1658](https://github.com/Shopify/shopify_app/pull/1658)
 * Set `access_scopes` column to string by default [#1636](https://github.com/Shopify/shopify_app/pull/1636)
 
 21.4.1 (Feb 21, 2023)

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -18,10 +18,10 @@ module ShopifyApp
           no_shop_name_in_subdomain = uri.host == trusted_domain
           from_trusted_domain = trusted_domain == uri.domain
 
+          return myshopify_domain_from_unified_admin(uri) if unified_admin?(uri) && from_trusted_domain
           return nil if no_shop_name_in_subdomain || uri.host&.empty?
           return uri.host if from_trusted_domain
         end
-
         nil
       end
 
@@ -64,6 +64,16 @@ module ShopifyApp
         uri
       rescue Addressable::URI::InvalidURIError
         nil
+      end
+
+      def unified_admin?(uri)
+        uri.host.split(".").first == "admin"
+      end
+
+      def myshopify_domain_from_unified_admin(uri)
+        shop = uri.path.split("/").last
+
+        "#{shop}.myshopify.com"
       end
     end
   end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -42,6 +42,16 @@ class UtilsTest < ActiveSupport::TestCase
     assert ShopifyApp::Utils.sanitize_shop_domain("some-shoppe-over-the-rainbow.myshopify.io")
   end
 
+  test "convert unified admin to old domain" do
+    trailing_forward_slash_url = "https://admin.shopify.com/store/store-name/"
+    unified_admin_url = "https://admin.shopify.com/store/store-name"
+
+    expected = "store-name.myshopify.com"
+
+    assert_equal expected, ShopifyApp::Utils.sanitize_shop_domain(trailing_forward_slash_url)
+    assert_equal expected, ShopifyApp::Utils.sanitize_shop_domain(unified_admin_url)
+  end
+
   ["myshop.com", "myshopify.com", "shopify.com", "two words", "store.myshopify.com.evil.com",
    "/foo/bar", "foo.myshopify.io.evil.ru",].each do |bad_url|
     test "sanitize_shop_domain for a non-myshopify URL (#{bad_url})" do


### PR DESCRIPTION
### What this PR does

<!-- Please describe what changes this PR introduces and why they're needed. -->
Installs with the unified admin url were not working. This PR recognizes if a unified admin url was used and converts it to the old url format. This is a bandaid right now since core doesn't support the authorize routes with the new format. 

closes https://github.com/Shopify/shopify_app/issues/1660

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

Try to install an app using a unified admin store url.

### Things to focus on

1. Is `unified_admin?(uri)` a good way to determine if a url is unified admin?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
