### PR TITLE
Support id_token from URL params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* Bumps `shopify_api` to `14.3.0` [1832](https://github.com/Shopify/shopify_app/pull/1832)
 
 22.1.0 (April 9,2024)
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Unreleased
 ----------
 * Bumps `shopify_api` to `14.3.0` [1832](https://github.com/Shopify/shopify_app/pull/1832)
+* Support `id_token` from URL param [1832](https://github.com/Shopify/shopify_app/pull/1832)
+  * Extracted controller concern `WithShopifyIdToken`
+      * This concern provides a method `shopify_id_token` to retrieve the Shopify Id token from either the authorization header or the URL param `id_token`.
+  * `ShopifyApp::JWTMiddleware` supports retrieving session token from URL param `id_token`
+  * `ShopifyApp::JWTMiddleware` returns early if the app is not embedded to avoid unnecessary JWT verification
+  * `LoginProtection` now uses `WithShopifyIdToken` concern to retrieve the Shopify Id token, thus accepting the session token from the URL param `id_token`
+* Marking `ShopifyApp::JWT` to be deprecated in version 23.0.0 [1832](https://github.com/Shopify/shopify_app/pull/1832), use `ShopifyAPI::Auth::JwtPayload` instead.
 
 22.1.0 (April 9,2024)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
-      shopify_api (>= 14.2.0, < 15.0)
+      shopify_api (>= 14.3.0, < 15.0)
       sprockets-rails (>= 2.0.0)
 
 GEM
@@ -217,7 +217,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.2.2)
-    shopify_api (14.2.0)
+    shopify_api (14.3.0)
       activesupport
       concurrent-ruby
       hash_diff

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -92,29 +92,6 @@ Edit `config/initializer/shopify_app.rb` and ensure the following configurations
 + config.shop_session_repository = 'Shop'
 ```
 
-#### Inspect server logs
-
-If you have checked the configurations above, and the app is still using cookies, then it is possible that the `shopify_app` gem defaulted to relying on cookies. This would happen when your browser allows third-party cookies and a session token was not successfully found as part of your request.
-
-In this case, check the server logs to see if the session token was invalid:
-
-```los
-[ShopifyApp::JWT] Failed to validate JWT: [JWT::<Error>] <Failure message>
-```
-
-*Example*
-
-```
-[ShopifyApp::JWT] Failed to validate JWT: [JWT::ImmatureSignature] Signature nbf has not been reached
-```
-
-**Note:** In a local development environment, you may want to temporarily update your `Gemfile` to point to a local instance of the `shopify_app` library instad of an installed gem. This will enable you to use a debugging tool like `byebug` to debug the library.
-
-```diff
-- gem 'shopify_app', '~> 14.2'
-+ gem 'shopify_app', path: '/path/to/shopify_app'
-```
-
 ### My app can't make requests to the Shopify API
 
 > **Note:** Session tokens cannot be used to make authenticated requests to the Shopify API. Learn more about authenticating your backend requests to Shopify APIs at [Shopify API authentication](https://shopify.dev/concepts/about-apis/authentication).

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -51,6 +51,10 @@ If you have overwritten these methods in your callback controller to modify the 
 update your app to use configurable option `config.custom_post_authenticate_tasks` instead. See [post authenticate tasks](/docs/shopify_app/authentication.md#post-authenticate-tasks)
 for more information.
 
+#### (v23.0.0) - Deprecated "ShopifyApp::JWT" class
+The `ShopifyApp::JWT` class has been deprecated in `v23.0.0`. Use [ShopifyAPI::Auth::JwtPayload](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/auth/jwt_payload.rb)
+class from the `shopify_api` gem instead.
+
 ## Upgrading to `v22.0.0`
 #### Dropped support for Ruby 2.x
 Support for Ruby 2.x has been dropped as it is no longer supported. You'll need to upgrade to 3.x.x

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -53,7 +53,9 @@ for more information.
 
 #### (v23.0.0) - Deprecated "ShopifyApp::JWT" class
 The `ShopifyApp::JWT` class has been deprecated in `v23.0.0`. Use [ShopifyAPI::Auth::JwtPayload](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/auth/jwt_payload.rb)
-class from the `shopify_api` gem instead.
+class from the `shopify_api` gem instead. A search and replace should be enough for this migration.
+  - `ShopifyAPI::Auth::JwtPayload` is a superset of the `ShopifyApp::JWT` class, and contains methods that were available in `ShopifyApp::JWT`. 
+  - `ShopifyAPI::Auth::JwtPayload` raises `ShopifyAPI::Errors::InvalidJwtTokenError` if the token is invalid.
 
 ## Upgrading to `v22.0.0`
 #### Dropped support for Ruby 2.x

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -56,6 +56,7 @@ module ShopifyApp
   require "shopify_app/controller_concerns/app_proxy_verification"
   require "shopify_app/controller_concerns/webhook_verification"
   require "shopify_app/controller_concerns/token_exchange"
+  require "shopify_app/controller_concerns/with_shopify_id_token"
 
   # Auth helpers
   require "shopify_app/auth/post_authenticate_tasks"

--- a/lib/shopify_app/auth/token_exchange.rb
+++ b/lib/shopify_app/auth/token_exchange.rb
@@ -14,7 +14,7 @@ module ShopifyApp
       end
 
       def perform
-        domain = ShopifyApp::JWT.new(id_token).shopify_domain
+        domain = ShopifyAPI::Auth::JwtPayload.new(id_token).shopify_domain
 
         Logger.info("Performing Token Exchange for [#{domain}] - (Offline)")
         session = exchange_token(

--- a/lib/shopify_app/controller_concerns/with_shopify_id_token.rb
+++ b/lib/shopify_app/controller_concerns/with_shopify_id_token.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ShopifyApp
+  module WithShopifyIdToken
+    extend ActiveSupport::Concern
+
+    def shopify_id_token
+      @shopify_id_token ||= id_token_from_request_env || id_token_from_authorization_header || id_token_from_url_param
+    end
+
+    private
+
+    def id_token_from_request_env
+      # This is set from ShopifyApp::JWTMiddleware
+      request.env["jwt.token"]
+    end
+
+    def id_token_from_authorization_header
+      request.headers["HTTP_AUTHORIZATION"]&.match(/^Bearer (.+)$/)&.[](1)
+    end
+
+    def id_token_from_url_param
+      params["id_token"]
+    end
+  end
+end

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -34,11 +34,14 @@ module ShopifyApp
     end
 
     def set_env_variables(token, env)
-      jwt = ShopifyApp::JWT.new(token)
+      jwt = ShopifyAPI::Auth::JwtPayload.new(token)
 
-      env["jwt.shopify_domain"] = jwt.shopify_domain
-      env["jwt.shopify_user_id"] = jwt.shopify_user_id
-      env["jwt.expire_at"] = jwt.expire_at
+      env["jwt.shopify_domain"] = jwt.shop
+      env["jwt.shopify_user_id"] = jwt.sub.to_i
+      env["jwt.expire_at"] = jwt.exp
+    rescue ShopifyAPI::Errors::InvalidJwtTokenError
+      # ShopifyApp::JWT did not raise any exceptions, ensuring behaviour does not change
+      nil
     end
   end
 end

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -2,7 +2,7 @@
 
 module ShopifyApp
   class JWTMiddleware
-    TOKEN_REGEX = /^Bearer\s+(.*?)$/
+    TOKEN_REGEX = /^Bearer (.+)$/
     ID_TOKEN_QUERY_PARAM = "id_token"
 
     def initialize(app)

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -40,6 +40,7 @@ module ShopifyApp
     def set_env_variables(token, env)
       jwt = ShopifyAPI::Auth::JwtPayload.new(token)
 
+      env["jwt.token"] = token
       env["jwt.shopify_domain"] = jwt.shop
       env["jwt.shopify_user_id"] = jwt.sub.to_i
       env["jwt.expire_at"] = jwt.exp

--- a/lib/shopify_app/middleware/jwt_middleware.rb
+++ b/lib/shopify_app/middleware/jwt_middleware.rb
@@ -12,7 +12,7 @@ module ShopifyApp
     def call(env)
       return call_next(env) unless ShopifyApp.configuration.embedded_app?
 
-      token = token_from_query_string(env) || token_from_authorization_header(env)
+      token = token_from_authorization_header(env) || token_from_query_string(env)
       return call_next(env) unless token
 
       set_env_variables(token, env)
@@ -26,11 +26,7 @@ module ShopifyApp
     end
 
     def token_from_authorization_header(env)
-      auth_header = env["HTTP_AUTHORIZATION"]
-      return unless auth_header
-
-      match = auth_header.match(TOKEN_REGEX)
-      match && match[1]
+      env["HTTP_AUTHORIZATION"]&.match(TOKEN_REGEX)&.[](1)
     end
 
     def token_from_query_string(env)
@@ -41,9 +37,9 @@ module ShopifyApp
       jwt = ShopifyAPI::Auth::JwtPayload.new(token)
 
       env["jwt.token"] = token
-      env["jwt.shopify_domain"] = jwt.shop
-      env["jwt.shopify_user_id"] = jwt.sub.to_i
-      env["jwt.expire_at"] = jwt.exp
+      env["jwt.shopify_domain"] = jwt.shopify_domain
+      env["jwt.shopify_user_id"] = jwt.shopify_user_id
+      env["jwt.expire_at"] = jwt.expire_at
     rescue ShopifyAPI::Errors::InvalidJwtTokenError
       # ShopifyApp::JWT did not raise any exceptions, ensuring behaviour does not change
       nil

--- a/lib/shopify_app/session/jwt.rb
+++ b/lib/shopify_app/session/jwt.rb
@@ -13,6 +13,7 @@ module ShopifyApp
     ]
 
     def initialize(token)
+      warn_deprecation
       @token = token
       set_payload
     end
@@ -59,6 +60,14 @@ module ShopifyApp
         "'dest' claim host does not match 'iss' claim host" unless dest_host == iss_host
 
       payload
+    end
+
+    def warn_deprecation
+      message = <<~EOS
+        "ShopifyApp::JWT will be deprecated, use ShopifyAPI::Auth::JwtPayload to parse JWT token instead."
+      EOS
+
+      ShopifyApp::Logger.deprecated(message, "23.0.0")
     end
   end
 end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jwt", ">= 2.2.3")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
-  s.add_runtime_dependency("shopify_api", ">= 14.2.0", "< 15.0")
+  s.add_runtime_dependency("shopify_api", ">= 14.3.0", "< 15.0")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
 
   s.add_development_dependency("byebug")

--- a/test/shopify_app/controller_concerns/with_shopify_id_token_test.rb
+++ b/test/shopify_app/controller_concerns/with_shopify_id_token_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WithShopifyIdTokenController < ActionController::Base
+  include ShopifyApp::WithShopifyIdToken
+
+  def index
+    render(plain: "index")
+  end
+end
+
+class WithShopifyIdTokenTest < ActionController::TestCase
+  tests WithShopifyIdTokenController
+
+  def setup
+    @id_token = "this-is-the-shopify-id-token"
+    @auth_header = "Bearer #{@id_token}"
+  end
+
+  test "#shopify_id_token returns nil if id_token can't be found anywhere" do
+    with_application_test_routes do
+      get :index
+
+      assert_nil @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns id token from request env" do
+    with_application_test_routes do
+      request.env["jwt.token"] = @id_token
+      get :index
+
+      assert_equal @id_token, @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns nil if request env is set to nil" do
+    with_application_test_routes do
+      request.env["jwt.token"] = nil
+      get :index
+
+      assert_nil @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns id token from authorization header" do
+    with_application_test_routes do
+      request.headers["HTTP_AUTHORIZATION"] = @auth_header
+      get :index
+
+      assert_equal @id_token, @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns nil for invalid authorization header format" do
+    [
+      nil,
+      "Bearer",
+      "Bearer ",
+      "Bearer#{@id_token}",
+      "something-else #{@id_token}",
+      "something-else",
+    ].each do |invalid_auth_headers|
+      with_application_test_routes do
+        request.headers["HTTP_AUTHORIZATION"] = invalid_auth_headers
+        get :index
+
+        assert_nil @controller.shopify_id_token
+      end
+    end
+  end
+
+  test "#shopify_id_token returns id token from URL params" do
+    with_application_test_routes do
+      get :index, params: { id_token: @id_token }
+
+      assert_equal @id_token, @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns id token from request env first" do
+    with_application_test_routes do
+      request.env["jwt.token"] = "OK"
+      request.headers["HTTP_AUTHORIZATION"] = "Bearer this-should-not-be-returned"
+      get :index, params: { id_token: "this-should-also-not-be-returned" }
+
+      assert_equal "OK", @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns id token from authorization header only if request env is nil" do
+    with_application_test_routes do
+      request.env["jwt.token"] = nil
+      request.headers["HTTP_AUTHORIZATION"] = "Bearer OK"
+      get :index, params: { id_token: "this-should-not-be-returned" }
+
+      assert_equal "OK", @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token returns id token from URL params only if request env and authorization header are nil" do
+    with_application_test_routes do
+      request.env["jwt.token"] = nil
+      request.headers["HTTP_AUTHORIZATION"] = nil
+      get :index, params: { id_token: "OK" }
+
+      assert_equal "OK", @controller.shopify_id_token
+    end
+  end
+
+  test "#shopify_id_token is memoized" do
+    with_application_test_routes do
+      request.env["jwt.token"] = "OK"
+      first = @controller.shopify_id_token
+      request.env["jwt.token"] = "NOT-OK"
+      second = @controller.shopify_id_token
+
+      assert_equal first, second, "OK"
+    end
+  end
+
+  def with_application_test_routes
+    with_routing do |set|
+      set.draw do
+        get "/" => "with_shopify_id_token#index"
+      end
+      yield
+    end
+  end
+end

--- a/test/shopify_app/middleware/jwt_middleware_test.rb
+++ b/test/shopify_app/middleware/jwt_middleware_test.rb
@@ -126,6 +126,7 @@ class ShopifyApp::JWTMiddlewareTest < ActiveSupport::TestCase
     assert_equal @shop, env["jwt.shopify_domain"]
     assert_equal @user_id, env["jwt.shopify_user_id"]
     assert_equal @expire_at, env["jwt.expire_at"]
+    assert_equal @jwt_token, env["jwt.token"]
   end
 
   def assert_envs_are_nil(env)

--- a/test/shopify_app/middleware/jwt_middleware_test.rb
+++ b/test/shopify_app/middleware/jwt_middleware_test.rb
@@ -13,8 +13,32 @@ class ShopifyApp::JWTMiddlewareTest < ActiveSupport::TestCase
     Rack::Lint.new(ShopifyApp::JWTMiddleware.new(simple_app))
   end
 
+  def setup
+    @user_id = 12345678
+    @shop = "test-shop.myshopify.io"
+    @expire_at = (Time.now + 10).to_i
+
+    payload = {
+      iss: "https://#{@shop}/admin",
+      dest: "https://#{@shop}",
+      aud: ShopifyAPI::Context.api_key,
+      sub: @user_id.to_s,
+      exp: @expire_at,
+      nbf: 1234,
+      iat: 1234,
+      jti: "4321",
+      sid: "abc123",
+    }
+
+    @jwt_token = JWT.encode(payload, ShopifyAPI::Context.api_secret_key, "HS256")
+    @auth_header = "Bearer #{@jwt_token}"
+    @jwt_payload = ShopifyAPI::Auth::JwtPayload.new(@jwt_token)
+  end
+
   test "does not change env if no authorization header" do
-    env = Rack::MockRequest.env_for("https://example.com")
+    env = Rack::MockRequest.env_for
+
+    ShopifyAPI::Auth::JwtPayload.expects(:new).never
 
     app.call(env)
 
@@ -22,66 +46,58 @@ class ShopifyApp::JWTMiddlewareTest < ActiveSupport::TestCase
   end
 
   test "does not change env if no bearer token" do
-    env = Rack::MockRequest.env_for("https://example.com")
+    env = Rack::MockRequest.env_for
     env["HTTP_AUTHORIZATION"] = "something"
 
+    ShopifyAPI::Auth::JwtPayload.expects(:new).never
+
     app.call(env)
 
     assert_nil env["jwt.shopify_domain"]
   end
 
-  test "does not add the shop to the env if nil shop value" do
-    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id, :expire_at).new(nil, 1, nil)
-    ShopifyApp::JWT.stubs(:new).with("abc").returns(jwt_mock)
-
-    env = Rack::MockRequest.env_for("https://example.com")
-    env["HTTP_AUTHORIZATION"] = "Bearer abc"
+  test "sets env values if JWT parses successfully" do
+    env = Rack::MockRequest.env_for
+    env["HTTP_AUTHORIZATION"] = @auth_header
+    ShopifyAPI::Auth::JwtPayload.expects(:new).with(@jwt_token).returns(@jwt_payload)
 
     app.call(env)
 
-    assert_nil env["jwt.shopify_domain"]
-    assert_equal 1, env["jwt.shopify_user_id"]
-    assert_nil env["jwt.expire_at"]
+    assert_equal @shop, env["jwt.shopify_domain"]
+    assert_equal @user_id, env["jwt.shopify_user_id"]
+    assert_equal @expire_at, env["jwt.expire_at"]
   end
 
-  test "does not add the user to the env if nil user value" do
-    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id, :expire_at).new("example.myshopify.com", nil, nil)
-    ShopifyApp::JWT.stubs(:new).with("abc").returns(jwt_mock)
+  test "sets the jwt values before calling the next middleware" do
+    env = Rack::MockRequest.env_for
+    env["HTTP_AUTHORIZATION"] = @auth_header
 
-    env = Rack::MockRequest.env_for("https://example.com")
-    env["HTTP_AUTHORIZATION"] = "Bearer abc"
+    _, _, body = ShopifyApp::JWTMiddleware.new(simple_app).call(env)
 
-    app.call(env)
+    assert_equal "test-shop.myshopify.io", body
+  end
 
-    assert_equal "example.myshopify.com", env["jwt.shopify_domain"]
+  test "does not set env or raise exception if JWT parsing fails" do
+    env = Rack::MockRequest.env_for
+    env["HTTP_AUTHORIZATION"] = @auth_header
+
+    ShopifyAPI::Auth::JwtPayload.expects(:new).raises(ShopifyAPI::Errors::InvalidJwtTokenError)
+
+    assert_nothing_raised { app.call(env) }
+
+    assert_nil env["jwt.shopify_domain"]
     assert_nil env["jwt.shopify_user_id"]
     assert_nil env["jwt.expire_at"]
   end
 
-  test "sets shopify_domain, shopify_user_id and expire_at if non-nil values" do
-    expire_at = 2.hours.from_now.to_i
-    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id, :expire_at).new("example.myshopify.com", 1, expire_at)
-    ShopifyApp::JWT.stubs(:new).with("abc").returns(jwt_mock)
+  test "calls the next middleware even if JWT parsing fails" do
+    env = Rack::MockRequest.env_for
+    env["HTTP_AUTHORIZATION"] = @auth_header
 
-    env = Rack::MockRequest.env_for("https://example.com")
-    env["HTTP_AUTHORIZATION"] = "Bearer abc"
-
-    app.call(env)
-
-    assert_equal "example.myshopify.com", env["jwt.shopify_domain"]
-    assert_equal 1, env["jwt.shopify_user_id"]
-    assert_equal expire_at, env["jwt.expire_at"]
-  end
-
-  test "sets the jwt values before calling the next middleware" do
-    jwt_mock = Struct.new(:shopify_domain, :shopify_user_id, :expire_at).new("example.myshopify.com", 1, nil)
-    ShopifyApp::JWT.stubs(:new).with("abc").returns(jwt_mock)
-
-    env = Rack::MockRequest.env_for("https://example.com")
-    env["HTTP_AUTHORIZATION"] = "Bearer abc"
+    ShopifyAPI::Auth::JwtPayload.expects(:new).raises(ShopifyAPI::Errors::InvalidJwtTokenError)
 
     _, _, body = ShopifyApp::JWTMiddleware.new(simple_app).call(env)
 
-    assert_equal "example.myshopify.com", body
+    assert_equal "", body
   end
 end

--- a/test/shopify_app/session/jwt_test.rb
+++ b/test/shopify_app/session/jwt_test.rb
@@ -16,6 +16,16 @@ module ShopifyApp
       ShopifyApp.configuration.myshopify_domain = "myshopify.io"
     end
 
+    test "warn deprecation" do
+      deprecation_message = <<~EOS
+        "ShopifyApp::JWT will be deprecated, use ShopifyAPI::Auth::JwtPayload to parse JWT token instead."
+      EOS
+
+      ShopifyApp::Logger.expects(:deprecated).with(deprecation_message, "23.0.0")
+
+      JWT.new("")
+    end
+
     test "#shopify_domain, #shopify_user_id and #expire_at are returned from jwt payload" do
       p = payload
       jwt = JWT.new(token(p))


### PR DESCRIPTION
- https://github.com/Shopify/develop-app-access/issues/289

### What this PR does
* Bumps `shopify_api` to `14.3.0`
* Support `id_token` from URL param 
  * Extracted controller concern `WithShopifyIdToken`
      * This concern provides a method `shopify_id_token` to retrieve the Shopify Id token from either the authorization header or the URL param `id_token`.
  * `ShopifyApp::JWTMiddleware` supports retrieving session token from URL param `id_token`
  * `ShopifyApp::JWTMiddleware` returns early if the app is not embedded to avoid unnecessary JWT verification
  * `LoginProtection` now uses `WithShopifyIdToken` concern to retrieve the Shopify Id token, thus accepting the session token from the URL param `id_token`
* Marking `ShopifyApp::JWT` to be deprecated in version 23.0.0, use `ShopifyAPI::Auth::JwtPayload` instead.

### Reviewer's guide to testing
- Ensure existing behaviour remains the same besides accepting id_token from param. Apps shouldn't raise more errors from JWT parsing.
- 📹 [LoginProtection still behaves the same, session token can be retrieved from id_token](https://videobin.shopify.io/v/bjQre0)
- 📹 [TokenExchange no longer bounces to patch session token on initial load since id_token is part of the URL params](https://videobin.shopify.io/v/xdRR15)

### Checklist
Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
