### PR TITLE
Fixing SHOPIFY_TEST_CHARGES env var check in template

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -32,8 +32,8 @@ ShopifyApp.configure do |config|
   #   amount: 5,
   #   interval: ShopifyApp::BillingConfiguration::INTERVAL_EVERY_30_DAYS,
   #   currency_code: "USD", # Only supports USD for now
-  #   test: !ENV['SHOPIFY_TEST_CHARGES'].nil? ? ENV['SHOPIFY_TEST_CHARGES'] == 'true' : !Rails.env.production?,
-  #   trial_days: 0
+  #   trial_days: 0,
+  #   test: !ENV['SHOPIFY_TEST_CHARGES'].nil? ? ENV['SHOPIFY_TEST_CHARGES'] == 'true' : !Rails.env.production?
   # )
 
   if defined? Rails::Server

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -33,7 +33,7 @@ ShopifyApp.configure do |config|
   #   interval: ShopifyApp::BillingConfiguration::INTERVAL_EVERY_30_DAYS,
   #   currency_code: "USD", # Only supports USD for now
   #   trial_days: 0,
-  #   test: !ENV['SHOPIFY_TEST_CHARGES'].nil? ? ENV['SHOPIFY_TEST_CHARGES'] == 'true' : !Rails.env.production?
+  #   test: !ENV['SHOPIFY_TEST_CHARGES'].nil? ? ["true", "1"].include?(ENV['SHOPIFY_TEST_CHARGES']) : !Rails.env.production?
   # )
 
   if defined? Rails::Server

--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -32,8 +32,8 @@ ShopifyApp.configure do |config|
   #   amount: 5,
   #   interval: ShopifyApp::BillingConfiguration::INTERVAL_EVERY_30_DAYS,
   #   currency_code: "USD", # Only supports USD for now
+  #   test: !ENV['SHOPIFY_TEST_CHARGES'].nil? ? ENV['SHOPIFY_TEST_CHARGES'] == 'true' : !Rails.env.production?,
   #   trial_days: 0
-  #   test: ENV.fetch('SHOPIFY_TEST_CHARGES', !Rails.env.production?)
   # )
 
   if defined? Rails::Server


### PR DESCRIPTION
What this PR does
This PR fixes the ENV check to correctly pass in a boolean for the `test:` value on `BillingConfiguration` rather than a string. **Note**: This only changes the template generated, not the underlying BillingConfiguration code itself.

Reviewer's guide to testing
Currently, if present, the environment variable will be pulled in as a string i.e. "true" / "false". That will fail when creating the recurring charge with the following error:

```[{"message"=>"Variable $test of type Boolean was provided invalid value",
"locations"=>[{"line"=>6, "column"=>3}], "extensions"=>{"value"=>"true", "problems"=>[{"path"=>[], "explanation"=>"Could not coerce value
\"true\" to Boolean"}]}}]
```

This fixes a bug introduced in my original pr here: #1688 

Things to focus on
N/A

Checklist

Before submitting the PR, please consider if any of the following are needed:

[-] Update CHANGELOG.md if the changes would impact users
[-] Update README.md, if appropriate.
[-] Update any relevant pages in /docs, if necessary
[-] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.