### PR TITLE
Post authentication tasks after token exchange

### DIFF
--- a/lib/shopify_app/controller_concerns/token_exchange.rb
+++ b/lib/shopify_app/controller_concerns/token_exchange.rb
@@ -67,7 +67,7 @@ module ShopifyApp
         )
       end
 
-      ShopifyApp.configuration.post_authenticate_tasks.perform(session) if session
+      ShopifyApp.configuration.post_authenticate_tasks.perform(session)
     end
 
     def exchange_token(shop:, session_token:, requested_token_type:)

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -220,16 +220,6 @@ class TokenExchangeControllerTest < ActionController::TestCase
     end
   end
 
-  test "Don't trigger post_authenticate_tasks if token exchange fails" do
-    with_application_test_routes do
-      ShopifyAPI::Utils::SessionUtils.stubs(:current_session_id).returns(nil)
-      ShopifyAPI::Auth::TokenExchange.expects(:exchange_token).returns(nil)
-      ShopifyApp.configuration.post_authenticate_tasks.expects(:perform).never
-
-      get :index, params: { shop: @shop }
-    end
-  end
-
   private
 
   def with_application_test_routes


### PR DESCRIPTION
- https://github.com/Shopify/temp-project-mover-Archetypically-20250319145332/issues/253

### What this PR does
- Trigger post_authenticate_tasks after token exchange completion

### Top hatting
##### PostAuthenticateTask methods are called after token exchange completes
![post-auth-tasks](https://github.com/Shopify/shopify_app/assets/102243935/688dafb9-a85a-4e4b-bf19-8f5ae7c45820)

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ will update when token exchange feature is complete ] Update `CHANGELOG.md` if the changes would impact users
- [ will update when token exchange feature is complete ] Update `README.md`, if appropriate.
- [ will update when token exchange feature is complete ] Update any relevant pages in `/docs`, if necessary
