### PR TITLE
Fix unified admin install path for spin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Remove old translation keys for `enable_cookies_*`, `top_level_interaction_*` and `request_storage_access_*` [#1865](https://github.com/Shopify/shopify_app/pull/1865)
 - Add invalid id token handling for `current_shopify_domain` method [#1868](https://github.com/Shopify/shopify_app/pull/1868)
 - Keep original path and params when redirecting deep links to embed [#1869](https://github.com/Shopify/shopify_app/pull/1869)
+- Fix managed install path for SPIN environments [#1877](https://github.com/Shopify/shopify_app/pull/1877)
 
 22.2.1 (May 6,2024)
 ----------

--- a/app/controllers/shopify_app/sessions_controller.rb
+++ b/app/controllers/shopify_app/sessions_controller.rb
@@ -52,7 +52,8 @@ module ShopifyApp
 
     def start_install
       shop_name = sanitized_shop_name.split(".").first
-      install_path = "https://admin.shopify.com/store/#{shop_name}/oauth/install?client_id=#{ShopifyApp.configuration.api_key}"
+      unified_admin_path = ShopifyApp::Utils.unified_admin_path(shop_name)
+      install_path = "#{unified_admin_path}/oauth/install?client_id=#{ShopifyApp.configuration.api_key}"
       redirect_to(install_path, allow_other_host: true)
     end
 

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -39,6 +39,15 @@ module ShopifyApp
         url.to_s
       end
 
+      def unified_admin_path(shop)
+        spin_env = ENV.fetch("SPIN_FQDN", nil)
+        if spin_env
+          "https://admin.web.#{spin_env}/store/#{shop}"
+        else
+          "https://admin.shopify.com/store/#{shop}"
+        end
+      end
+
       private
 
       def myshopify_domain

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -74,4 +74,16 @@ class UtilsTest < ActiveSupport::TestCase
       assert_nil ShopifyApp::Utils.sanitize_shop_domain(bad_url)
     end
   end
+
+  test "#unified_admin_path returns the path to shop" do
+    expected = "https://admin.shopify.com/store/my-shop"
+    assert_equal expected, ShopifyApp::Utils.unified_admin_path("my-shop")
+  end
+
+  test "#unified_admin_path returns the path to shop with spin env" do
+    ENV["SPIN_FQDN"] = "my.spin.dev"
+    expected = "https://admin.web.my.spin.dev/store/my-shop"
+    assert_equal expected, ShopifyApp::Utils.unified_admin_path("my-shop")
+    ENV["SPIN_FQDN"] = nil
+  end
 end


### PR DESCRIPTION
### What this PR does
Closes: https://github.com/Shopify/develop-app-runtime-primitives/issues/396
Fixes the install path for SPIN URLs

## Tophatting
#### Install works for spin shops
https://videobin.shopify.io/v/5ZGq8n

#### Install still works for production shops
https://videobin.shopify.io/v/oadmV1

### Checklist
Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
