### PR TITLE
Fix changelog style for 22.2.1 and unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Unreleased
 ----------
-[1852](https://github.com/Shopify/shopify_app/pull/1852) - Handle scenario when invalid URI is passed to `sanitize_shop_domain `
+- Handle scenario when invalid URI is passed to `sanitize_shop_domain` [#1852](https://github.com/Shopify/shopify_app/pull/1852)
 
 22.2.1 (May 6,2024)
+----------
 * Patch - Don't delete session on 401 errors during retry in `with_token_refetch` [#1844](https://github.com/Shopify/shopify_app/pull/1844)
 
 22.2.0 (May 2,2024)


### PR DESCRIPTION
### What this PR does

Fixes up the changelog. Noticed it looking a bit off.

**Before**
<img width="1034" alt="Screenshot 2024-05-29 at 10 08 36" src="https://github.com/Shopify/shopify_app/assets/1557529/aad04e68-0e08-4e32-8c92-7816878187bb">

**After**
<img width="898" alt="Screenshot 2024-05-29 at 10 11 07" src="https://github.com/Shopify/shopify_app/assets/1557529/f1045c3e-133e-4e70-811d-5c91aa98635b">

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
