### PR TITLE
Enable "per-PR" async PR mode

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -1,5 +1,6 @@
 source_language: en
 target_languages: [cs, da, de, es, fi, fr, it, ja, ko, nb, nl, pl, pt-BR, pt-PT, sv, th, tr, vi, zh-CN, zh-TW]
+async_pr_mode: per_pr
 components:
   - name: 'merchant'
     paths:


### PR DESCRIPTION
### PR Summary: 
This changes the async translations workflow to a new "per-PR" mode, which means async translations will now come back grouped by the PR number that originally requested them.


### Why are these changes introduced?
This makes it easier to manage those translations and allows the requester to be in the full loop of the process.


### What approach did you take?
Changed the translation.yml config file to add the new setting.