### PR TITLE
Store session expiry and check it to trigger a re-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 * Fix session deletion for users with customized session storage[#1773](https://github.com/Shopify/shopify_app/pull/1773)
+* Add configuration flag `check_session_expiry_date` to trigger a re-auth when the (user) session is expired. The session expiry date must be stored and retrieved for this flag to be effective. When the `UserSessionStorageWithScopes` concern is used, a DB migration can be generated with `rails generate shopify_app:user_model --skip` and should be applied before enabling that flag[#1757](https://github.com/Shopify/shopify_app/pull/1757)
 
 21.9.0 (January 16, 2023)
 ----------

--- a/docs/shopify_app/sessions.md
+++ b/docs/shopify_app/sessions.md
@@ -159,7 +159,7 @@ end
 ```
 
 ##### User Sessions - `EnsureHasSession`
-- [EnsureHasSession](https://github.com/Shopify/shopify_app/blob/main/app/controllers/concerns/shopify_app/ensure_has_session.rb) controller concern will load a user session via `current_shopify_session`. As part of loading this session, this concern will also ensure that the user session has the appropriate scopes needed for the application. If the user isn't found or has fewer permitted scopes than are required, they will be prompted to authorize the application.
+- [EnsureHasSession](https://github.com/Shopify/shopify_app/blob/main/app/controllers/concerns/shopify_app/ensure_has_session.rb) controller concern will load a user session via `current_shopify_session`. As part of loading this session, this concern will also ensure that the user session has the appropriate scopes needed for the application and that it is not expired (when `check_session_expiry_date` is enabled). If the user isn't found or has fewer permitted scopes than are required, they will be prompted to authorize the application.
 - This controller concern should be used if you don't need your app to make calls on behalf of a user. With that in mind, there are a few other embedded concerns that are mixed in to ensure that embedding, CSRF, localization, and billing allow the action for the user.
 - Example
 ```ruby
@@ -233,6 +233,9 @@ class User < ActiveRecord::Base
   end
 end
 ```
+
+## Expiry date
+When the configuration flag `check_session_expiry_date` is set to true, the user session expiry date will be checked to trigger a re-auth and get a fresh user token when it is expired. This requires the `ShopifyAPI::Auth::Session` `expires` attribute to be stored. When the `User` model includes the `UserSessionStorageWithScopes` concern, a DB migration can be generated with `rails generate shopify_app:user_model --skip` to add the `expires_at` attribute to the model.
 
 ## Migrating from shop-based to user-based token strategy
 

--- a/lib/generators/shopify_app/user_model/templates/db/migrate/add_user_expires_at_column.erb
+++ b/lib/generators/shopify_app/user_model/templates/db/migrate/add_user_expires_at_column.erb
@@ -1,0 +1,5 @@
+class AddUserExpiresAtColumn < ActiveRecord::Migration[<%= rails_migration_version %>]
+  def change
+    add_column :users, :expires_at, :datetime
+  end
+end

--- a/lib/generators/shopify_app/user_model/user_model_generator.rb
+++ b/lib/generators/shopify_app/user_model/user_model_generator.rb
@@ -40,6 +40,26 @@ module ShopifyApp
         end
       end
 
+      def create_expires_at_storage_in_user_model
+        expires_at_column_prompt = <<~PROMPT
+          It is highly recommended that apps record the User session expiry date. \
+          This will allow to check if the session has expired and re-authenticate \
+          without a first call to Shopify.
+
+          After running the migration, the `check_session_expiry_date` configuration can be enabled.
+
+          The following migration will add an `expires_at` column to the User model. \
+          Do you want to include this migration? [y/n]
+        PROMPT
+
+        if new_shopify_cli_app? || Rails.env.test? || yes?(expires_at_column_prompt)
+          migration_template(
+            "db/migrate/add_user_expires_at_column.erb",
+            "db/migrate/add_user_expires_at_column.rb",
+          )
+        end
+      end
+
       def update_shopify_app_initializer
         gsub_file("config/initializers/shopify_app.rb", "ShopifyApp::InMemoryUserSessionStore", "User")
       end

--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -20,6 +20,7 @@ module ShopifyApp
     attr_accessor :api_version
 
     attr_accessor :reauth_on_access_scope_changes
+    attr_accessor :check_session_expiry_date
     attr_accessor :log_level
 
     # customise urls

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -30,8 +30,7 @@ module ShopifyApp
         return redirect_to_login
       end
 
-      if ShopifyApp.configuration.check_session_expiry_date && current_shopify_session.expires &&
-          current_shopify_session.expires < Time.now
+      if ShopifyApp.configuration.check_session_expiry_date && current_shopify_session.expired?
         ShopifyApp::Logger.debug("Session expired, redirecting to login")
         clear_shopify_session
         return redirect_to_login

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -30,6 +30,13 @@ module ShopifyApp
         return redirect_to_login
       end
 
+      if ShopifyApp.configuration.check_session_expiry_date && current_shopify_session.expires &&
+          current_shopify_session.expires < Time.now
+        ShopifyApp::Logger.debug("Session expired, redirecting to login")
+        clear_shopify_session
+        return redirect_to_login
+      end
+
       if ShopifyApp.configuration.reauth_on_access_scope_changes &&
           !ShopifyApp.configuration.user_access_scopes_strategy.covers_scopes?(current_shopify_session)
         clear_shopify_session

--- a/lib/shopify_app/session/user_session_storage_with_scopes.rb
+++ b/lib/shopify_app/session/user_session_storage_with_scopes.rb
@@ -15,6 +15,7 @@ module ShopifyApp
         user.shopify_token = auth_session.access_token
         user.shopify_domain = auth_session.shop
         user.access_scopes = auth_session.scope.to_s
+        user.expires_at = auth_session.expires
 
         user.save!
         user.id
@@ -56,6 +57,7 @@ module ShopifyApp
           scope: user.access_scopes,
           associated_user_scope: user.access_scopes,
           associated_user: associated_user,
+          expires: user.expires_at,
         )
       end
     end
@@ -70,6 +72,25 @@ module ShopifyApp
       super
     rescue NotImplementedError, NoMethodError
       raise NotImplementedError, "#access_scopes= must be defined to hook into stored access scopes"
+    end
+
+    def expires_at=(expires_at)
+      super
+    rescue NotImplementedError, NoMethodError
+      if ShopifyApp.configuration.check_session_expiry_date
+        raise NotImplementedError,
+          "#expires_at= must be defined to handle storing the session expiry date"
+      end
+    end
+
+    def expires_at
+      super
+    rescue NotImplementedError, NoMethodError
+      if ShopifyApp.configuration.check_session_expiry_date
+        raise NotImplementedError, "#expires_at must be defined to check the session expiry date"
+      end
+
+      nil
     end
   end
 end

--- a/test/generators/user_model_generator_test.rb
+++ b/test/generators/user_model_generator_test.rb
@@ -35,7 +35,14 @@ class UserModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "create User with access_scopes migration with --new-shopify-cli-app flag provided" do
+  test "create expires_at migration for User model" do
+    run_generator
+    assert_migration "db/migrate/add_user_expires_at_column.rb" do |migration|
+      assert_match "add_column :users, :expires_at, :datetime", migration
+    end
+  end
+
+  test "create User with all migrations with --new-shopify-cli-app flag provided" do
     Rails.env = "mock_environment"
 
     run_generator ["--new-shopify-cli-app"]
@@ -43,6 +50,9 @@ class UserModelGeneratorTest < Rails::Generators::TestCase
 
     assert_migration "db/migrate/add_user_access_scopes_column.rb" do |migration|
       assert_match "add_column :users, :access_scopes, :string", migration
+    end
+    assert_migration "db/migrate/add_user_expires_at_column.rb" do |migration|
+      assert_match "add_column :users, :expires_at, :datetime", migration
     end
   end
 

--- a/test/shopify_app/session/user_session_storage_with_scopes_test.rb
+++ b/test/shopify_app/session/user_session_storage_with_scopes_test.rb
@@ -12,6 +12,7 @@ module ShopifyApp
     TEST_SHOPIFY_DOMAIN = "example.myshopify.com"
     TEST_SHOPIFY_USER_TOKEN = "some-user-token-42"
     TEST_MERCHANT_SCOPES = "read_orders, write_products"
+    TEST_EXPIRES_AT = Time.now
 
     test ".retrieve returns user session by id" do
       UserMockSessionStoreWithScopes.stubs(:find_by).returns(MockUserInstance.new(
@@ -19,6 +20,7 @@ module ShopifyApp
         shopify_domain: TEST_SHOPIFY_DOMAIN,
         shopify_token: TEST_SHOPIFY_USER_TOKEN,
         scopes: TEST_MERCHANT_SCOPES,
+        expires_at: TEST_EXPIRES_AT,
       ))
 
       session = UserMockSessionStoreWithScopes.retrieve(shopify_user_id: TEST_SHOPIFY_USER_ID)
@@ -26,6 +28,7 @@ module ShopifyApp
       assert_equal TEST_SHOPIFY_DOMAIN, session.shop
       assert_equal TEST_SHOPIFY_USER_TOKEN, session.access_token
       assert_equal ShopifyAPI::Auth::AuthScopes.new(TEST_MERCHANT_SCOPES), session.scope
+      assert_equal TEST_EXPIRES_AT, session.expires
     end
 
     test ".retrieve_by_shopify_user_id returns user session by shopify_user_id" do
@@ -35,6 +38,7 @@ module ShopifyApp
         shopify_token: TEST_SHOPIFY_USER_TOKEN,
         api_version: ShopifyApp.configuration.api_version,
         scopes: TEST_MERCHANT_SCOPES,
+        expires_at: TEST_EXPIRES_AT,
       )
       UserMockSessionStoreWithScopes.stubs(:find_by).with(shopify_user_id: TEST_SHOPIFY_USER_ID).returns(instance)
 
@@ -42,6 +46,7 @@ module ShopifyApp
         shop: instance.shopify_domain,
         access_token: instance.shopify_token,
         scope: TEST_MERCHANT_SCOPES,
+        expires: TEST_EXPIRES_AT,
       )
 
       user_id = TEST_SHOPIFY_USER_ID
@@ -49,6 +54,7 @@ module ShopifyApp
       assert_equal expected_session.shop, session.shop
       assert_equal expected_session.access_token, session.access_token
       assert_equal expected_session.scope, session.scope
+      assert_equal expected_session.expires, session.expires
     end
 
     test ".destroy_by_shopify_user_id destroys user session by shopify_user_id" do

--- a/test/support/session_store_strategy_test_helpers.rb
+++ b/test/support/session_store_strategy_test_helpers.rb
@@ -21,8 +21,8 @@ module SessionStoreStrategyTestHelpers
   end
 
   class MockUserInstance
-    attr_reader :id, :shopify_user_id, :shopify_domain, :shopify_token, :api_version, :access_scopes
-    attr_writer :shopify_token, :shopify_domain, :access_scopes
+    attr_reader :id, :shopify_user_id, :shopify_domain, :shopify_token, :api_version, :access_scopes, :expires_at
+    attr_writer :shopify_token, :shopify_domain, :access_scopes, :expires_at
 
     def initialize(
       id: 1,
@@ -30,7 +30,8 @@ module SessionStoreStrategyTestHelpers
       shopify_domain: "example.myshopify.com",
       shopify_token: "1234-user-token",
       api_version: ShopifyApp.configuration.api_version,
-      scopes: "read_products"
+      scopes: "read_products",
+      expires_at: nil
     )
       @id = id
       @shopify_user_id = shopify_user_id
@@ -38,6 +39,7 @@ module SessionStoreStrategyTestHelpers
       @shopify_token = shopify_token
       @api_version = api_version
       @access_scopes = scopes
+      @expires_at = expires_at
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,7 @@ class ActiveSupport::TestCase
     mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(scope))
     mock_session.stubs(:shopify_session_id).returns(1)
     mock_session.stubs(:expires).returns(nil)
+    mock_session.stubs(:expired?).returns(false)
 
     mock_session
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,7 @@ class ActiveSupport::TestCase
     mock_session.stubs(:access_token).returns("a-new-user_token!")
     mock_session.stubs(:scope).returns(ShopifyAPI::Auth::AuthScopes.new(scope))
     mock_session.stubs(:shopify_session_id).returns(1)
+    mock_session.stubs(:expires).returns(nil)
 
     mock_session
   end


### PR DESCRIPTION
### What this PR does

Embedded apps using user tokens currently have to wait for a 401 from Shopify to know that the user token is not valid anymore. By storing the token expiry date, we are able to detect an expired session without a round trip to Shopify and to trigger the Oauth flow to get a fresh token.

Goals of this PR are:
- to store the user token expiry date and to check it during the session check. This allows to trigger the Oauth flow early and has the nice side effect of removing useless calls to Shopify
- to align `shopify_app` with `shopify-app-js` which already stores the expiry date in the data model ([Prisma one](https://github.com/Shopify/shopify-app-js/blob/2dec481c10109ba4b16fc4f7c4ef30819361d06f/packages/shopify-app-session-storage-prisma/prisma/schema.prisma#L16) for example) and checks it [here](https://github.com/Shopify/shopify-api-js/blob/3ef82b9cea4272ac9e8a0d71349513eb67a51cc7/packages/shopify-api/lib/session/session.ts#L99).
- to prepare for the integration of the new token exchange flow which will also be able to leverage that date

For that, the PR:
- updates the User model with an `expires_at` attribute. A DB migration is created with a prompt when running `rails generate shopify_app:user_model`
- creates a new `UserSessionStorageWithScopesAndExpiry` concern that will store/retrieve the session expiry date (which is already set during Oauth [here](https://github.com/Shopify/shopify-api-ruby/blob/459b04e4cc58942866c0b53a5ece0bac73d90167/lib/shopify_api/auth/oauth.rb#L121)). This will be included in the `User` model for new apps and be an opt-in for existing apps.
- check if the session is expired in the login protection to trigger a re-auth

### Reviewer's guide to testing

- create a new Shopify Rails app with user sessions leveraging `UserSessionStorageWithScopes` (or use an existing one)
- update the Gemfile to use that branch
  - `gem "shopify_app", git: 'https://github.com/Shopify/shopify_app.git', branch: 'store-session-expiry'`
  - bundle install

#### Backward compatibility (config flag off and no expiry date column)

- Check that sessions can still be saved and retrieved
```
user = ShopifyAPI::Auth::AssociatedUser.new(id: 1, first_name: "first name", last_name: "last name", email: "my.email@email.com", email_verified: true, account_owner: true, locale: "en", collaborator: true)
session = ShopifyAPI::Auth::Session.new(shop: "shop1.myshopify.com", access_token: "token1", scope: ["read_products"], associated_user: user, expires: Time.now + 1.day)
ShopifyApp::SessionRepository.store_session(session)
ShopifyApp::SessionRepository.load_session("shop1.myshopify.com_1")
```

https://github.com/Shopify/shopify_app/assets/13165539/e1b3c2d6-b126-40d6-b9b6-f026b65e89e6

#### Config flag on and no expiry date column
- set the new config flag `check_session_expiry_date` to true in `shopify_app.rb`
- restart the rails server (`rails restart`)
- check that you get an error when trying to save or retrieve sessions as the flag is on but the model has no expiry date
```
user = ShopifyAPI::Auth::AssociatedUser.new(id: 2, first_name: "first name", last_name: "last name", email: "my.email@email.com", email_verified: true, account_owner: true, locale: "en", collaborator: true)
session = ShopifyAPI::Auth::Session.new(shop: "shop1.myshopify.com", access_token: "token2", scope: ["read_products"], associated_user: user, expires: Time.now + 1.day)
ShopifyApp::SessionRepository.store_session(session)
ShopifyApp::SessionRepository.load_session("shop1.myshopify.com_1")
```
https://github.com/Shopify/shopify_app/assets/13165539/47fb1cb6-61cb-44b5-b5b0-697496bff52d

#### Config flag on and expiry date column
- check the User model is correctly generated:
  - `rails generate shopify_app:user_model --skip` -> answer Y to the prompt to include the `expiry_date` migration
  -> check that a DB migration was created to add the `expires_at` column to the `users` table
  - `rails db:migrate`
- check that the session expiry date is well stored and retrieved. The `@expires` attribute should not be `nil` when retrieving the session
```
user = ShopifyAPI::Auth::AssociatedUser.new(id: 3, first_name: "first name", last_name: "last name", email: "my.email@email.com", email_verified: true, account_owner: true, locale: "en", collaborator: true)
session = ShopifyAPI::Auth::Session.new(shop: "shop1.myshopify.com", access_token: "token3", scope: ["read_products"], associated_user: user, expires: Time.now + 1.day)
ShopifyApp::SessionRepository.store_session(session)
ShopifyApp::SessionRepository.load_session("shop1.myshopify.com_3")
```
https://github.com/Shopify/shopify_app/assets/13165539/00174705-ea5b-4f3e-a3e7-b3af0bb65f23

#### Expiry date check

- on an app with the updated `User` model and `check_session_expiry_date` set to true, check that the user session expiry date is stored in the `users` table (you need to restart the app after updating)
- manually change the expiry date to be in the past
- hit the app and check the login flow is triggered before any call to the Shopify API is done

### Things to focus on

1. Could this have any bad side effect? 

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] ~~Update `README.md`, if appropriate.~~
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] ~~For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.~~
