### PR TITLE
Refactor recreate webhooks logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 * Set `access_scopes` column to string by default [#1636](https://github.com/Shopify/shopify_app/pull/1636)
 * Fixes a bug with `EnsureBilling` causing infinite redirect in embedded apps [#1578](https://github.com/Shopify/shopify_app/pull/1578)
 * Modifies SessionStorage#with_shopify_session to call a block with a supplied session instance [#1488](https://github.com/Shopify/shopify_app/pull/1488)
+* Refactors `ShopifyApp::WebhhooksManager#recreate_webhooks!` to have a uniform webhook inventory that doesn't clash with the API library. Updates webhook generator to use supplied session. [#1686](https://github.com/Shopify/shopify_app/pull/1686)
 
 21.4.1 (Feb 21, 2023)
 ----------

--- a/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb.tt
+++ b/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb.tt
@@ -12,11 +12,11 @@ class <%= @job_class_name %> < ActiveJob::Base
 
     if shop.nil?
       logger.error("#{self.class} failed: cannot find shop with domain '#{shop_domain}'")
-      
+
       raise ActiveRecord::RecordNotFound, "Shop Not Found"
     end
 
-    shop.with_shopify_session do
+    shop.with_shopify_session do |session|
     end
   end
 end

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -24,10 +24,8 @@ module ShopifyApp
         destroy_webhooks(session: session)
         return unless ShopifyApp.configuration.has_webhooks?
 
-        add_registrations
-
         ShopifyApp::Logger.debug("Recreating webhooks")
-        ShopifyAPI::Webhooks::Registry.register_all(session: session)
+        add_registrations
       end
 
       def destroy_webhooks(session:)

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -78,9 +78,10 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
   end
 
   test "#recreate_webhooks! destroys all webhooks and recreates" do
+    ShopifyApp.configuration.expects(:has_webhooks?).returns(true)
     session = ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com")
 
-    ShopifyApp::WebhooksManager.expects(:destroy_webhooks).with(session: session)
+    ShopifyApp::WebhooksManager.expects(:destroy_webhooks)
     ShopifyApp::WebhooksManager.expects(:add_registrations)
 
     ShopifyApp::WebhooksManager.recreate_webhooks!(session: session)

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -80,29 +80,10 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
   test "#recreate_webhooks! destroys all webhooks and recreates" do
     session = ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com")
 
-    ShopifyAPI::Webhooks::Registry.expects(:register_all)
-    ShopifyAPI::Webhooks::Registry.expects(:unregister).with(topic: "orders/updated", session: session)
-    ShopifyApp::WebhooksManager.expects(:add_registrations).twice
+    ShopifyApp::WebhooksManager.expects(:destroy_webhooks).with(session: session)
+    ShopifyApp::WebhooksManager.expects(:add_registrations)
 
-    ShopifyApp.configure do |config|
-      config.webhooks = [
-        { topic: "orders/updated", path: "webhooks" },
-      ]
-    end
-    ShopifyApp::WebhooksManager.add_registrations
     ShopifyApp::WebhooksManager.recreate_webhooks!(session: session)
-  end
-
-  test "#recreate_webhooks! does not call unregister if there is no webhook" do
-    ShopifyAPI::Webhooks::Registry.expects(:register_all).never
-    ShopifyAPI::Webhooks::Registry.expects(:unregister).never
-    ShopifyAPI::Webhooks::Registry.expects(:add_registration).never
-
-    ShopifyApp.configure do |config|
-      config.webhooks = []
-    end
-    ShopifyApp::WebhooksManager.add_registrations
-    ShopifyApp::WebhooksManager.recreate_webhooks!(session: ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com"))
   end
 
   test "#destroy_webhooks destroy all webhooks" do


### PR DESCRIPTION
![](https://media.tenor.com/ocHIc7zPJLwAAAAC/remove-sunglasses-sunglasses.gif)

### What this PR does

Fixes two bugs with webhooks within the app gem:

1. The webhook generators need to use the session that is now passed in the block when using `with_shopify_session`
2. `ShopifyApp::WebhhooksManager#recreate_webhooks!` was using API libraries methods to recreate webhooks instead of the methods it already had to do the same work. Since there were differing approaches with storing what topics were being used this was introducing bugs to consumers of both libraries. 

Should address https://github.com/Shopify/shopify-api-ruby/issues/1123 and https://github.com/Shopify/shopify_app/issues/1659

### Reviewer's guide to testing

Use this branch with a shopify app created with the CLI. Create webhooks:

```
irb(main):003:0>  ShopifyApp::WebhooksManager.recreate_webhooks!(session:)
=> [{:topic=>"app/uninstalled", :address=>"api/webhooks/app_uninstalled"}, {:topic=>"orders/create", :address=>"api/webhooks/order_create"}]
```

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
