### PR TITLE
Remove references to unused assets and features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - ⚠️ [Breaking] Removes `ShopifyApp::JWTMiddleware`. Any existing app code relying on decoded JWT contents set from `request.env` should instead include the `WithShopifyIdToken` concern and call its respective methods. [#1861](https://github.com/Shopify/shopify_app/pull/1861)
 - Handle scenario when invalid URI is passed to `sanitize_shop_domain` [#1852](https://github.com/Shopify/shopify_app/pull/1852)
+- Remove references to old JS files during asset precompile [#1865](https://github.com/Shopify/shopify_app/pull/1865)
+- Remove old translation keys for `enable_cookies_*`, `top_level_interaction_*` and `request_storage_access_*` [#1865](https://github.com/Shopify/shopify_app/pull/1865)
 
 22.2.1 (May 6,2024)
 ----------

--- a/app/assets/images/storage_access.svg
+++ b/app/assets/images/storage_access.svg
@@ -1,1 +1,0 @@
-<svg width="140" height="140" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M79 55a9 9 0 00-18 0v8h18v-8zm6 8v-8a15 15 0 00-30 0v8h-5a2 2 0 00-2 2v20a15 15 0 0015 15h14a15 15 0 0015-15V65a2 2 0 00-2-2h-5zM70 90a3 3 0 01-3-3V75a3 3 0 116 0v12a3 3 0 01-3 3z" fill="#8C9196"/></svg>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -3,21 +3,3 @@ cs:
   logged_out: Odhlášení proběhlo úspěšně
   could_not_log_in: Nelze se přihlásit do obchodu Shopify
   invalid_shop_url: Neplatná doména obchodu
-  enable_cookies_heading: Zapnout soubory cookie z aplikace %{app}
-  enable_cookies_body: Pokud chcete v Shopify používat aplikaci %{app}, musíte soubory
-    cookie v tomto prohlížeči povolit ručně.
-  enable_cookies_footer: Soubory cookie umožňují, aby vás aplikace ověřila pomocí
-    dočasného uchování preferencí a osobních údajů. Jejich platnost vyprší po 30 dnech.
-  enable_cookies_action: Povolit soubory cookie
-  top_level_interaction_heading: Váš prohlížeč potřebuje ověřit aplikaci %{app}
-  top_level_interaction_body: Váš prohlížeč vyžaduje, aby si od vás aplikace, jako
-    je %{app}, nejdřív vyžádaly přístup k souborům cookie, než je pro vás Shopify
-    otevře.
-  top_level_interaction_action: Pokračovat
-  request_storage_access_heading: Aplikace %{app} potřebuje získat přístup k souborům
-    cookie
-  request_storage_access_body: Tato aplikace vám umožní ověření prostřednictvím dočasného
-    uchování vašich osobních údajů. Pokud chcete používat tuto aplikaci, klikněte
-    na tlačítko Pokračovat a povolte soubory cookie.
-  request_storage_access_footer: Platnost souborů cookie vyprší po 30 dnech.
-  request_storage_access_action: Pokračovat

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -3,18 +3,3 @@ da:
   logged_out: Logget ud
   could_not_log_in: Kunne ikke logge ind på Shopify-butik
   invalid_shop_url: Ugyldig butiksdomæne
-  enable_cookies_heading: Aktivér cookies fra %{app}
-  enable_cookies_body: Du skal manuelt aktivere cookies i denne browser for at kunne
-    bruge %{app} i Shopify.
-  enable_cookies_footer: Cookies lader appen godkende dig ved at gemme dine præferencer
-    og personlige oplysninger midlertidigt. De udløber efter 30 dage.
-  enable_cookies_action: Aktivér cookies
-  top_level_interaction_heading: Din browser skal godkende %{app}
-  top_level_interaction_body: Din browser kræver, at apps som f.eks. %{app} spørger
-    dig om adgang til cookies, inden Shopify kan åbne den for dig.
-  top_level_interaction_action: Fortsæt
-  request_storage_access_heading: "%{app} skal have adgang til cookies"
-  request_storage_access_body: Det lader appen godkende dig ved at gemme dine personlige
-    oplysninger midlertidigt. Klik på forsæt, og tillad cookies for at bruge appen.
-  request_storage_access_footer: Cookies udløber efter 30 dage.
-  request_storage_access_action: Fortsæt

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3,20 +3,3 @@ de:
   logged_out: Erfolgreich ausgelogt
   could_not_log_in: Shopify Store Login fehlgeschlagen
   invalid_shop_url: Ungültige Shop-Domain
-  enable_cookies_heading: Cookies von %{app} aktivieren
-  enable_cookies_body: Du musst Cookies in diesem Browser manuell aktivieren, um %{app}
-    in Shopify verwenden zu können.
-  enable_cookies_footer: Mithilfe von Cookies kann die App dich authentifizieren,
-    indem deine Einstellungen und personenbezogenen Daten vorübergehend gespeichert
-    werden. Sie laufen nach 30 Tagen ab.
-  enable_cookies_action: Cookies aktivieren
-  top_level_interaction_heading: Dein Browser muss %{app} authentifizieren
-  top_level_interaction_body: Dein Browser verlangt, dass Apps wie %{app} dich um
-    Zugriff auf Cookies bitten, bevor Shopify sie für dich öffnen kann.
-  top_level_interaction_action: Weiter
-  request_storage_access_heading: "%{app} braucht Zugriff auf Cookies"
-  request_storage_access_body: Damit kann die App dich authentifizieren, indem deine
-    Einstellungen und personenbezogenen Daten vorübergehend gespeichert werden. Klicke
-    auf "Weiter" und erlaube Cookies, um die App zu verwenden.
-  request_storage_access_footer: Cookies laufen nach 30 Tagen ab.
-  request_storage_access_action: Weiter

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,14 +2,3 @@ en:
   logged_out: 'Successfully logged out'
   could_not_log_in: 'Could not log in to Shopify store'
   invalid_shop_url: 'Invalid shop domain'
-  enable_cookies_heading: "Enable cookies from %{app}"
-  enable_cookies_body: "You must manually enable cookies in this browser in order to use %{app} within Shopify."
-  enable_cookies_footer: 'Cookies let the app authenticate you by temporarily storing your preferences and personal information. They expire after 30 days.'
-  enable_cookies_action: 'Enable cookies'
-  top_level_interaction_heading: "Your browser needs to authenticate %{app}"
-  top_level_interaction_body: "Your browser requires apps like %{app} to ask you for access to cookies before Shopify can open it for you."
-  top_level_interaction_action: 'Continue'
-  request_storage_access_heading: "%{app} needs access to cookies"
-  request_storage_access_body: "This lets the app authenticate you by temporarily storing your personal information. Click continue and allow cookies to use the app."
-  request_storage_access_footer: 'Cookies expire after 30 days.'
-  request_storage_access_action: 'Continue'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,20 +3,3 @@ es:
   logged_out: Cerrar sesión
   could_not_log_in: No se pudo iniciar sesión en tu tienda Shopify
   invalid_shop_url: Dominio de tienda inválido
-  enable_cookies_heading: Habilitar cookies de %{app}
-  enable_cookies_body: Debes habilitar manualmente las cookies en este navegador para
-    usar %{app} en Shopify.
-  enable_cookies_footer: Las cookies permiten que la aplicación te autentique almacenando
-    temporalmente tus preferencias y datos personales. Las cookies expiran al cabo
-    de 30 días.
-  enable_cookies_action: Habilitar cookies
-  top_level_interaction_heading: Tu navegador necesita autenticar %{app}
-  top_level_interaction_body: Tu navegador requiere aplicaciones como %{app} para
-    solicitarte acceso a cookies antes de que Shopify pueda abrirlo por ti.
-  top_level_interaction_action: Continuar
-  request_storage_access_heading: "%{app} necesita acceso a las cookies"
-  request_storage_access_body: Esto permite que la aplicación te autentique almacenando
-    temporalmente tus datos personales. Haz clic en continuar y permite que las cookies
-    utilicen la aplicación.
-  request_storage_access_footer: Las cookies expiran a los 30 días.
-  request_storage_access_action: Continuar

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -3,18 +3,3 @@ fi:
   logged_out: Olet kirjautunut ulos
   could_not_log_in: Kirjautuminen Shopify-kauppaan ei onnistunut
   invalid_shop_url: Virheellinen kaupan verkkotunnus
-  enable_cookies_heading: Ota käyttöön sovelluksen %{app} evästeet
-  enable_cookies_body: Sinun on otettava evästeet käyttöön manuaalisesti tässä selaimessa,
-    jotta voit käyttää sovellusta %{app} Shopifyssa.
-  enable_cookies_footer: Evästeiden avulla sovellus voi todentaa sinut tallentamalla
-    asetuksesi ja henkilötietosi tilapäisesti. Ne vanhenevat 30 päivän kuluttua.
-  enable_cookies_action: Ota evästeet käyttöön
-  top_level_interaction_heading: Selaimesi täytyy todentaa %{app}
-  top_level_interaction_body: Selaimesi vaatii sovelluksia, kuten %{app}, pyytämään
-    sinulta luvan evästeiden käyttöön, ennen kuin Shopify voi avata sovelluksen.
-  top_level_interaction_action: Jatka
-  request_storage_access_heading: "%{app} edellyttää evästeiden käyttöä"
-  request_storage_access_body: Näin sovellus voi todentaa sinut tallentamalla henkilötietosi
-    tilapäisesti. Klikkaa Jatka ja salli evästeet sovelluksen käyttämiseksi.
-  request_storage_access_footer: Evästeet vanhenevat 30 päivän kuluttua.
-  request_storage_access_action: Jatka

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,21 +3,3 @@ fr:
   logged_out: Vous êtes déconnecté(e)
   could_not_log_in: Impossible de se connecter à la boutique Shopify
   invalid_shop_url: Url invalide
-  enable_cookies_heading: Activer les cookies de %{app}
-  enable_cookies_body: Vous devez manuellement activer les cookies dans ce navigateur
-    pour utiliser %{app} dans Shopify.
-  enable_cookies_footer: Les cookies permettent à l'application de vous authentifier
-    en stockant temporairement vos préférences et informations personnelles. Celles-ci
-    expirent après 30 jours.
-  enable_cookies_action: Activer les cookies
-  top_level_interaction_heading: Votre navigateur doit s'authentifier %{app}
-  top_level_interaction_body: Votre navigateur nécessite des applications telles que
-    %{app} pour vous demander l'accès aux cookies avant que Shopify ne puisse l'ouvrir
-    pour vous.
-  top_level_interaction_action: Continuer
-  request_storage_access_heading: "%{app} a besoin d'accéder aux cookies"
-  request_storage_access_body: Cela permet à l'application de vous authentifier en
-    stockant temporairement vos informations personnelles. Cliquez pour continuer
-    et autorisez les cookies à utiliser l'application.
-  request_storage_access_footer: Les cookies expirent après 30 jours.
-  request_storage_access_action: Continuer

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -3,19 +3,3 @@ it:
   logged_out: Disconnessione effettuata correttamente
   could_not_log_in: Impossibile accedere al negozio Shopify
   invalid_shop_url: Dominio negozio non valido
-  enable_cookies_heading: Abilita i cookie di %{app}
-  enable_cookies_body: Devi abilitare manualmente i cookie in questo browser per poter
-    utilizzare %{app} da Shopify.
-  enable_cookies_footer: I cookie consentono all'app di autenticarti memorizzando
-    temporaneamente le tue preferenze e informazioni personali. Scadono dopo 30 giorni.
-  enable_cookies_action: Abilita i cookie
-  top_level_interaction_heading: Il tuo browser deve autenticare %{app}
-  top_level_interaction_body: Il tuo browser richiede che app come %{app} ti chiedano
-    l'accesso ai cookie prima dell'apertura automatica da parte di Shopify.
-  top_level_interaction_action: Continua
-  request_storage_access_heading: "%{app} deve accedere ai cookie"
-  request_storage_access_body: L'app potrà così autenticarti memorizzando temporaneamente
-    le tue informazioni personali. Clicca su Continua e consenti ai cookie di utilizzare
-    l'app.
-  request_storage_access_footer: I cookie scadono dopo 30 giorni.
-  request_storage_access_action: Continua

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,15 +3,3 @@ ja:
   logged_out: ログアウトに成功しました
   could_not_log_in: Shopifyストアにログインできませんでした
   invalid_shop_url: ショップのドメインが無効です
-  enable_cookies_heading: "%{app}からのCookieを有効にする"
-  enable_cookies_body: Shopifyで%{app}を使用できるようにするためには、このブラウザのCookieを手動で有効にする必要があります。
-  enable_cookies_footer: Cookieを使用すると、各種設定や個人情報を一時的に保存することで、アプリ認証を受けることができます。30日後に有効期限が切れます。
-  enable_cookies_action: Cookieを有効にする
-  top_level_interaction_heading: お使いのブラウザを更新する必要があります%{app}
-  top_level_interaction_body: Shopifyがアプリを開けるように、ブラウザはCookieにアクセスするための%{app}のようなアプリが必要です。
-  top_level_interaction_action: 続ける
-  request_storage_access_heading: "%{app}はCookieへのアクセス許可が必要です"
-  request_storage_access_body: Cookieを使用すると、個人情報を一時的に保存することで、アプリ認証を受けることができます。[続ける]
-    をクリックすると、アプリはCookieを利用します。
-  request_storage_access_footer: Cookieは30日後に有効期限が切れます。
-  request_storage_access_action: 続ける

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -3,17 +3,3 @@ ko:
   logged_out: 성공적으로 로그아웃 되었습니다.
   could_not_log_in: Shopify 스토어에 로그인할 수 없습니다.
   invalid_shop_url: 유효하지 않은 상점 도메인
-  enable_cookies_heading: "%{app}에서 쿠키를 사용 가능"
-  enable_cookies_body: Shopify 내에서 %{app} 을 사용하기 위해 이 브라우저에서 쿠키를 수동으로 사용할 수 있습니다.
-  enable_cookies_footer: 쿠키를 사용하면 개인의 선호나 정보를 임시로 저장하여 앱에서 사용자를 인증할 수 있습니다. 쿠키는 30일
-    후에 만료됩니다.
-  enable_cookies_action: 쿠리 사용 가능
-  top_level_interaction_heading: 브라우저에서 %{app} 을 인증해야 합니다.
-  top_level_interaction_body: Shopify를 열기 전 쿠키에 엑세스하려면 %{app} 과 같은 앱 들이 브라우저에 설치되어야
-    합니다.
-  top_level_interaction_action: 계속
-  request_storage_access_heading: "%{app}에서 쿠키에 접근해야 합니다."
-  request_storage_access_body: 이를 통해 개인 정보를 임시로 저장하여 앱에서 사용자를 인증할 수 있습니다. 계속 클릭하여
-    쿠키로 앱을 사용하세요.
-  request_storage_access_footer: 쿠키는 30일 후에 만료됩니다.
-  request_storage_access_action: 계속

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -3,19 +3,3 @@ nb:
   logged_out: Logget ut
   could_not_log_in: Kunne ikke logge på Shopify-butikken
   invalid_shop_url: Ugyldig butikkdomene
-  enable_cookies_heading: Aktiver informasjonskapsler fra %{app}
-  enable_cookies_body: Du kan manuelt aktivere informasjonskapsler i denne nettleseren
-    for å kunne bruke %{app} i Shopify.
-  enable_cookies_footer: Informasjonskapsler lar appen autentisere deg ved å midlertidig
-    lagre innstillingene og personopplysningene dine. De går ut etter 30 dager.
-  enable_cookies_action: Aktiver informasjonskapsler
-  top_level_interaction_heading: Nettleseren din må autentisere %{app}
-  top_level_interaction_body: Nettleseren din krever apper som %{app} for å spørre
-    deg om tilgang til informasjonskapsler før Shopify kan åpne den for deg.
-  top_level_interaction_action: Fortsett
-  request_storage_access_heading: "%{app} må ha tilgang til informasjonskapsler"
-  request_storage_access_body: Informasjonskapsler lar appen autentisere deg ved å
-    midlertidig lagre personopplysningene dine. Klikk på Fortsett og gi informasjonskapsler
-    tillatelse til å bruke appen.
-  request_storage_access_footer: Informasjonskapslene går ut etter 30 dager.
-  request_storage_access_action: Fortsett

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -3,19 +3,3 @@ nl:
   logged_out: Je bent afgemeld
   could_not_log_in: Kon niet inloggen bij Shopify-winkel
   invalid_shop_url: Ongeldig winkeldomein
-  enable_cookies_heading: Schakel cookies in van %{app}
-  enable_cookies_body: Je moet cookies in deze browser handmatig inschakelen om %{app}
-    binnen Shopify te gebruiken.
-  enable_cookies_footer: Met cookies kan de app je verifiëren door je voorkeuren en
-    persoonlijke informatie tijdelijk op te slaan. Ze vervallen na 30 dagen.
-  enable_cookies_action: Schakel cookies in
-  top_level_interaction_heading: Je browser moet %{app} verifiëren
-  top_level_interaction_body: Je browser heeft apps nodig zoals %{app} om je toegang
-    te vragen tot cookies voordat Shopify het voor je kan openen.
-  top_level_interaction_action: Doorgaan
-  request_storage_access_heading: "%{app} heeft toegang tot cookies nodig"
-  request_storage_access_body: Hiermee kan de app je verifiëren door je persoonlijke
-    gegevens tijdelijk op te slaan. Klik op Doorgaan en sta cookies toe om de app
-    te gebruiken.
-  request_storage_access_footer: Cookies verlopen na 30 dagen.
-  request_storage_access_action: Doorgaan

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3,19 +3,3 @@ pl:
   logged_out: Pomyślne wylogowanie
   could_not_log_in: Nie można zalogować się do sklepu Shopify
   invalid_shop_url: Nieprawidłowa domena sklepu
-  enable_cookies_heading: Włącz korzystanie z plików cookie z %{app}
-  enable_cookies_body: Aby móc korzystać z %{app} w Shopify, musisz ręcznie włączyć
-    korzystanie z plików cookie w tej przeglądarce.
-  enable_cookies_footer: Pliki cookie umożliwiają uwierzytelnianie aplikacji przez
-    tymczasowe przechowywanie preferencji i danych osobowych. Wygasają one po 30 dniach.
-  enable_cookies_action: Włącz korzystanie z plików cookie
-  top_level_interaction_heading: Twoja przeglądarka wymaga uwierzytelnienia %{app}
-  top_level_interaction_body: Twoja przeglądarka wymaga takich aplikacji jak %{app},
-    aby poprosić o dostęp do plików cookie, zanim Shopify będzie mógł ją otworzyć.
-  top_level_interaction_action: Kontynuuj
-  request_storage_access_heading: "%{app} potrzebuje dostępu do plików cookie"
-  request_storage_access_body: Dzięki temu aplikacja może Cię uwierzytelniać, tymczasowo,
-    przechowując Twoje dane osobowe. Kliknij przycisk Kontynuuj i zezwalaj na pliki
-    cookie, aby korzystać z aplikacji.
-  request_storage_access_footer: Pliki cookie wygasają po 30 dniach.
-  request_storage_access_action: Kontynuuj

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -3,19 +3,3 @@ pt-BR:
   logged_out: Você saiu.
   could_not_log_in: Não foi possível fazer login na Shopify store
   invalid_shop_url: Domínio de loja inválido
-  enable_cookies_heading: Habilitar cookies de %{app}
-  enable_cookies_body: Você precisa habilitar manualmente os cookies neste navegador
-    para usar %{app} dentro da Shopify.
-  enable_cookies_footer: Os cookies permitem que o app o autentique armazenando temporariamente
-    suas preferências e dados pessoais. Eles expiram depois de 30 dias.
-  enable_cookies_action: Habilitar cookies
-  top_level_interaction_heading: Seu navegador precisa autenticar %{app}
-  top_level_interaction_body: Seu navegador exige que apps como o %{app} consultem
-    você sobre o acesso a cookies antes que a Shopify os abra.
-  top_level_interaction_action: Continuar
-  request_storage_access_heading: "%{app} precisa acessar cookies"
-  request_storage_access_body: Isso permite que o app autentique você armazenando
-    temporariamente seus dados pessoais. Clique em continuar e permita os cookies
-    para usar o app.
-  request_storage_access_footer: Os cookies expiram depois de 30 dias.
-  request_storage_access_action: Continuar

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -3,20 +3,3 @@ pt-PT:
   logged_out: Terminou a sessão com sucesso
   could_not_log_in: Não foi possível iniciar sessão na loja da Shopify
   invalid_shop_url: Domínio de loja inválido
-  enable_cookies_heading: Ativar cookies de %{app}
-  enable_cookies_body: Tem de ativar manualmente os cookies neste navegador para utilizar
-    %{app} dentro da Shopify.
-  enable_cookies_footer: Os cookies permitem que a aplicação o autentique armazenando
-    temporariamente as suas preferências e informações pessoais. Expiram ao fim de
-    30 dias.
-  enable_cookies_action: Ativar cookies
-  top_level_interaction_heading: O seu navegador tem de autenticar %{app}
-  top_level_interaction_body: O seu navegador exige que aplicações como %{app} lhe
-    solicitem o acesso de cookies, antes que a Shopify as possa abrir.
-  top_level_interaction_action: Continuar
-  request_storage_access_heading: "%{app} tem de aceder a cookies"
-  request_storage_access_body: Isto permite que a aplicação o autentique armazenando
-    temporariamente as suas informações pessoais. Clique em continuar e permita os
-    cookies para utilizar a aplicação.
-  request_storage_access_footer: Os cookies expiram ao fim de 30 dias.
-  request_storage_access_action: Continuar

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -3,19 +3,3 @@ sv:
   logged_out: Har loggats ut
   could_not_log_in: Det gick inte att logga in i Shopify-butiken
   invalid_shop_url: Ogiltig butiksdomän
-  enable_cookies_heading: Aktivera cookies från %{app}
-  enable_cookies_body: Du måste aktivera cookies manuellt i den här webbläsaren för
-    att kunna använda %{app} inom Shopify.
-  enable_cookies_footer: Cookies låter appen autentisera dig genom att tillfälligt
-    lagra dina inställningar och personuppgifter. De upphör efter 30 dagar.
-  enable_cookies_action: Aktivera cookies
-  top_level_interaction_heading: Din webbläsare måste verifiera %{app}
-  top_level_interaction_body: Din webbläsare kräver att appar som %{app} frågar dig
-    om tillgång till cookies innan Shopify kan öppna den för dig.
-  top_level_interaction_action: Fortsätt
-  request_storage_access_heading: "%{app} behöver tillgång till cookies"
-  request_storage_access_body: Detta gör det möjligt för appen att autentisera dig
-    genom att tillfälligt lagra din personliga information. Klicka på fortsätt och
-    tillåta cookies att använda appen.
-  request_storage_access_footer: Cookies upphör efter 30 dagar.
-  request_storage_access_action: Fortsätt

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -3,18 +3,3 @@ th:
   logged_out: ออกจากระบบสำเร็จ
   could_not_log_in: ไม่สามารถเข้าสู่ระบบร้านค้า Shopify ได้
   invalid_shop_url: โดเมนร้านค้าไม่ถูกต้อง
-  enable_cookies_heading: เปิดใช้คุกกี้จาก %{app}
-  enable_cookies_body: คุณต้องเปิดใช้คุกกี้ด้วยตนเองในเบราว์เซอร์นี้เพื่อใช้งาน %{app}
-    ภายใน Shopify
-  enable_cookies_footer: คุกกี้ช่วยให้แอปตรวจสอบความถูกต้องของคุณด้วยการจัดเก็บความชื่นชอบและข้อมูลส่วนตัวของคุณชั่วคราว
-    คุกกี้จะหมดอายุหลังจาก 30 วัน
-  enable_cookies_action: เปิดใช้คุกกี้
-  top_level_interaction_heading: เบราว์เซอร์ของคุณต้องรับรองความถูกต้องของ %{app}
-  top_level_interaction_body: เบราว์เซอร์ของคุณต้องการแอปอย่าง %{app} เพื่อขอให้คุณเข้าถึงคุกกี้ก่อนที่
-    Shopify จะสามารถเปิดมันให้คุณได้
-  top_level_interaction_action: ดำเนินการต่อ
-  request_storage_access_heading: "%{app} ต้องการสิทธิ์การเข้าถึงคุกกี้"
-  request_storage_access_body: สิ่งนี้ช่วยให้แอปตรวจสอบความถูกต้องของคุณด้วยการจัดเก็บข้อมูลส่วนตัวของคุณชั่วคราว
-    คลิกดำเนินการต่อและอนุญาตให้คุกกี้ใช้แอป
-  request_storage_access_footer: คุกกี้จะหมดอายุหลังจาก 30 วัน
-  request_storage_access_action: ดำเนินการต่อ

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -3,20 +3,3 @@ tr:
   logged_out: Oturum başarıyla kapatıldı
   could_not_log_in: Shopify mağazasında oturum açılamadı
   invalid_shop_url: Geçersiz mağaza alan adı
-  enable_cookies_heading: "%{app} uygulamasından çerezleri etkinleştir"
-  enable_cookies_body: "%{app} uygulamasını Shopify içinde kullanabilmek için bu tarayıcıda
-    çerezleri manuel olarak etkinleştirmelisiniz."
-  enable_cookies_footer: Çerezler, tercihlerinizi ve kişisel bilgilerinizi geçici
-    olarak saklayıp uygulamanın kimliğinizi doğrulamasına imkan tanır. Çerezlerin
-    süresi 30 gün sonra sonra sona erer.
-  enable_cookies_action: Çerezleri etkinleştir
-  top_level_interaction_heading: Tarayıcınızın %{app} kimliğini doğrulaması gerekiyor
-  top_level_interaction_body: Tarayıcınız, Shopify tarafından açılmadan önce %{app}
-    gibi uygulamaların sizden çerezlere erişim izni istemesini zorunlu tutuyor.
-  top_level_interaction_action: Devam
-  request_storage_access_heading: "%{app} uygulamasının çerezlere erişmesi gerekiyor"
-  request_storage_access_body: Böylece uygulama, kişisel bilgilerinizi geçici olarak
-    saklayıp kimliğinizi doğrulayabilir. Devam et'e tıklayın ve çerezlerin uygulamayı
-    kullanmasına izin verin.
-  request_storage_access_footer: Çerezlerin süresi 30 gün sonra sonra sona erer.
-  request_storage_access_action: Devam

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -3,20 +3,3 @@ vi:
   logged_out: Đã đăng xuất thành công
   could_not_log_in: Không thể đăng nhập vào cửa hàng trên Shopify
   invalid_shop_url: Miền cửa hàng không hợp lệ
-  enable_cookies_heading: Bật cookie từ %{app}
-  enable_cookies_body: Bạn phải bật cookie trong trình duyệt này theo cách thủ công
-    để sử dụng %{app} trong Shopify.
-  enable_cookies_footer: Cookie cho phép ứng dụng xác thực bạn bằng cách tạm thời
-    lưu trữ tùy chọn và thông tin cá nhân của bạn. Những thông tin này sẽ hết hạn
-    sau 30 ngày.
-  enable_cookies_action: Bật cookie
-  top_level_interaction_heading: Trình duyệt của bạn cần xác thực %{app}
-  top_level_interaction_body: Trình duyệt của bạn cần các ứng dụng như %{app} để yêu
-    cầu quyền truy cập vào cookie thì Shopify mới có thể mở giúp bạn.
-  top_level_interaction_action: Tiếp tục
-  request_storage_access_heading: "%{app} cần quyền truy cập cookie"
-  request_storage_access_body: Nhờ vậy, ứng dụng có thể xác thực bạn bằng cách tạm
-    thời lưu trữ thông tin cá nhân của bạn. Nhấp vào tiếp tục và cho phép cookie sử
-    dụng ứng dụng.
-  request_storage_access_footer: Cookie sẽ hết hạn sau 30 ngày.
-  request_storage_access_action: Tiếp tục

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -3,14 +3,3 @@ zh-CN:
   logged_out: 已成功退出
   could_not_log_in: 无法登录到 Shopify 商店
   invalid_shop_url: 商店域名无效
-  enable_cookies_heading: 从 %{app} 启用 Cookie
-  enable_cookies_body: 您必须在此浏览器中手动启用 Cookie 才能在 Shopify 中使用 %{app}。
-  enable_cookies_footer: Cookie 使此应用能够通过暂时存储您的偏好设置和个人信息来验证您的身份。这些信息将在 30 天后过期。
-  enable_cookies_action: 启用 Cookie
-  top_level_interaction_heading: 您的浏览器需要对 %{app} 进行验证
-  top_level_interaction_body: 您的浏览器要求类似 %{app} 的应用向您申请访问 Cookie，之后 Shopify 才能为您打开它。
-  top_level_interaction_action: 继续
-  request_storage_access_heading: "%{app} 需要访问 Cookie"
-  request_storage_access_body: 这使此应用能够通过暂时存储您的个人信息来验证您的身份。点击继续并启用 Cookie 以使用此应用。
-  request_storage_access_footer: Cookie 将在 30 天后过期。
-  request_storage_access_action: 继续

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -3,14 +3,3 @@ zh-TW:
   logged_out: 登出成功
   could_not_log_in: 無法登入 Shopify 商店
   invalid_shop_url: 商店網域無效
-  enable_cookies_heading: 啟用 %{app} 的 Cookie
-  enable_cookies_body: 您必須在此瀏覽器中手動啟用 Cookie，才能夠在 Shopify 使用 %{app}。
-  enable_cookies_footer: Cookie 可讓應用程式暫時儲存您的偏好設定和個人資訊，藉此驗證您的身分，這些資料會在 30 天後失效。
-  enable_cookies_action: 啟用 Cookie
-  top_level_interaction_heading: 您的瀏覽器需要驗證 %{app}
-  top_level_interaction_body: 您的瀏覽器要求 %{app} 等應用程式向您請求 Cookie 的存取權限，才能讓 Shopify 為您開啟該應用程式。
-  top_level_interaction_action: 繼續
-  request_storage_access_heading: "%{app} 需要 Cookie 存取權限"
-  request_storage_access_body: Cookie 可讓應用程式暫時儲存您的個人資訊，藉此驗證您的身分。按一下繼續並允許 Cookie 使用此應用程式。
-  request_storage_access_footer: Cookie 將於 30 天後失效。
-  request_storage_access_action: 繼續

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,9 +16,6 @@ module.exports = function(config) {
     exclude: [
       // Exclude JS files that create 'DOMContentLoaded' event listeners
       'app/assets/javascripts/**/redirect.js',
-      'app/assets/javascripts/**/storage_access_redirect.js',
-      'app/assets/javascripts/**/top_level_interaction.js',
-      'app/assets/javascripts/**/partition_cookies.js',
     ],
     mochaReporter: {
       output: 'autowatch',

--- a/lib/shopify_app/engine.rb
+++ b/lib/shopify_app/engine.rb
@@ -19,11 +19,6 @@ module ShopifyApp
     initializer "shopify_app.assets.precompile" do |app|
       app.config.assets.precompile += [
         "shopify_app/redirect.js",
-        "shopify_app/post_redirect.js",
-        "shopify_app/top_level.js",
-        "shopify_app/enable_cookies.js",
-        "shopify_app/request_storage_access.js",
-        "storage_access.svg",
       ]
     end
 


### PR DESCRIPTION
### What this PR does

This PR is a cleanup to:

1. Remove non-existent references to JS files from the Rails precompile.

        "shopify_app/post_redirect.js",
        "shopify_app/top_level.js",
        "shopify_app/enable_cookies.js",
        "shopify_app/request_storage_access.js",
        "storage_access.svg",

1. Remove the `storage_access.svg`
1. Remove unused translation keys for features that have been removed.

Most of this is related to old features such as cookies (https://github.com/Shopify/shopify_app/pull/617), which was removed in https://github.com/Shopify/shopify_app/pull/1611 (2 years ago).

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
