### PR TITLE
Fix and Refactor splash page URL Handling to Respect Nested URLs

### DIFF
--- a/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
+++ b/app/controllers/concerns/shopify_app/ensure_authenticated_links.rb
@@ -18,7 +18,7 @@ module ShopifyApp
         embedded: params[:embedded],
       )
     end
-    
+
     def splash_page_with_params(params)
       uri = URI(base_url)
       uri.query = params.compact.to_query


### PR DESCRIPTION
This PR addresses an inconsistency in the splash_page_with_params method within the controller concern, where the method previously defaulted to the application's root path, disregarding the nested URL setting [as explained here](https://github.com/Shopify/shopify_app/blob/main/docs/shopify_app/engine.md).

Previously, when a nested_url was enabled and the app was accessed from the Shopify dashboard or the page was refreshed, the user was incorrectly redirected back to the app's root URL, instead of the intended Shopify app root (the nested URL).
