### PR TITLE
eject session storage from session repository

### DIFF
--- a/lib/shopify_app/session/session_repository.rb
+++ b/lib/shopify_app/session/session_repository.rb
@@ -2,8 +2,6 @@
 
 module ShopifyApp
   class SessionRepository
-    extend ShopifyAPI::Auth::SessionStorage
-
     class << self
       attr_writer :shop_storage
 

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -33,7 +33,6 @@ class ShopifyAppConfigurer
       scope: ShopifyApp.configuration.scope,
       is_private: false,
       is_embedded: ShopifyApp.configuration.embedded_app,
-      session_storage: ShopifyApp::SessionRepository,
       log_level: :off,
     )
   end

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -69,7 +69,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
       api_version: ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION,
       host_name: "host.example.io",
       scope: ShopifyApp.configuration.scope,
-      session_storage: ShopifyApp::SessionRepository,
       is_private: false,
       is_embedded: true,
     )
@@ -89,7 +88,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
       api_version: ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION,
       host_name: "host.example.io",
       scope: ShopifyApp.configuration.scope,
-      session_storage: ShopifyApp::SessionRepository,
       is_private: false,
       is_embedded: true,
     )
@@ -120,7 +118,6 @@ class LoginProtectionControllerTest < ActionController::TestCase
       api_version: ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION,
       host_name: "host.example.io",
       scope: ShopifyApp.configuration.scope,
-      session_storage: ShopifyApp::SessionRepository,
       is_private: false,
       is_embedded: true,
     )


### PR DESCRIPTION
![](https://media.tenor.com/-65sY-evY_QAAAAC/gif-full-jump.gif)

Removes the abstract session storage from the API library