### PR TITLE
package for release 21.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Unreleased
 ----------
 
-21.8.0 (Nov 13, 2023)
+21.8.0 (Dec 1, 2023)
 ----------
+* Bump `shopify_api` to include bugfix with mandatory webhooks + fixes for CI failures that prevented earlier release
 * Fixes bug with `WebhooksManager#recreate_webhooks!` where we failed to register topics in the registry[#1743](https://github.com/Shopify/shopify_app/pull/1704)
 * Allow embedded apps to provide a full URL to get redirected to, rather than defaulting to Shopify Admin [#1746](https://github.com/Shopify/shopify_app/pull/1746)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "21.7.0",
+  "version": "21.8.0",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
We failed to release `v21.8` to rubygems as we had npm security failures. We fixed that as well as patched a high severity bug in the API where mandatory webhooks were unable to be processed. 