### PR TITLE
Redirect to root if attempted phishing attack when trying to embed app in Admin

### DIFF
--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -86,11 +86,25 @@ class EmbeddedAppTest < ActionController::TestCase
     assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}"
   end
 
-  test "raises an exception when neither the host nor shop param is present" do
+  test "Redirect to login URL when host nor shop param is present" do
     ShopifyApp.configuration.embedded_app = true
 
-    assert_raises ShopifyApp::ShopifyDomainNotFound do
-      get :redirect_to_embed
-    end
+    get :redirect_to_embed
+    assert_redirected_to ShopifyApp.configuration.login_url
+  end
+
+  test "Redirect to root URL when decoded host is not a shopify domain" do
+    shop = "my-shop.fakeshopify.com"
+    host = Base64.encode64("#{shop}/admin")
+
+    get :redirect_to_embed, params: { host: host }
+    assert_redirected_to ShopifyApp.configuration.root_url
+  end
+
+  test "Redirect to root URL when shop is not a shopify domain" do
+    shop = "my-shop.fakeshopify.com"
+
+    get :redirect_to_embed, params: { shop: shop }
+    assert_redirected_to ShopifyApp.configuration.root_url
   end
 end

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -249,15 +249,13 @@ class TokenExchangeControllerTest < ActionController::TestCase
       end
     end
 
-    test "Raise domain not found error when trying to embed app with missing shop and host params - #{invalid_shopify_id_token_error}" do
+    test "Redirects to login when trying to embed app with missing shop and host params - #{invalid_shopify_id_token_error}" do
       ShopifyAPI::Utils::SessionUtils.stubs(:session_id_from_shopify_id_token).raises(invalid_shopify_id_token_error)
       request.headers["HTTP_AUTHORIZATION"] = nil
 
       with_application_test_routes do
-        error = assert_raises(ShopifyApp::ShopifyDomainNotFound) do
-          get :index
-        end
-        assert_equal "Host or shop param is missing", error.message
+        get :index
+        assert_redirected_to ShopifyApp.configuration.login_url
       end
     end
 


### PR DESCRIPTION
### What this PR does
Followed similar approach to this issue:
- https://github.com/Shopify/shopify_app/pull/1605

Redirect to app's login route unless host has been verified

📹 [Redirecting to login with invalid host](https://videobin.shopify.io/v/bjM1Ne)

