### PR TITLE
Packaging for release 22.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+
+22.2.1 (May 6,2024)
 * Patch - Don't delete session on 401 errors during retry in `with_token_refetch` [#1844](https://github.com/Shopify/shopify_app/pull/1844)
 
 22.2.0 (May 2,2024)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (22.2.0)
+    shopify_app (22.2.1)
       activeresource
       addressable (~> 2.7)
       jwt (>= 2.2.3)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "22.2.0"
+  VERSION = "22.2.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "22.2.0",
+  "version": "22.2.1",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
### What this PR does

Package v22.2.1

* Patch - Don't delete session on 401 errors during retry in `with_token_refetch` [#1844](https://github.com/Shopify/shopify_app/pull/1844)

