### PR TITLE
EnsureBilling and EnsureAuthenticatedLinks works with token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
   * `ShopifyApp::JWTMiddleware` returns early if the app is not embedded to avoid unnecessary JWT verification
   * `LoginProtection` now uses `WithShopifyIdToken` concern to retrieve the Shopify Id token, thus accepting the session token from the URL param `id_token`
 * Marking `ShopifyApp::JWT` to be deprecated in version 23.0.0 [1832](https://github.com/Shopify/shopify_app/pull/1832), use `ShopifyAPI::Auth::JwtPayload` instead.
+* Fix infinite redirect loop caused by handling errors from Billing API [1833](https://github.com/Shopify/shopify_app/pull/1833)
 
 22.1.0 (April 9,2024)
 ----------

--- a/app/controllers/concerns/shopify_app/ensure_installed.rb
+++ b/app/controllers/concerns/shopify_app/ensure_installed.rb
@@ -19,7 +19,6 @@ module ShopifyApp
 
       if ShopifyApp.configuration.use_new_embedded_auth_strategy?
         include ShopifyApp::TokenExchange
-        include ShopifyApp::EmbeddedApp
         around_action :activate_shopify_session
       else
         before_action :check_shop_known

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -5,6 +5,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
 
     include ShopifyApp::FrameAncestors
+    include ShopifyApp::SanitizedParams
 
     included do
       layout :embedded_app_layout
@@ -12,6 +13,20 @@ module ShopifyApp
     end
 
     protected
+
+    def redirect_to_embed_app_in_admin
+      ShopifyApp::Logger.debug("Redirecting to embed app in admin")
+
+      host = if params[:host]
+        params[:host]
+      elsif params[:shop]
+        Base64.encode64("#{sanitized_shop_name}/admin")
+      else
+        raise ShopifyApp::ShopifyDomainNotFound, "Host or shop param is missing"
+      end
+
+      redirect_to(ShopifyAPI::Auth.embedded_app_url(host), allow_other_host: true)
+    end
 
     def use_embedded_app_layout?
       ShopifyApp.configuration.embedded_app?

--- a/lib/shopify_app/controller_concerns/ensure_billing.rb
+++ b/lib/shopify_app/controller_concerns/ensure_billing.rb
@@ -27,11 +27,15 @@ module ShopifyApp
 
       unless has_payment
         if request.xhr?
-          add_top_level_redirection_headers(url: confirmation_url, ignore_response_code: true)
           ShopifyApp::Logger.debug("Responding with 401 unauthorized")
+          RedirectForEmbedded.add_app_bridge_redirect_url_header(confirmation_url, response)
           head(:unauthorized)
         elsif ShopifyApp.configuration.embedded_app?
-          fullpage_redirect_to(confirmation_url)
+          render(
+            "shopify_app/shared/redirect",
+            layout: false,
+            locals: { url: confirmation_url, current_shopify_domain: session&.shop },
+          )
         else
           redirect_to(confirmation_url, allow_other_host: true)
         end

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -79,7 +79,7 @@ module ShopifyApp
       response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, "true")
     end
 
-    def add_top_level_redirection_headers(ignore_response_code: false)
+    def add_top_level_redirection_headers(url: nil, ignore_response_code: false)
       if request.xhr? && (ignore_response_code || response.code.to_i == 401)
         ShopifyApp::Logger.debug("Adding top level redirection headers")
         # Make sure the shop is set in the redirection URL
@@ -94,7 +94,7 @@ module ShopifyApp
           end
         end
 
-        url = login_url_with_optional_shop
+        url ||= login_url_with_optional_shop
 
         ShopifyApp::Logger.debug("Setting Reauthorize-Url to #{url}")
         RedirectForEmbedded.add_app_bridge_redirect_url_header(url, response)

--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -79,14 +79,7 @@ module ShopifyApp
       response.set_header(ACCESS_TOKEN_REQUIRED_HEADER, "true")
     end
 
-    def jwt_expire_at
-      expire_at = request.env["jwt.expire_at"]
-      return unless expire_at
-
-      expire_at - 5.seconds # 5s gap to start fetching new token in advance
-    end
-
-    def add_top_level_redirection_headers(url: nil, ignore_response_code: false)
+    def add_top_level_redirection_headers(ignore_response_code: false)
       if request.xhr? && (ignore_response_code || response.code.to_i == 401)
         ShopifyApp::Logger.debug("Adding top level redirection headers")
         # Make sure the shop is set in the redirection URL
@@ -101,23 +94,14 @@ module ShopifyApp
           end
         end
 
-        url ||= login_url_with_optional_shop
+        url = login_url_with_optional_shop
 
         ShopifyApp::Logger.debug("Setting Reauthorize-Url to #{url}")
-        response.set_header("X-Shopify-API-Request-Failure-Reauthorize", "1")
-        response.set_header("X-Shopify-API-Request-Failure-Reauthorize-Url", url)
+        RedirectForEmbedded.add_app_bridge_redirect_url_header(url, response)
       end
     end
 
     protected
-
-    def jwt_shopify_domain
-      request.env["jwt.shopify_domain"]
-    end
-
-    def jwt_shopify_user_id
-      request.env["jwt.shopify_user_id"]
-    end
 
     def host
       params[:host]

--- a/lib/shopify_app/controller_concerns/redirect_for_embedded.rb
+++ b/lib/shopify_app/controller_concerns/redirect_for_embedded.rb
@@ -4,6 +4,11 @@ module ShopifyApp
   module RedirectForEmbedded
     include ShopifyApp::SanitizedParams
 
+    def self.add_app_bridge_redirect_url_header(url, response)
+      response.set_header("X-Shopify-API-Request-Failure-Reauthorize", "1")
+      response.set_header("X-Shopify-API-Request-Failure-Reauthorize-Url", url)
+    end
+
     private
 
     def embedded_redirect_url?

--- a/lib/shopify_app/controller_concerns/token_exchange.rb
+++ b/lib/shopify_app/controller_concerns/token_exchange.rb
@@ -60,7 +60,7 @@ module ShopifyApp
     def respond_to_invalid_shopify_id_token
       if request.headers["HTTP_AUTHORIZATION"].blank?
         if missing_embedded_param?
-          redirect_to_embed_app
+          redirect_to_embed_app_in_admin
         else
           redirect_to_bounce_page
         end
@@ -91,20 +91,6 @@ module ShopifyApp
 
     def missing_embedded_param?
       !params[:embedded].present? || params[:embedded] != "1"
-    end
-
-    def redirect_to_embed_app
-      ShopifyApp::Logger.debug("Redirecting to embed app")
-
-      host = if params[:host]
-        params[:host]
-      elsif params[:shop]
-        Base64.encode64("#{sanitized_shop_name}/admin")
-      else
-        raise ShopifyApp::ShopifyDomainNotFound, "Host or shop param is missing"
-      end
-
-      redirect_to(ShopifyAPI::Auth.embedded_app_url(host), allow_other_host: true)
     end
 
     def online_token_configured?

--- a/lib/shopify_app/controller_concerns/token_exchange.rb
+++ b/lib/shopify_app/controller_concerns/token_exchange.rb
@@ -5,6 +5,7 @@ module ShopifyApp
     extend ActiveSupport::Concern
     include ShopifyApp::AdminAPI::WithTokenRefetch
     include ShopifyApp::SanitizedParams
+    include ShopifyApp::EmbeddedApp
 
     included do
       include ShopifyApp::WithShopifyIdToken

--- a/lib/shopify_app/controller_concerns/with_shopify_id_token.rb
+++ b/lib/shopify_app/controller_concerns/with_shopify_id_token.rb
@@ -8,6 +8,21 @@ module ShopifyApp
       @shopify_id_token ||= id_token_from_request_env || id_token_from_authorization_header || id_token_from_url_param
     end
 
+    def jwt_shopify_domain
+      request.env["jwt.shopify_domain"]
+    end
+
+    def jwt_shopify_user_id
+      request.env["jwt.shopify_user_id"]
+    end
+
+    def jwt_expire_at
+      expire_at = request.env["jwt.expire_at"]
+      return unless expire_at
+
+      expire_at - 5.seconds # 5s gap to start fetching new token in advance
+    end
+
     private
 
     def id_token_from_request_env

--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -24,6 +24,10 @@ class EmbeddedAppTest < ActionController::TestCase
     include ShopifyApp::EmbeddedApp
 
     def index; end
+
+    def redirect_to_embed
+      redirect_to_embed_app_in_admin
+    end
   end
 
   tests EmbeddedAppTestController
@@ -31,6 +35,7 @@ class EmbeddedAppTest < ActionController::TestCase
   setup do
     Rails.application.routes.draw do
       get "/embedded_app", to: "embedded_app_test/embedded_app_test#index"
+      get "/redirect_to_embed", to: "embedded_app_test/embedded_app_test#redirect_to_embed"
     end
   end
 
@@ -62,5 +67,30 @@ class EmbeddedAppTest < ActionController::TestCase
     get :index
     assert_not_includes @controller.response.headers, "P3P"
     assert_includes @controller.response.headers, "X-Frame-Options"
+  end
+
+  test "#redirect_to_embed_app_in_admin redirects to the embed app in the admin when the host param is present" do
+    ShopifyApp.configuration.embedded_app = true
+
+    shop = "my-shop.myshopify.com"
+    host = Base64.encode64("#{shop}/admin")
+    get :redirect_to_embed, params: { host: host }
+    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}"
+  end
+
+  test "#redirect_to_embed_app_in_admin redirects to the embed app in the admin when the shop param is present" do
+    ShopifyApp.configuration.embedded_app = true
+
+    shop = "my-shop.myshopify.com"
+    get :redirect_to_embed, params: { shop: shop }
+    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}"
+  end
+
+  test "raises an exception when neither the host nor shop param is present" do
+    ShopifyApp.configuration.embedded_app = true
+
+    assert_raises ShopifyApp::ShopifyDomainNotFound do
+      get :redirect_to_embed
+    end
   end
 end

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -350,7 +350,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
       request.headers["HTTP_AUTHORIZATION"] = nil
 
       @controller.expects(:with_token_refetch).raises(invalid_shopify_id_token_error)
-      @controller.stubs(:performed?).returns(true)
+      @controller.stubs(:performed?).returns(false, true)
 
       with_application_test_routes do
         get :ensure_render, params: { shop: @shop }
@@ -363,7 +363,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
       ShopifyApp::Auth::TokenExchange.stubs(:perform)
 
       @controller.expects(:with_token_refetch).raises(invalid_shopify_id_token_error)
-      @controller.stubs(:performed?).returns(true)
+      @controller.stubs(:performed?).returns(false, true)
 
       with_application_test_routes do
         get :ensure_render, params: { shop: @shop }

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -210,7 +210,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
 
       params = { shop: @shop, my_param: "for-keeps", id_token: "dont-include-this-id-token" }
       reload_url = CGI.escape("/reloaded_path?my_param=for-keeps&shop=#{@shop}")
-      expected_redirect_url = "/my-root/patch_shopify_id_token"\
+      expected_redirect_url = "https://test.host/my-root/patch_shopify_id_token"\
         "?my_param=for-keeps&shop=#{@shop}"\
         "&shopify-reload=#{reload_url}"
 
@@ -242,7 +242,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
 
       params = { shop: @shop, my_param: "for-keeps", id_token: "dont-include-this-id-token" }
       reload_url = CGI.escape("/reloaded_path?my_param=for-keeps&shop=#{@shop}")
-      expected_redirect_url = "/my-root/patch_shopify_id_token"\
+      expected_redirect_url = "https://test.host/my-root/patch_shopify_id_token"\
         "?my_param=for-keeps&shop=#{@shop}"\
         "&shopify-reload=#{reload_url}"
 
@@ -277,7 +277,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
 
       params = { shop: @shop, my_param: "for-keeps", id_token: "dont-include-this-id-token" }
       reload_url = CGI.escape("/reloaded_path?my_param=for-keeps&shop=#{@shop}")
-      expected_redirect_url = "/my-root/patch_shopify_id_token"\
+      expected_redirect_url = "https://test.host/my-root/patch_shopify_id_token"\
         "?my_param=for-keeps&shop=#{@shop}"\
         "&shopify-reload=#{reload_url}"
 

--- a/test/shopify_app/controller_concerns/with_shopify_id_token_test.rb
+++ b/test/shopify_app/controller_concerns/with_shopify_id_token_test.rb
@@ -120,6 +120,36 @@ class WithShopifyIdTokenTest < ActionController::TestCase
     end
   end
 
+  test "#jwt_shopify_domain returns jwt.shopify_domain from request env" do
+    expected_domain = "hello-world.myshopify.com"
+    with_application_test_routes do
+      request.env["jwt.shopify_domain"] = expected_domain
+      get :index
+
+      assert_equal expected_domain, @controller.jwt_shopify_domain
+    end
+  end
+
+  test "#jwt_shopify_user_id returns jwt.shopify_user_id from request env" do
+    expected_user_id = 123
+    with_application_test_routes do
+      request.env["jwt.shopify_user_id"] = expected_user_id
+      get :index
+
+      assert_equal expected_user_id, @controller.jwt_shopify_user_id
+    end
+  end
+
+  test "#jwt_expire_at returns jwt.expire_at - 5 seconds from request env" do
+    expected_expire_at = Time.now.to_i
+    with_application_test_routes do
+      request.env["jwt.expire_at"] = expected_expire_at
+      get :index
+
+      assert_equal expected_expire_at - 5.seconds, @controller.jwt_expire_at
+    end
+  end
+
   def with_application_test_routes
     with_routing do |set|
       set.draw do

--- a/test/shopify_app/controller_concerns/with_shopify_id_token_test.rb
+++ b/test/shopify_app/controller_concerns/with_shopify_id_token_test.rb
@@ -141,12 +141,14 @@ class WithShopifyIdTokenTest < ActionController::TestCase
   end
 
   test "#jwt_expire_at returns jwt.expire_at - 5 seconds from request env" do
-    expected_expire_at = Time.now.to_i
-    with_application_test_routes do
-      request.env["jwt.expire_at"] = expected_expire_at
-      get :index
+    freeze_time do
+      expected_expire_at = Time.now.to_i
+      with_application_test_routes do
+        request.env["jwt.expire_at"] = expected_expire_at
+        get :index
 
-      assert_equal expected_expire_at - 5.seconds, @controller.jwt_expire_at
+        assert_equal expected_expire_at - 5.seconds, @controller.jwt_expire_at
+      end
     end
   end
 


### PR DESCRIPTION
- Fixes: https://github.com/Shopify/develop-app-access/issues/295

### What this PR does
* Making sure EnsureBilling and EnsureAuthenticatedLinks can call methods defined in token exchange, by extracting some common helper methods for re-use
* Fixed an infinite redirect loop caused by handling billing API error -
  * Steps to reprduce:
    1. Open app
    2. EnsureHasSession checks if billing is valid
    3. Billing API responds with billing error 
    4. EnsureBilling handles billing error by redirecting to shop /login with shop and host params
    5. /login starts auth again
    6. Auth CallbackController handles the callback, but it also checks billing, which could still return error - thus redirecting back to /login again.  ↺
   * Fix was to only redirect to shop /login withOUT shop and host params so that /login does not re-start auth.
* TokenExchangeConcern -
  *  If id_session is invalid, redirect to embed the app first before redirecting to bounce page.


### Before - Billing API error sent app into infinite redirect loop
https://github.com/Shopify/shopify_app/assets/102243935/24cb3077-3bb2-4c34-a620-2b69d67c003f

### After - Billing API error does not send app into infinite redirect loop
https://github.com/Shopify/shopify_app/assets/102243935/527b509e-f844-41c9-94a8-5b5379a94a57

### Token exchange works with EnsureBIlling and can load app after confirming charge
https://github.com/Shopify/shopify_app/assets/102243935/e71b810d-653a-40f3-9f49-2dc34860618d


### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
