### PR TITLE
WebhooksManager#recreate_webhooks! should creates webhooks

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -10,10 +10,7 @@ ShopifyApp.configure do |config|
   config.log_level = :info
   config.reauth_on_access_scope_changes = true
   config.webhooks = [
-    { topic: "app/uninstalled", address: "webhooks/app_uninstalled"},
-    { topic: "customers/data_request", address: "webhooks/customers_data_request" },
-    { topic: "customers/redact", address: "webhooks/customers_redact"},
-    { topic: "shop/redact", address: "webhooks/shop_redact"}
+    { topic: "app/uninstalled", address: "webhooks/app_uninstalled"}
   ]
 
   config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -16,16 +16,12 @@ module ShopifyApp
         return unless ShopifyApp.configuration.has_webhooks?
 
         ShopifyApp::Logger.debug("Creating webhooks #{ShopifyApp.configuration.webhooks}")
-
         ShopifyAPI::Webhooks::Registry.register_all(session: session)
       end
 
       def recreate_webhooks!(session:)
         destroy_webhooks(session: session)
-        return unless ShopifyApp.configuration.has_webhooks?
-
-        ShopifyApp::Logger.debug("Recreating webhooks")
-        add_registrations
+        create_webhooks(session: session)
       end
 
       def destroy_webhooks(session:)

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -78,11 +78,11 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
   end
 
   test "#recreate_webhooks! destroys all webhooks and recreates" do
-    ShopifyApp.configuration.expects(:has_webhooks?).returns(true)
+    ShopifyApp.configuration.expects(:has_webhooks?).at_least(1).times.returns(true)
     session = ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com")
 
     ShopifyApp::WebhooksManager.expects(:destroy_webhooks)
-    ShopifyApp::WebhooksManager.expects(:add_registrations)
+    ShopifyApp::WebhooksManager.expects(:create_webhooks)
 
     ShopifyApp::WebhooksManager.recreate_webhooks!(session: session)
   end


### PR DESCRIPTION
### What this PR does

``#recreate_webhooks!`` doesn't seem to attempt to create webhooks after destroying them. This patch fixes that.

I have also removed the suggestion of including manual registration of mandatory webhooks from the generator template. [Shopify graphql API documentation](https://shopify.dev/docs/api/admin-graphql/2023-07/enums/WebhookSubscriptionTopic) states that these shouldn't be registered manually via the API and instead need be set up on the partner dashboard (in App Settings). From the docs:

"You don't create webhook subscriptions to [mandatory webhooks](https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks). Instead, you configure mandatory webhooks in your Partner Dashboard as part of your app setup."

To avoid errors, existing users should remove the three mandatory webhooks from their ``ShopifyApp.configuration.webhooks``.

### Reviewer's guide to testing

Mandatory webhook configuration should be removed before testing on a real app.

### Things to focus on

1. Is Shopify documentation correct? Are all these manually webhook API subscriptions just being ignored? Why are the subscription not failing? So many questions...

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
