### PR TITLE
Make type param optional on webhook route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Make type param for webhooks route optional. This will fix a bug with CLI initiated webhooks.
 
 21.10.0 (January 24, 2024)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ----------
-* Make type param for webhooks route optional. This will fix a bug with CLI initiated webhooks.
+* Make type param for webhooks route optional. This will fix a bug with CLI initiated webhooks.[1786](https://github.com/Shopify/shopify_app/pull/1786)
 
 21.10.0 (January 24, 2024)
 ----------

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,6 @@ ShopifyApp::Engine.routes.draw do
   end
 
   namespace :webhooks do
-    post ":type" => :receive
+    post "(:type)" => :receive
   end
 end


### PR DESCRIPTION
### What this PR does
Fixes [Shopify Ruby Template , APP_UNINSTALLED Webhook Delivery Failed, Can't Verify CSRF Token.](https://github.com/Shopify/shopify-app-template-ruby/issues/115)
* This makes the `type` param on the webhooks route optional
* When webhooks are initiated from the CLI they are sent to the `/api/webhooks` address
* Prior to this change this was causing CLI initiated webhooks to error
* The webhook type is never read from the URL param, and always from the webhook header so we do not forsee any issues with making this param optional.
### Reviewer's guide to testing

_Are there any cases where you forsee this being an error?_

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
