### PR TITLE
LoginProtection: Extract private method set_session_return_to

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -122,10 +122,17 @@ module ShopifyApp
           query = Rack::Utils.parse_nested_query(referer.query)
           query = query.merge(sanitized_params).to_query
         end
-        session[:return_to] = query.blank? ? path.to_s : "#{path}?#{query}"
+        session[:return_to] = return_to_url(path, query)
         ShopifyApp::Logger.debug("Redirecting to #{login_url_with_optional_shop}")
         redirect_to(login_url_with_optional_shop)
       end
+    end
+
+    # Apps which use cookies for session storage, and thus have a 4kB session data
+    # limit, may choose to override this method to prevent excessively-long `query`
+    # strings from causing a CookieOverflow error.
+    def return_to_url(path, query)
+      query.blank? ? path.to_s : "#{path}?#{query}"
     end
 
     def close_session


### PR DESCRIPTION
### What this PR does

Apps which use cookies for session storage, and thus have a 4kB session data limit, may choose to override this method to prevent excessively-long `query` strings from causing a CookieOverflow error.

Currently, apps must override the entire `redirect_to_login` method. To make gem updates easier, we want to override a smaller area.

### Reviewer's guide to testing

This PR does not change functionality.

### Things to focus on

Confirm that the method extraction was performed correctly, ie. without changing functionality.

### Checklist

Please let me know if any of the following are necessary in this case. It's not immediately clear to me if they are necessary.

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
