### PR TITLE
Fix bug where locale is not read from session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 - Fix managed install path for SPIN environments [#1877](https://github.com/Shopify/shopify_app/pull/1877)
 - Migrate fullpage redirect to App Bridge CDN [#1870](https://github.com/Shopify/shopify_app/pull/1870)
 - Improve embedded requests detection with `Sec-Fetch-Dest` header [#1873](https://github.com/Shopify/shopify_app/pull/1873)
+- Fix bug where locale is not read from session if locale param is not present in app request [#1878](https://github.com/Shopify/shopify_app/pull/1878)
 
 22.2.1 (May 6,2024)
 ----------

--- a/lib/shopify_app/controller_concerns/localization.rb
+++ b/lib/shopify_app/controller_concerns/localization.rb
@@ -11,7 +11,7 @@ module ShopifyApp
     private
 
     def set_locale(&action)
-      locale = params[:locale] || I18n.default_locale
+      locale = params[:locale] || session[:locale] || I18n.default_locale
 
       # Fallback to the 2 letter language code if the requested locale unavailable
       unless I18n.available_locales.include?(locale.to_sym)

--- a/test/shopify_app/controller_concerns/localization_test.rb
+++ b/test/shopify_app/controller_concerns/localization_test.rb
@@ -19,10 +19,22 @@ class LocalizationTest < ActionController::TestCase
     I18n.available_locales = [:en, :de, :es, :ja, :fr]
   end
 
-  test "falls back to I18n.default if locale param is not present" do
+  test "falls back to locale stored in session if locale param is not present" do
     I18n.default_locale = :ja
 
     with_test_routes do
+      @request.session[:locale] = :de
+
+      get :index
+      assert_equal :de, response.body.to_sym
+    end
+  end
+
+  test "falls back to I18n.default if locale param is not present and session not populated" do
+    I18n.default_locale = :ja
+
+    with_test_routes do
+      @request.session[:locale] = nil
       get :index
       assert_equal :ja, response.body.to_sym
     end


### PR DESCRIPTION
### What this PR does

<!-- Please describe what changes this PR introduces and why they're needed. -->

The changes in https://github.com/Shopify/shopify_app/pull/1711 introduced a bug where single-page apps that don't include the locale param in subsequent requests were unable to properly set the locale that was persisted in the user session. Instead they would use the default locale.

See https://github.com/Shopify/shopify_app/pull/1711/files#r1664570299 for background.

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

### Things to focus on

Nothing in particular since this is a very small change. A new test case was added to make sure it was accounted for.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
