### PR TITLE
Add invalid id token handling for `current_shopify_domain` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - ⚠️ [Breaking] Removes `ShopifyApp::JWTMiddleware`. Any existing app code relying on decoded JWT contents set from `request.env` should instead include the `WithShopifyIdToken` concern and call its respective methods. [#1861](https://github.com/Shopify/shopify_app/pull/1861)
 - Handle scenario when invalid URI is passed to `sanitize_shop_domain` [#1852](https://github.com/Shopify/shopify_app/pull/1852)
+- Add invalid id token handling for `current_shopify_domain` method [#1868](https://github.com/Shopify/shopify_app/pull/1868)
 
 22.2.1 (May 6,2024)
 ----------


### PR DESCRIPTION
### What this PR does

Fixes #1866

When app root URL is opened directly outside of iframe it used to redirect to `/login` page. With Token Exchange auth it now throws an exception `ShopifyAPI::Errors::MissingJwtTokenError` because `current_shopify_domain` method is called by `ShopifyApp::FrameAncestors` and it doesn't have any error handling at the moment.
![CleanShot 2024-06-22 at 11 33 38@2x](https://github.com/Shopify/shopify_app/assets/839922/c3c536c6-f9c7-4acc-944c-f10cee12f09a)
![CleanShot 2024-06-22 at 11 34 16@2x](https://github.com/Shopify/shopify_app/assets/839922/00dfa4d0-a75d-460d-b611-d895b5cde837)

In this PR I added missing error handling for `current_shopify_domain` and redirect to `/login` work again.
https://github.com/Shopify/shopify_app/assets/839922/da1eb29c-1f7f-4f26-b8ea-637778cfd8b0

### Reviewer's guide to testing

To reproduce the issue:

1. Launch the app that uses Token Exchange auth
2. Open root URL outside of iframe
3. You should see `ShopifyAPI::Errors::MissingJwtTokenError`

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.