### PR TITLE
Fix InMemoryUserSessionStore - user.shopify_user_id does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 * Fix registration of event_bridge and pub_sub webhooks [#1635](https://github.com/Shopify/shopify_app/pull/1635)
 * Adds support for adding any number of trial days within `EnsureBilling` by adding the `trial_days` field to `BillingConfiguration`
 * Updated AppBridge to 3.7.8 [#1680](https://github.com/Shopify/shopify_app/pull/1680)
+* Fix bug in `InMemoryUserSessionStore#store`, this can now be used out of box. [#1716](https://github.com/Shopify/shopify_app/pull/1716)
 
 21.6.0 (July 11, 2023)
 ----------

--- a/lib/shopify_app/session/in_memory_user_session_store.rb
+++ b/lib/shopify_app/session/in_memory_user_session_store.rb
@@ -5,7 +5,7 @@ module ShopifyApp
     class << self
       def store(session, user)
         id = super
-        repo[user.shopify_user_id] = session
+        repo[user.id.to_s] = session
         id
       end
 

--- a/test/shopify_app/session/in_memory_user_session_store_test.rb
+++ b/test/shopify_app/session/in_memory_user_session_store_test.rb
@@ -14,5 +14,24 @@ module ShopifyApp
       user_id = "abra"
       assert_equal "something", InMemoryUserSessionStore.retrieve_by_shopify_user_id(user_id)
     end
+
+    test "stores a user session by id" do
+      user_id = 123456
+      user = ShopifyAPI::Auth::AssociatedUser.new(
+        id: user_id,
+        first_name: "firstname",
+        last_name: "lastname",
+        email: "email",
+        email_verified: true,
+        account_owner: true,
+        locale: "locale",
+        collaborator: false,
+      )
+      session = ShopifyAPI::Auth::Session.new(shop: "my_shop", associated_user: user)
+
+      InMemoryUserSessionStore.store(session, user)
+
+      assert_equal session, InMemoryUserSessionStore.retrieve_by_shopify_user_id(user_id.to_s)
+    end
   end
 end


### PR DESCRIPTION
### What this PR does
Using `ShopifyApp` gem's `InMemoryUserSessionStore` doesn't work out of the box 
<img width="981" alt="nomethoderror" src="https://github.com/Shopify/shopify_app/assets/102243935/757d131d-868b-4098-aaf0-1f4ebaa5adc7">

`shopify_user_id` does not belong in `ShopifyAPI::Auth::AssociatedUser` , using `id` instead.

Added test around `InMemoryUserSessionStore` as well.

### Reviewer's guide to testing
Set configuration user session repository to use `InMemoryUserSessionStore`, see that it fails before this fix, and can store sessions after this fix.
```ruby
# my-app/web/config/initializers/shopify_app.rb
ShopifyApp.configure do |config|
#...
  config.shop_session_repository = ShopifyApp::InMemoryShopSessionStore
  config.user_session_repository= ShopifyApp::InMemoryUserSessionStore
#...
end
```
### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
