### PR TITLE
Keep original path and params when redirecting deep links to embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - ⚠️ [Breaking] Removes `ShopifyApp::JWTMiddleware`. Any existing app code relying on decoded JWT contents set from `request.env` should instead include the `WithShopifyIdToken` concern and call its respective methods. [#1861](https://github.com/Shopify/shopify_app/pull/1861)
 - Handle scenario when invalid URI is passed to `sanitize_shop_domain` [#1852](https://github.com/Shopify/shopify_app/pull/1852)
+- Keep original path and params when redirecting deep links to embed [#1869](https://github.com/Shopify/shopify_app/pull/1869)
 
 22.2.1 (May 6,2024)
 ----------

--- a/lib/shopify_app/controller_concerns/embedded_app.rb
+++ b/lib/shopify_app/controller_concerns/embedded_app.rb
@@ -25,7 +25,11 @@ module ShopifyApp
         return redirect_to(ShopifyApp.configuration.login_url)
       end
 
-      redirect_path = ShopifyAPI::Auth.embedded_app_url(host)
+      original_path = request.path
+      original_params = request.query_parameters.except(:host, :shop, :id_token)
+      original_path += "?#{original_params.to_query}" if original_params.present?
+
+      redirect_path = ShopifyAPI::Auth.embedded_app_url(host) + original_path.to_s
       redirect_path = ShopifyApp.configuration.root_url if deduced_phishing_attack?(redirect_path)
       redirect_to(redirect_path, allow_other_host: true)
     end

--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -90,7 +90,8 @@ class EmbeddedAppTest < ActionController::TestCase
     ShopifyApp.configuration.embedded_app = true
 
     shop = "my-shop.myshopify.com"
-    get :redirect_to_embed, params: { shop: shop, foo: "bar" }
+    host = Base64.encode64("#{shop}/admin")
+    get :redirect_to_embed, params: { shop: shop, foo: "bar", host: host, id_token: "id_token" }
     assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}/redirect_to_embed?foo=bar"
   end
 

--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -75,7 +75,7 @@ class EmbeddedAppTest < ActionController::TestCase
     shop = "my-shop.myshopify.com"
     host = Base64.encode64("#{shop}/admin")
     get :redirect_to_embed, params: { host: host }
-    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}"
+    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}/redirect_to_embed"
   end
 
   test "#redirect_to_embed_app_in_admin redirects to the embed app in the admin when the shop param is present" do
@@ -83,7 +83,15 @@ class EmbeddedAppTest < ActionController::TestCase
 
     shop = "my-shop.myshopify.com"
     get :redirect_to_embed, params: { shop: shop }
-    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}"
+    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}/redirect_to_embed"
+  end
+
+  test "#redirect_to_embed_app_in_admin keeps original path and params when redirecting to the embed app" do
+    ShopifyApp.configuration.embedded_app = true
+
+    shop = "my-shop.myshopify.com"
+    get :redirect_to_embed, params: { shop: shop, foo: "bar" }
+    assert_redirected_to "https://#{shop}/admin/apps/#{ShopifyApp.configuration.api_key}/redirect_to_embed?foo=bar"
   end
 
   test "Redirect to login URL when host nor shop param is present" do

--- a/test/shopify_app/controller_concerns/token_exchange_test.rb
+++ b/test/shopify_app/controller_concerns/token_exchange_test.rb
@@ -227,7 +227,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
       host = Base64.encode64("#{@shop}/admin")
       params = { shop: @shop, host: host }
 
-      expected_redirect_url = "https://my-shop.myshopify.com/admin/apps/key"
+      expected_redirect_url = "https://my-shop.myshopify.com/admin/apps/key/"
 
       with_application_test_routes do
         get :index, params: params
@@ -241,7 +241,7 @@ class TokenExchangeControllerTest < ActionController::TestCase
 
       params = { shop: @shop }
 
-      expected_redirect_url = "https://my-shop.myshopify.com/admin/apps/key"
+      expected_redirect_url = "https://my-shop.myshopify.com/admin/apps/key/"
 
       with_application_test_routes do
         get :index, params: params


### PR DESCRIPTION
### What this PR does

Fixes deep link behavior to make sure the original path and params are preserved after redirect to app embed. Right now all deep links are redirected to home page. In addition to deep links it fixes opening links in new tab in app embed.

https://github.com/Shopify/shopify_app/assets/839922/a1c43f6a-8486-40ea-af4c-5ef384906807

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
