### PR TITLE
Fix CHANGELOG style for release 21.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 21.8.1 (December 6, 2023)
+----------
 * Bump `shopify_api` to 13.3.1 [1763](https://github.com/Shopify/shopify-api-ruby/blob/main/CHANGELOG.md#1331)
 
 21.8.0 (Dec 1, 2023)


### PR DESCRIPTION
Simply fixing the style for the latest release. Missing the heading bar, making `21.8.1` quite small.

<img width="989" alt="Screenshot 2023-12-07 at 8 26 24" src="https://github.com/Shopify/shopify_app/assets/1557529/81dbb713-1eb7-408f-8b7c-a0c1a589c3bf">