### PR TITLE
Improve issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,36 +6,41 @@ labels: "Type: Bug 🐛"
 
 # Issue summary
 
+Before opening this issue, I have:
+
+- [ ] Upgraded to the latest version of the package
+  - `shopify_app` version:
+  - Ruby version:
+  - Operating system:
+- [ ] Set `log_level: :debug` [in my configuration](https://github.com/Shopify/shopify-api-ruby#setup-shopify-context), if applicable
+- [ ] Found a reliable way to reproduce the problem that indicates it's a problem with the package
+- [ ] Looked for similar issues in this repository
+- [ ] Checked that this isn't an issue with a Shopify API
+  - If it is, please create a post in the [Shopify community forums](https://community.shopify.com/c/partners-and-developers/ct-p/appdev) or report it to [Shopify Partner Support](https://help.shopify.com/en/support/partners/org-select)
+
 <!--
+Write a short description of the issue here.
 
-Write a short description of the issue here. Please provide any details or logs that
-can help us debug it.
-
-Increase the logs as described in the README by setting log_level to :debug, and paste the relevant portion here.
-
-Learn more: https://github.com/Shopify/shopify-api-ruby#setup-shopify-context
-
+We can only fix issues for which there is a clear reproduction scenario.
+The more context you can provide, the easier it becomes for us to investigate and fix the issue.
 -->
-
-- `shopify_api` version:
-- `shopify_app` version:
-- Ruby version:
-- Operating system:
-
-```
-// Paste any relevant logs here
-```
 
 ## Expected behavior
 
-<!-- What do you think should happen? -->
+What do you think should happen?
 
 ## Actual behavior
 
-<!-- What actually happens? -->
+What actually happens?
 
 ## Steps to reproduce the problem
 
 1.
 1.
 1.
+
+## Debug logs
+
+```
+// Paste any relevant logs here
+```


### PR DESCRIPTION
### WHY are these changes introduced?

We want to be able to solve as many problems as possible, and help unblock developers. However, when we get duplicate / hard to reproduce issues, it takes away from the time we could be spending fixing them.

### WHAT is this pull request doing?

Revamping the issue template to suggest some things developers can check before opening an issue to see if a solution has been found, or to ensure we're getting as much context as we can, which really makes it easier for us to solve issues.