### PR TITLE
Allow more control over the application layout

### DIFF
--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -64,5 +64,26 @@ Implements Rails' [protect_from_forgery](https://api.rubyonrails.org/classes/Act
 #### EmbeddedApp
 If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P header](https://www.w3.org/P3P/) and [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) are handled for you.
 
+By default, the `EmbeddedApp` concern also sets the layout file to be `app/views/layouts/embedded_app.html.erb`.
+
+Sometimes one wants to run an embedded app in non-embedded mode. For example:
+
+- When the remote environment is a CI;
+- When the remote environment is a preview/PR app;
+- When the developer wants to run the app in a non-embedded mode for testing.
+
+To use the same application layout for every application controller, a developer can now overwrite the `#use_embedded_app_layout?` method.
+
+```ruby
+class ApplicationController
+  # Ensures every controller is using the standard app/views/layouts/application.html.erb layout.
+  #
+  # @return [true, false]
+  def use_embedded_app_layout?
+    false
+  end
+end
+```
+
 #### EnsureBilling
 If billing is enabled for the app, the active payment for the session is queried and enforced if needed. If billing is required the user will be redirected to a page requesting payment.

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -7,13 +7,21 @@ module ShopifyApp
     include ShopifyApp::FrameAncestors
 
     included do
-      if ShopifyApp.configuration.embedded_app?
-        after_action(:set_esdk_headers)
-        layout("embedded_app")
-      end
+      layout :embedded_app_layout
+      after_action :set_esdk_headers, if: -> { ShopifyApp.configuration.embedded_app? }
+    end
+
+    protected
+
+    def use_embedded_app_layout?
+      ShopifyApp.configuration.embedded_app?
     end
 
     private
+
+    def embedded_app_layout
+      "embedded_app" if use_embedded_app_layout?
+    end
 
     def set_esdk_headers
       response.set_header("P3P", 'CP="Not used"')

--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "action_view/testing/resolvers"
+
+class EmbeddedAppTest < ActionController::TestCase
+  class BaseTestController < ActionController::Base
+    abstract!
+
+    self.view_paths = [
+      ActionView::FixtureResolver.new(
+        "layouts/application.erb"                             => "Application Layout <%= yield %>",
+        "layouts/embedded_app.erb"                            => "Embedded App Layout <%= yield %>",
+        "embedded_app_test/embedded_app_test/index.html.erb"  => "OK",
+      ),
+    ]
+  end
+
+  class ApplicationTestController < BaseTestController
+    layout "application"
+  end
+
+  class EmbeddedAppTestController < ApplicationTestController
+    include ShopifyApp::EmbeddedApp
+
+    def index; end
+  end
+
+  tests EmbeddedAppTestController
+
+  setup do
+    Rails.application.routes.draw do
+      get "/embedded_app", to: "embedded_app_test/embedded_app_test#index"
+    end
+  end
+
+  test "uses the embedded app layout when running in embedded mode" do
+    ShopifyApp.configuration.embedded_app = true
+
+    get :index
+    assert_template layout: "embedded_app"
+  end
+
+  test "uses the default layout when running in non-embedded mode" do
+    ShopifyApp.configuration.embedded_app = false
+
+    get :index
+    assert_template layout: "application"
+  end
+end

--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -47,4 +47,20 @@ class EmbeddedAppTest < ActionController::TestCase
     get :index
     assert_template layout: "application"
   end
+
+  test "sets the ESDK headers when running in embedded mode" do
+    ShopifyApp.configuration.embedded_app = true
+
+    get :index
+    assert_equal @controller.response.headers["P3P"], 'CP="Not used"'
+    assert_not_includes @controller.response.headers, "X-Frame-Options"
+  end
+
+  test "does not touch the ESDK headers when running in non-embedded mode" do
+    ShopifyApp.configuration.embedded_app = false
+
+    get :index
+    assert_not_includes @controller.response.headers, "P3P"
+    assert_includes @controller.response.headers, "X-Frame-Options"
+  end
 end


### PR DESCRIPTION
> **TLDR:** The PR gives an app developer more granular control over what layout to render when using the `shopify_app` gem to build an embedded Shopify app.

When running a Shopify app in embedded mode, every controller that requires an authenticated session will use the embedded app layout by default. This is enforced by the `ShopifyApp::EmbeddedApp` module.

As a default, this is great. It helps the developer to make fewer choices when they start to develop their new Shopify app. However, sometimes one wants to run an embedded app in non-embedded mode.

Some examples of running a normally embedded app in non-embedded mode:
- When the remote environment is a CI;
- When the remote environment is a preview/PR app;
- When the developer wants to run the app in a non-embedded mode for testing.

The static implementation of the embedded app layout causes duplication and maintainability issues when running in both modes.

This PR introduces a more flexible system whereby the developer has more control over what layout is being rendered during the process and allows the developer to ignore the embedded app layout.

Instead, the developer can implement the embedded app layout (as provided by the gem) once in the application.html.erb and set the

Now, when running the app both in embedded and non-embedded mode, the developer only has to maintain a single layout file for all controllers in its app.

### Reviewer's guide to testing

To use the same application layout for every application controller, a developer can now overwrite the `#use_embedded_app_layout?` method.

```ruby
class ApplicationController
  # Ensures every controller is using the standard layouts/application.html.erb layout.
  # 
  # @return [true, false]
  def use_embedded_app_layout?
    false
  end
end
```

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] ~~For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.~~

