### PR TITLE
Don't delete shop session on 401 error

### DIFF
--- a/lib/shopify_app/admin_api/with_token_refetch.rb
+++ b/lib/shopify_app/admin_api/with_token_refetch.rb
@@ -11,8 +11,7 @@ module ShopifyApp
           ShopifyApp::Logger.debug("Encountered error: #{error.code} - #{error.response.inspect}, re-raising")
         elsif retrying
           ShopifyApp::Logger.debug("Shopify API returned a 401 Unauthorized error that was not corrected " \
-            "with token exchange, deleting current session and re-raising")
-          ShopifyApp::SessionRepository.delete_session(session.id)
+            "with token exchange, re-raising error")
         else
           retrying = true
           ShopifyApp::Logger.debug("Shopify API returned a 401 Unauthorized error, exchanging token and " \

--- a/test/shopify_app/admin_api/with_token_refetch_test.rb
+++ b/test/shopify_app/admin_api/with_token_refetch_test.rb
@@ -55,7 +55,7 @@ class ShopifyApp::AdminAPI::WithTokenRefetchTest < ActiveSupport::TestCase
     assert_equal @new_session.expires, @session.expires
   end
 
-  test "#with_token_refetch deletes existing token and re-raises when 401 persists" do
+  test "#with_token_refetch re-raises when 401 persists" do
     response = ShopifyAPI::Clients::HttpResponse.new(code: 401, body: "401 message", headers: {})
     api_error = ShopifyAPI::Errors::HttpResponseError.new(response: response)
 
@@ -67,8 +67,7 @@ class ShopifyApp::AdminAPI::WithTokenRefetchTest < ActiveSupport::TestCase
       "and retrying with new session")
 
     ShopifyApp::Logger.expects(:debug).with("Shopify API returned a 401 Unauthorized error that was not corrected " \
-      "with token exchange, deleting current session and re-raising")
-    ShopifyApp::SessionRepository.expects(:delete_session).with("session-id")
+      "with token exchange, re-raising error")
 
     reraised_error = assert_raises ShopifyAPI::Errors::HttpResponseError do
       with_token_refetch(@session, @id_token) do


### PR DESCRIPTION
### What this PR does
Not deleting the shop session when 401 error has occurred in token exchange retry.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
