### PR TITLE
[Fix] Update sanitize_shop_domain to handle nil host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+[1852](https://github.com/Shopify/shopify_app/pull/1852) - Handle scenario when invalid URI is passed to `sanitize_shop_domain `
 
 22.1.0 (April 9,2024)
 ----------

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -12,7 +12,7 @@ module ShopifyApp
 
       def sanitize_shop_domain(shop_domain)
         uri = uri_from_shop_domain(shop_domain)
-        return nil if uri.nil?
+        return nil if uri.nil? || uri.host.nil?
 
         trusted_domains.each do |trusted_domain|
           no_shop_name_in_subdomain = uri.host == trusted_domain

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -68,6 +68,7 @@ class UtilsTest < ActiveSupport::TestCase
     "store.myshopify.com.evil.com",
     "/foo/bar",
     "foo.myshopify.io.evil.ru",
+    "javascript:alert(1)",
   ].each do |bad_url|
     test "sanitize_shop_domain for a non-myshopify URL (#{bad_url})" do
       assert_nil ShopifyApp::Utils.sanitize_shop_domain(bad_url)


### PR DESCRIPTION
### What this PR does

* When `javascript:alert(1)` is used the `host` is `nil` not empty
* This was causing the code to crash in `unified_admin` where we would attempt to split `uri.host`

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
