### PR TITLE
Properly handle 401 errors in XHR requests with LoginProtection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 * Make type param for webhooks route optional. This will fix a bug with CLI initiated webhooks.[1786](https://github.com/Shopify/shopify_app/pull/1786)
+* Fix redirecting to login when we catch a 401 response from Shopify, so that it can also handle cases where the app is already embedded when that happens.[1787](https://github.com/Shopify/shopify_app/pull/1787)
 
 21.10.0 (January 24, 2024)
 ----------

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -147,10 +147,11 @@ module ShopifyApp
     end
 
     def close_session
-      clear_shopify_session
       ShopifyApp::Logger.debug("Closing session")
-      ShopifyApp::Logger.debug("Redirecting to #{login_url_with_optional_shop}")
-      redirect_to(login_url_with_optional_shop)
+      clear_shopify_session
+
+      ShopifyApp::Logger.debug("Redirecting to login")
+      redirect_to_login
     end
 
     def handle_http_error(error)


### PR DESCRIPTION
### What this PR does

Related to #1708

After a 401 response from Shopify, we were simply attempting to redirect to Shopify, which wouldn't work for XHR requests for embedded apps.

We can instead use redirect_to_login, which is aware of the context and will return the appropriate response in all cases.

### Reviewer's guide to testing

You can reproduce the problem by:

- installing an app
- stopping my server
- uninstalling the app
- restarting server
- opening app

Before, this would lead to an attempt at logging in within the iframe, which would fail.

### Things to focus on

Is there any reason _not_ to use the 401 response with headers at this point?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
