### PR TITLE
Update shopify-api to v13.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 * Fix `add_webhook` generator to create the webhook jobs under the correct directory[#1748](https://github.com/Shopify/shopify_app/pull/1748)
 * Add support for metafield_namespaces in webhook registration [#1745](https://github.com/Shopify/shopify_app/pull/1745)
+* Bumps shopify_api to latest version, adds support for 2024-01 API version [#1776](https://github.com/Shopify/shopify_app/pull/1776)
 
 21.8.1 (December 6, 2023)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
-      shopify_api (~> 13.3)
+      shopify_api (~> 13.4)
       sprockets-rails (>= 2.0.0)
 
 GEM
@@ -217,7 +217,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.2.2)
-    shopify_api (13.3.1)
+    shopify_api (13.4.0)
       activesupport
       concurrent-ruby
       hash_diff

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jwt", ">= 2.2.3")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
-  s.add_runtime_dependency("shopify_api", "~> 13.3")
+  s.add_runtime_dependency("shopify_api", "~> 13.4")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
 
   s.add_development_dependency("byebug")


### PR DESCRIPTION
### What this PR does

* Update shopify_api gem to [latest version](https://rubygems.org/gems/shopify_api/versions/13.4.0) 

### Reviewer's guide to testing

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
