### PR TITLE
Prefer #media_type over #content_type

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -280,8 +280,8 @@ module ShopifyApp
 
     def requested_by_javascript?
       request.xhr? ||
-        request.content_type == "text/javascript" ||
-        request.content_type == "application/javascript"
+        request.media_type == "text/javascript" ||
+        request.media_type == "application/javascript"
     end
   end
 end


### PR DESCRIPTION
### What this PR does

As per the Rails documentation here:
https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-response-content-type-now-returns-the-content-type-header-without-modification

`#content_type` will begin returning the charset as of Rails 7.1. This PR changes the method `requested_by_javascript?` to use `#media_type` which indicates the MIME type.

This change addresses the following deprecation warning:
```
DEPRECATION WARNING: Rails 7.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. 
```

There are no functional changes in this PR, so I've removed the rest of the template. If you need anything further please let me know.
