### PR TITLE
Always register webhooks with offline sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 * Make type param for webhooks route optional. This will fix a bug with CLI initiated webhooks.[1786](https://github.com/Shopify/shopify_app/pull/1786)
 * Fix redirecting to login when we catch a 401 response from Shopify, so that it can also handle cases where the app is already embedded when that happens.[1787](https://github.com/Shopify/shopify_app/pull/1787)
+* Always register webhooks with offline sessions.[1788](https://github.com/Shopify/shopify_app/pull/1788)
 
 21.10.0 (January 24, 2024)
 ----------

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -130,11 +130,11 @@ module ShopifyApp
     end
 
     def perform_post_authenticate_jobs(session)
-      # Ensure we use the offline session to install webhooks and scripttags
-      offline_session = session.online? ? shop_session : session
+      # Ensure we use the shop session to install webhooks and scripttags
+      session_for_shop = session.online? ? shop_session : session
 
-      install_webhooks(offline_session)
-      install_scripttags(offline_session)
+      install_webhooks(session_for_shop)
+      install_scripttags(session_for_shop)
 
       perform_after_authenticate_job(session)
     end

--- a/app/controllers/shopify_app/callback_controller.rb
+++ b/app/controllers/shopify_app/callback_controller.rb
@@ -130,8 +130,12 @@ module ShopifyApp
     end
 
     def perform_post_authenticate_jobs(session)
-      install_webhooks(session)
-      install_scripttags(session)
+      # Ensure we use the offline session to install webhooks and scripttags
+      offline_session = session.online? ? shop_session : session
+
+      install_webhooks(offline_session)
+      install_scripttags(offline_session)
+
       perform_after_authenticate_job(session)
     end
 

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -316,9 +316,8 @@ module ShopifyApp
 
       get :callback, params: @callback_params
       assert_response 302
-    rescue => e
-      shop_storage.clear
-      raise e
+    ensure
+      ShopifyApp::SessionRepository.shop_storage.clear
     end
 
     test "#callback performs install_scripttags job after authentication" do

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -21,6 +21,8 @@ class CartsUpdateJob < ActiveJob::Base
 end
 
 module ShopifyApp
+  SHOP_DOMAIN = "shop.myshopify.io"
+
   class CallbackControllerTest < ActionController::TestCase
     setup do
       @routes = ShopifyApp::Engine.routes
@@ -28,12 +30,12 @@ module ShopifyApp
       ShopifyApp::SessionRepository.user_storage = nil
       ShopifyAppConfigurer.setup_context
       I18n.locale = :en
-      @stubbed_session = ShopifyAPI::Auth::Session.new(shop: "shop", access_token: "token")
+      @stubbed_session = ShopifyAPI::Auth::Session.new(shop: SHOP_DOMAIN, access_token: "token")
       @stubbed_cookie = ShopifyAPI::Auth::Oauth::SessionCookie.new(value: "", expires: Time.now)
       @host = "little-shoppe-of-horrors.#{ShopifyApp.configuration.myshopify_domain}"
       host = Base64.strict_encode64(@host + "/admin")
       @callback_params = {
-        shop: "shop",
+        shop: SHOP_DOMAIN,
         code: "code",
         state: "state",
         timestamp: "timestamp",
@@ -47,17 +49,27 @@ module ShopifyApp
       ShopifyApp::SessionRepository.stubs(:store_session)
     end
 
+    teardown do
+      SessionRepository.shop_storage.clear
+    end
+
     test "#callback flashes error in Spanish" do
       I18n.expects(:t).with("could_not_log_in")
       get :callback,
-        params: { shop: "shop", code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
+        params: { shop: SHOP_DOMAIN, code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
     end
 
     test "#callback rescued errors of ShopifyAPI::Error will not emit a deprecation notice" do
       ShopifyAPI::Auth::Oauth.expects(:validate_auth_callback).raises(ShopifyAPI::Errors::MissingRequiredArgumentError)
       assert_not_deprecated do
-        get :callback,
-          params: { shop: "shop", code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
+        get :callback, params: {
+          shop: SHOP_DOMAIN,
+          code: "code",
+          state: "state",
+          timestamp: "timestamp",
+          host: "host",
+          hmac: "hmac",
+        }
       end
       assert_equal flash[:error], "Could not log in to Shopify store"
     end
@@ -69,7 +81,7 @@ module ShopifyApp
 
       ShopifyApp::Logger.expects(:deprecated).never
       get :callback,
-        params: { shop: "shop", code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
+        params: { shop: SHOP_DOMAIN, code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
     end
 
     test "#callback rescued non-shopify errors will be deprecated" do
@@ -86,7 +98,7 @@ module ShopifyApp
       assert_within_deprecation_schedule(version)
       ShopifyApp::Logger.expects(:deprecated).with(message, version)
       get :callback,
-        params: { shop: "shop", code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
+        params: { shop: SHOP_DOMAIN, code: "code", state: "state", timestamp: "timestamp", host: "host", hmac: "hmac" }
     end
 
     test "#callback calls ShopifyAPI::Auth::Oauth.validate_auth_callback" do
@@ -118,29 +130,18 @@ module ShopifyApp
     end
 
     test "#callback sets the shopify_user_id in the Rails session when session is online" do
-      associated_user = ShopifyAPI::Auth::AssociatedUser.new(
-        id: 42,
-        first_name: "LeeeEEeeeeee3roy",
-        last_name: "Jenkins",
-        email: "dat_email@tho.com",
-        email_verified: true,
-        locale: "en",
-        collaborator: true,
-        account_owner: true,
-      )
-      mock_session = ShopifyAPI::Auth::Session.new(
-        shop: "shop",
-        access_token: "token",
-        is_online: true,
-        associated_user: associated_user,
-      )
-      mock_oauth(session: mock_session)
+      ShopifyApp::SessionRepository.shop_storage.store(@stubbed_session)
+      ShopifyApp::SessionRepository.user_storage = ShopifyApp::InMemoryUserSessionStore
+
+      mock_session = online_session
+      mock_oauth(session: online_session)
+
       get :callback, params: @callback_params
-      assert_equal session[:shopify_user_id], associated_user.id
+      assert_equal session[:shopify_user_id], mock_session.associated_user.id
     end
 
     test "#callback DOES NOT set the shopify_user_id in the Rails session when session is offline" do
-      mock_session = ShopifyAPI::Auth::Session.new(shop: "shop", access_token: "token", is_online: false)
+      mock_session = ShopifyAPI::Auth::Session.new(shop: SHOP_DOMAIN, access_token: "token", is_online: false)
       mock_oauth(session: mock_session)
       get :callback, params: @callback_params
       assert_nil session[:shopify_user_id]
@@ -166,7 +167,7 @@ module ShopifyApp
         config.webhooks = [{ topic: "carts/update", address: "example-app.com/webhooks" }]
       end
 
-      ShopifyApp::WebhooksManager.expects(:queue).with("shop", "token")
+      ShopifyApp::WebhooksManager.expects(:queue).with(SHOP_DOMAIN, "token")
 
       mock_oauth
       get :callback, params: @callback_params
@@ -189,7 +190,7 @@ module ShopifyApp
         config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: true }
       end
 
-      Shopify::AfterAuthenticateJob.expects(:perform_now).with(shop_domain: "shop")
+      Shopify::AfterAuthenticateJob.expects(:perform_now).with(shop_domain: SHOP_DOMAIN)
 
       mock_oauth
       get :callback, params: @callback_params
@@ -200,7 +201,7 @@ module ShopifyApp
         config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: false }
       end
 
-      Shopify::AfterAuthenticateJob.expects(:perform_later).with(shop_domain: "shop")
+      Shopify::AfterAuthenticateJob.expects(:perform_later).with(shop_domain: SHOP_DOMAIN)
 
       mock_oauth
       get :callback, params: @callback_params
@@ -222,7 +223,7 @@ module ShopifyApp
         config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob }
       end
 
-      Shopify::AfterAuthenticateJob.expects(:perform_later).with(shop_domain: "shop")
+      Shopify::AfterAuthenticateJob.expects(:perform_later).with(shop_domain: SHOP_DOMAIN)
 
       mock_oauth
       get :callback, params: @callback_params
@@ -233,7 +234,7 @@ module ShopifyApp
         config.after_authenticate_job = { job: "Shopify::AfterAuthenticateJob", inline: false }
       end
 
-      Shopify::AfterAuthenticateJob.expects(:perform_later).with(shop_domain: "shop")
+      Shopify::AfterAuthenticateJob.expects(:perform_later).with(shop_domain: SHOP_DOMAIN)
 
       mock_oauth
       get :callback, params: @callback_params
@@ -296,10 +297,28 @@ module ShopifyApp
         config.webhooks = [{ topic: "carts/update", address: "example-app.com/webhooks" }]
       end
 
-      ShopifyApp::WebhooksManager.expects(:queue).with("shop", "token")
+      ShopifyApp::WebhooksManager.expects(:queue).with(SHOP_DOMAIN, "token")
 
       get :callback, params: @callback_params
       assert_response 302
+    end
+
+    test "#callback performs install_webhook job with an offline session after an online session OAuth" do
+      ShopifyApp.configure do |config|
+        config.webhooks = [{ topic: "carts/update", address: "example-app.com/webhooks" }]
+      end
+      ShopifyApp::SessionRepository.shop_storage.store(@stubbed_session)
+      ShopifyApp::SessionRepository.user_storage = ShopifyApp::InMemoryUserSessionStore
+
+      mock_oauth(session: online_session)
+
+      ShopifyApp::WebhooksManager.expects(:queue).with(SHOP_DOMAIN, "token")
+
+      get :callback, params: @callback_params
+      assert_response 302
+    rescue => e
+      shop_storage.clear
+      raise e
     end
 
     test "#callback performs install_scripttags job after authentication" do
@@ -309,7 +328,7 @@ module ShopifyApp
         config.scripttags = [{ event: "onload", src: "https://example.com/fancy.js" }]
       end
 
-      ShopifyApp::ScripttagsManager.expects(:queue).with("shop", "token", ShopifyApp.configuration.scripttags)
+      ShopifyApp::ScripttagsManager.expects(:queue).with(SHOP_DOMAIN, "token", ShopifyApp.configuration.scripttags)
 
       get :callback, params: @callback_params
       assert_response 302
@@ -322,7 +341,7 @@ module ShopifyApp
         config.after_authenticate_job = { job: Shopify::AfterAuthenticateJob, inline: true }
       end
 
-      Shopify::AfterAuthenticateJob.expects(:perform_now).with(shop_domain: "shop")
+      Shopify::AfterAuthenticateJob.expects(:perform_now).with(shop_domain: SHOP_DOMAIN)
 
       get :callback, params: @callback_params
       assert_response 302
@@ -347,6 +366,25 @@ module ShopifyApp
           cookie: cookie,
           session: session,
         })
+    end
+
+    def online_session
+      associated_user = ShopifyAPI::Auth::AssociatedUser.new(
+        id: 42,
+        first_name: "LeeeEEeeeeee3roy",
+        last_name: "Jenkins",
+        email: "dat_email@tho.com",
+        email_verified: true,
+        locale: "en",
+        collaborator: true,
+        account_owner: true,
+      )
+      ShopifyAPI::Auth::Session.new(
+        shop: SHOP_DOMAIN,
+        access_token: "online-token",
+        is_online: true,
+        associated_user: associated_user,
+      )
     end
   end
 end


### PR DESCRIPTION
### What this PR does

Fixes #1708

Currently, we use the session we just created in the OAuth callback to trigger webhook registration. When using online tokens, that registration might not kick in before the token has expired.

To solve that, we can register webhooks using offline tokens, which won't expire.

### Reviewer's guide to testing

- Install an app in a store, but don't run the webhook manager job
- Alter the user access token in the database
- Perform the job

Before this change, that would break. Now, it should work the same way.

### Things to focus on

1. Does this have any impact on performance?
2. Is it enough?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users