### PR TITLE
Update session persistence documentation for ruby template

### DIFF
--- a/docs/shopify_app/sessions.md
+++ b/docs/shopify_app/sessions.md
@@ -59,7 +59,10 @@ If your app has user interactions and would like to control permission based on 
 
 [Shop (offline) tokens must still be maintained](#shop-offline-token-storage).
 
-1. Run the following generator to create a user model to store the individual based access tokens
+1. Run the following generator to create a user model to store the individual based access tokens.
+
+⚠️ If you started from the [Ruby App Template](https://github.com/Shopify/shopify-app-template-ruby), you don't need to run the generator as it's already included in the template. You can skip this step.
+
 ```sh
 rails generate shopify_app:user_model
 ```


### PR DESCRIPTION
Following up Shopify/shopify-app-template-ruby#136, the ruby template will ship with the user model and migrations already present in the codebase. This means that running the generator is no longer needed to enable User session persistence.

This change might impact users who started the template with the previous version of the ruby template. In that case, this documentation won't work, as they need to also run the generator. 