### PR TITLE
Fix `add_webhook` generator to create the webhook jobs under the correct directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Fix add_webhook generator to create the webhook jobs under the correct directory[#1748](https://github.com/Shopify/shopify_app/pull/1748)
 
 21.8.1 (December 6, 2023)
 ----------
@@ -10,7 +11,6 @@ Unreleased
 * Bump `shopify_api` to include bugfix with mandatory webhooks + fixes for CI failures that prevented earlier release
 * Fixes bug with `WebhooksManager#recreate_webhooks!` where we failed to register topics in the registry[#1743](https://github.com/Shopify/shopify_app/pull/1704)
 * Allow embedded apps to provide a full URL to get redirected to, rather than defaulting to Shopify Admin [#1746](https://github.com/Shopify/shopify_app/pull/1746)
-* Fix add_webhook generator to create the webhook jobs under the correct directory[#1748](https://github.com/Shopify/shopify_app/pull/1748)
 
 21.7.0 (Oct 12, 2023)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 * Fixes bug with `WebhooksManager#recreate_webhooks!` where we failed to register topics in the registry[#1743](https://github.com/Shopify/shopify_app/pull/1704)
+* Fix add_webhook generator to create the webhook jobs under the correct directory[#1748](https://github.com/Shopify/shopify_app/pull/1748)
 
 21.7.0 (Oct 12, 2023)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ----------
-* Fix add_webhook generator to create the webhook jobs under the correct directory[#1748](https://github.com/Shopify/shopify_app/pull/1748)
+* Fix `add_webhook` generator to create the webhook jobs under the correct directory[#1748](https://github.com/Shopify/shopify_app/pull/1748)
 
 21.8.1 (December 6, 2023)
 ----------

--- a/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
@@ -46,7 +46,7 @@ module ShopifyApp
                            "#{job_file_name}_job"
                          end
         @job_class_name = @job_file_name.classify
-        template('webhook_job.rb', "app/jobs/#{@job_file_name}.rb")
+        template("webhook_job.rb", "app/jobs/#{@job_file_name}.rb")
       end
 
       private

--- a/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
@@ -41,7 +41,7 @@ module ShopifyApp
       def add_webhook_job
         @job_file_name = job_file_name + "_job"
         @job_class_name = @job_file_name.classify
-        template("webhook_job.rb", "app/jobs/#{@job_file_name}.rb")
+        template("webhook_job.rb", "app/jobs/#{ShopifyApp.configuration.webhook_jobs_namespace}/#{@job_file_name}.rb")
       end
 
       private

--- a/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
@@ -39,11 +39,14 @@ module ShopifyApp
       end
 
       def add_webhook_job
-        @job_file_name = "#{job_file_name}_job"
-        @job_class_name = @job_file_name.classify
         namespace = ShopifyApp.configuration.webhook_jobs_namespace
-        dir_path = namespace.present? ? "app/jobs/#{namespace}" : "app/jobs"
-        template("webhook_job.rb", "#{dir_path}/#{@job_file_name}.rb")
+        @job_file_name = if namespace.present?
+                           "#{namespace}/#{job_file_name}_job"
+                         else
+                           "#{job_file_name}_job"
+                         end
+        @job_class_name = @job_file_name.classify
+        template('webhook_job.rb', "app/jobs/#{@job_file_name}.rb")
       end
 
       private

--- a/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
@@ -41,10 +41,10 @@ module ShopifyApp
       def add_webhook_job
         namespace = ShopifyApp.configuration.webhook_jobs_namespace
         @job_file_name = if namespace.present?
-                           "#{namespace}/#{job_file_name}_job"
-                         else
-                           "#{job_file_name}_job"
-                         end
+          "#{namespace}/#{job_file_name}_job"
+        else
+          "#{job_file_name}_job"
+        end
         @job_class_name = @job_file_name.classify
         template("webhook_job.rb", "app/jobs/#{@job_file_name}.rb")
       end

--- a/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_webhook/add_webhook_generator.rb
@@ -39,9 +39,11 @@ module ShopifyApp
       end
 
       def add_webhook_job
-        @job_file_name = job_file_name + "_job"
+        @job_file_name = "#{job_file_name}_job"
         @job_class_name = @job_file_name.classify
-        template("webhook_job.rb", "app/jobs/#{ShopifyApp.configuration.webhook_jobs_namespace}/#{@job_file_name}.rb")
+        namespace = ShopifyApp.configuration.webhook_jobs_namespace
+        dir_path = namespace.present? ? "app/jobs/#{namespace}" : "app/jobs"
+        template("webhook_job.rb", "#{dir_path}/#{@job_file_name}.rb")
       end
 
       private


### PR DESCRIPTION
### What this PR does

Fixes #1747

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

Please check if the webhook job is created under the correct directory.

### Things to focus on

1. Run `bundle add shopify_app`
2. Set `config.webhook_jobs_namespace = "shopify/webhooks"`
3. Run `bin/rails g shopify_app:add_webhook --topic carts/update --path webhooks/carts_update`
4. Check if `app/jobs/shopify/webhooks/carts_update_job.rb` is created

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
