### PR TITLE
Handle invalid session token

### DIFF
--- a/app/controllers/concerns/shopify_app/ensure_installed.rb
+++ b/app/controllers/concerns/shopify_app/ensure_installed.rb
@@ -17,7 +17,11 @@ module ShopifyApp
 
       before_action :check_shop_domain
 
-      unless ShopifyApp.configuration.use_new_embedded_auth_strategy?
+      if ShopifyApp.configuration.use_new_embedded_auth_strategy?
+        include ShopifyApp::TokenExchange
+        include ShopifyApp::EmbeddedApp
+        around_action :activate_shopify_session
+      else
         # TODO: Add support to use new embedded auth strategy here when invalid
         # session token can be handled by AppBridge app reload
         before_action :check_shop_known

--- a/app/controllers/concerns/shopify_app/ensure_installed.rb
+++ b/app/controllers/concerns/shopify_app/ensure_installed.rb
@@ -22,8 +22,6 @@ module ShopifyApp
         include ShopifyApp::EmbeddedApp
         around_action :activate_shopify_session
       else
-        # TODO: Add support to use new embedded auth strategy here when invalid
-        # session token can be handled by AppBridge app reload
         before_action :check_shop_known
         before_action :validate_non_embedded_session
       end

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -7,7 +7,7 @@ module ShopifyApp
 
     layout false, only: :new
 
-    after_action only: [:new, :create] do |controller|
+    after_action only: [:new, :create, :patch_session_token] do |controller|
       controller.response.headers.except!("X-Frame-Options")
     end
 
@@ -17,6 +17,10 @@ module ShopifyApp
 
     def create
       authenticate
+    end
+
+    def patch_session_token
+      render(layout: "shopify_app/layouts/app_bridge")
     end
 
     def top_level_interaction

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -7,7 +7,7 @@ module ShopifyApp
 
     layout false, only: :new
 
-    after_action only: [:new, :create, :patch_session_token] do |controller|
+    after_action only: [:new, :create, :patch_shopify_id_token] do |controller|
       controller.response.headers.except!("X-Frame-Options")
     end
 
@@ -19,7 +19,7 @@ module ShopifyApp
       authenticate
     end
 
-    def patch_session_token
+    def patch_shopify_id_token
       render(layout: "shopify_app/layouts/app_bridge")
     end
 

--- a/app/views/shopify_app/layouts/app_bridge.html.erb
+++ b/app/views/shopify_app/layouts/app_bridge.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title><%= ShopifyApp.configuration.application_name %></title>
+    <%= yield :head %>
+    <script
+      data-api-key="<%= ShopifyApp.configuration.api_key %>"
+      src="https://cdn.shopify.com/shopifycloud/app-bridge.js">
+    </script>
+    <%= csrf_meta_tags %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ ShopifyApp::Engine.routes.draw do
     get login_url => :new, :as => :login
     post login_url => :create, :as => :authenticate
     get "logout" => :destroy, :as => :logout
+    get "patch_session_token" => :patch_session_token
 
     # Kept to prevent apps relying on these routes from breaking
     if login_url.gsub(%r{^/}, "") != "login"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ ShopifyApp::Engine.routes.draw do
     get login_url => :new, :as => :login
     post login_url => :create, :as => :authenticate
     get "logout" => :destroy, :as => :logout
-    get "patch_session_token" => :patch_session_token
+    get "patch_shopify_id_token" => :patch_shopify_id_token
 
     # Kept to prevent apps relying on these routes from breaking
     if login_url.gsub(%r{^/}, "") != "login"

--- a/lib/shopify_app/controller_concerns/token_exchange.rb
+++ b/lib/shopify_app/controller_concerns/token_exchange.rb
@@ -75,16 +75,16 @@ module ShopifyApp
     end
 
     def redirect_to_bounce_page
-      patch_session_token_url = "#{ShopifyApp.configuration.root_url}/patch_session_token"
-      patch_session_token_params = request.query_parameters.except(:id_token)
+      patch_shopify_id_token_url = "#{ShopifyApp.configuration.root_url}/patch_shopify_id_token"
+      patch_shopify_id_token_params = request.query_parameters.except(:id_token)
 
-      bounce_url = "#{request.path}?#{patch_session_token_params.to_query}"
+      bounce_url = "#{request.path}?#{patch_shopify_id_token_params.to_query}"
 
       # App Bridge will trigger a fetch to the URL in shopify-reload, with a new session token in headers
-      patch_session_token_params["shopify-reload"] = bounce_url
+      patch_shopify_id_token_params["shopify-reload"] = bounce_url
 
       redirect_to(
-        "#{patch_session_token_url}?#{patch_session_token_params.to_query}",
+        "#{patch_shopify_id_token_url}?#{patch_shopify_id_token_params.to_query}",
         allow_other_host: true,
       )
     end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -402,6 +402,11 @@ module ShopifyApp
       end
     end
 
+    test "#patch_shopify_id_token renders the app bridge layout" do
+      get :patch_shopify_id_token, params: { shop: "my-shop" }
+      assert_template "shopify_app/layouts/app_bridge"
+    end
+
     private
 
     def assert_redirected_to_top_level(shop_domain, expected_url = nil)

--- a/test/dummy/config/initializers/shopify_app.rb
+++ b/test/dummy/config/initializers/shopify_app.rb
@@ -17,8 +17,13 @@ class ShopifyAppConfigurer
       config.embedded_redirect_url = nil
 
       config.shop_session_repository = ShopifyApp::InMemorySessionStore
+      config.user_session_repository = nil
       config.after_authenticate_job = false
       config.reauth_on_access_scope_changes = true
+      config.root_url = "/"
+      config.wip_new_embedded_auth_strategy = false
+      config.check_session_expiry_date = false
+      config.custom_post_authenticate_tasks = nil
     end
 
     setup_context

--- a/test/routes/sessions_routes_test.rb
+++ b/test/routes/sessions_routes_test.rb
@@ -25,6 +25,10 @@ class SessionsRoutesTest < ActionController::TestCase
     assert_routing "/logout", { controller: "shopify_app/sessions", action: "destroy" }
   end
 
+  test "patch_shopify_id_token routes to sessions#patch_shopify_id_token" do
+    assert_routing "/patch_shopify_id_token", { controller: "shopify_app/sessions", action: "patch_shopify_id_token" }
+  end
+
   test "login route doesn't change with custom root URL because it is in an engine" do
     ShopifyApp.configuration.root_url = "/new-root"
     Rails.application.reload_routes!

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -193,8 +193,10 @@ class TokenExchangeControllerTest < ActionController::TestCase
       request.headers["HTTP_AUTHORIZATION"] = nil
 
       params = { shop: @shop, my_param: "for-keeps", id_token: "dont-include-this-id-token" }
-      expected_redirect_url = "/my-root/patch_shopify_id_token?my_param=for-keeps&shop=my-shop.myshopify.com"
-      expected_redirect_url += "&shopify-reload=%2Freloaded_path%3Fmy_param%3Dfor-keeps%26shop%3Dmy-shop.myshopify.com"
+      reload_url = CGI.escape("/reloaded_path?my_param=for-keeps&shop=#{@shop}")
+      expected_redirect_url = "/my-root/patch_shopify_id_token"\
+        "?my_param=for-keeps&shop=#{@shop}"\
+        "&shopify-reload=#{reload_url}"
 
       with_application_test_routes do
         get :reloaded_path, params: params

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 require "action_controller"
 require "action_controller/base"
+require "json"
 
 class ApiClass
   def self.perform; end
@@ -14,6 +15,10 @@ class TokenExchangeController < ActionController::Base
   around_action :activate_shopify_session
 
   def index
+    render(plain: "OK")
+  end
+
+  def reloaded_path
     render(plain: "OK")
   end
 
@@ -178,6 +183,40 @@ class TokenExchangeControllerTest < ActionController::TestCase
     end
   end
 
+  [
+    ShopifyAPI::Errors::InvalidJwtTokenError,
+    ShopifyAPI::Errors::CookieNotFoundError,
+  ].each do |invalid_shopify_id_token_error|
+    test "Redirects to bounce page if Shopify ID token is invalid with #{invalid_shopify_id_token_error}" do
+      ShopifyApp.configuration.root_url = "/my-root"
+      ShopifyAPI::Utils::SessionUtils.stubs(:current_session_id).raises(invalid_shopify_id_token_error)
+      request.headers["HTTP_AUTHORIZATION"] = nil
+
+      params = { shop: @shop, my_param: "for-keeps", id_token: "dont-include-this-id-token" }
+      expected_redirect_url = "/my-root/patch_shopify_id_token?my_param=for-keeps&shop=my-shop.myshopify.com"
+      expected_redirect_url += "&shopify-reload=%2Freloaded_path%3Fmy_param%3Dfor-keeps%26shop%3Dmy-shop.myshopify.com"
+
+      with_application_test_routes do
+        get :reloaded_path, params: params
+        assert_redirected_to expected_redirect_url
+      end
+    end
+
+    test "Responds with unauthorized if Shopify Id token is invalid with #{invalid_shopify_id_token_error} and authorization header exists" do
+      ShopifyAPI::Utils::SessionUtils.stubs(:current_session_id).raises(invalid_shopify_id_token_error)
+      request.headers["HTTP_AUTHORIZATION"] = @id_token_in_header
+      expected_response = { errors: [{ message: :unauthorized }] }
+
+      with_application_test_routes do
+        get :make_api_call, params: { shop: @shop }
+
+        assert_response :unauthorized
+        assert_equal expected_response.to_json, response.body
+        assert_equal 1, response.headers["X-Shopify-Retry-Invalid-Session-Request"]
+      end
+    end
+  end
+
   private
 
   def with_application_test_routes
@@ -185,6 +224,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
       set.draw do
         get "/" => "token_exchange#index"
         get "/make_api_call" => "token_exchange#make_api_call"
+        get "/reloaded_path" => "token_exchange#reloaded_path"
       end
       yield
     end


### PR DESCRIPTION
- closes https://github.com/Shopify/develop-app-access/issues/145

### What this PR does
- Handle invalid session token errors 
- Redirect to app-bridge-next bounce page if session token is invalid & Auth header doesn't exist
- Respond with 401 if auth header exists and session token is invalid. If the app's front-end is using CDN version of app bridge next, it'll automatically be retried. otherwise, the 401 error will be exposed.

### Tophatting-

* 📹 [Redirecting to bounce page on initial app render](https://videobin.shopify.io/v/5rOD2g) (we are not parsing `id_token` from URL param yet, so session token will be invalid initially, this redirect shouldn't be hit as often once we are using `id_token`)  
* For testing - I created a temp global variable count that raises an "invalid session token" error on **every other try**. 
  * 📹 [App configured with app bridge from CDN](https://videobin.shopify.io/v/rzQElp) - The initial `create` failed from invalid session token, since `X-Shopify-Retry-Invalid-Session-Request` is set from the response, app bridge will retry `create` with new session token, thus passing the second time
  * 📹 [App configured with old version of app bridge NOT using the CDN](https://videobin.shopify.io/v/bjkoE1) - Response for `create` returns 401 in every other request from my test setup.. 

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ will update once feature is released ] Update `CHANGELOG.md` if the changes would impact users
- [will update once feature is released  ] Update `README.md`, if appropriate.
- [will update once feature is released  ] Update any relevant pages in `/docs`, if necessary

