### PR TITLE
Add test stub for token exchange auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 * Add the `unified_admin_domain` configuration option for the unified admin domain.
 - Add new generators for webhook subscriptions defined in the `shopify.app.toml` file [1882](https://github.com/Shopify/shopify_app/pull/1882)
+- Fix test stubbing for Token Exchange auth [1897](https://github.com/Shopify/shopify_app/pull/1897)
 
 22.3.1 (July 26, 2024)
 ----------

--- a/lib/shopify_app/test_helpers/shopify_session_helper.rb
+++ b/lib/shopify_app/test_helpers/shopify_session_helper.rb
@@ -7,6 +7,7 @@ module ShopifyApp
         ShopifyAPI::Auth::Session.new(id: session_id, shop: shop_domain).tap do |session|
           ShopifyApp::SessionRepository.stubs(:load_session).returns(session)
           ShopifyAPI::Utils::SessionUtils.stubs(:current_session_id).returns(session.id)
+          ShopifyAPI::Utils::SessionUtils.stubs(:session_id_from_shopify_id_token).returns(session.id)
           ShopifyAPI::Context.activate_session(session)
         end
       end


### PR DESCRIPTION
### What this PR does
Fixes this issue:
- https://github.com/Shopify/shopify_app/issues/1867

We were missing a test stub for token exchange because we introduced a new helper in `ShopifyAPI::Utils::SessionUtils` for [session_id_from_shopify_id_token](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/utils/session_utils.rb#L45), used in [Token Exchange](https://github.com/Shopify/shopify_app/blob/fb4dd79a3c64ea5495cb15969bdb7c70e9a2e7b9/lib/shopify_app/controller_concerns/token_exchange.rb#L43) 

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
