### PR TITLE
Set CurrentTenant to nil when gem is present

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -108,6 +108,11 @@ module ShopifyApp
     end
 
     def redirect_to_login
+      if defined?(ShopifySecurityBase::CurrentTenant)
+        ShopifyApp::Logger.debug("ShopifySecurityBase::CurrentTenant detected, setting current tenant to NilTenant")
+        ShopifySecurityBase::CurrentTenant.tenant = ShopifySecurityBase::NilTenant.new
+      end
+
       if requested_by_javascript?
         add_top_level_redirection_headers(ignore_response_code: true)
         ShopifyApp::Logger.debug("Login redirect request is a XHR")

--- a/lib/shopify_app/controller_concerns/token_exchange.rb
+++ b/lib/shopify_app/controller_concerns/token_exchange.rb
@@ -63,6 +63,11 @@ module ShopifyApp
       ShopifyApp::Logger.debug("Responding to invalid Shopify ID token: #{error.message}")
       return if performed?
 
+      if defined?(ShopifySecurityBase::CurrentTenant)
+        ShopifyApp::Logger.debug("ShopifySecurityBase::CurrentTenant detected, setting current tenant to NilTenant")
+        ShopifySecurityBase::CurrentTenant.tenant = ShopifySecurityBase::NilTenant.new
+      end
+
       if request.headers["HTTP_AUTHORIZATION"].blank?
         if embedded?
           redirect_to_bounce_page


### PR DESCRIPTION
### What this PR does

This makes sure the `CurrentTenant` is set to `nil` if gem is present whenever `ShopifyApp` ends the request in a before action, which happens:

- When there's no current session when using auth code flow
- When there's no `id_token` or if it's invalid when using token exchange

### Reviewer's guide to testing

#### Steps to reproduce the error:
1. create a new app with the CLI
2. make sure it has `write_products` scope and `shopify app deploy`
3. make sure `new_embedded_auth_strategy` is `false`
4. add the line to set the current tenant to `HomeController#index`, `ProductsController#count` and `ProductsController#create`
5. add the security gem
6. `bundle` and start the server
7. install the app
8. delete the row created in the `shops` table
9. click on `Populate 5 products`
10. 👀 see the current tenant exception in the server logs 💥 

#### Seeing the fix
1. point `shopify_app` in the Gemfile to this branch with `gem "shopify_app", github: "Shopify/shopify_app", ref: "fix_current_tenant_error"`
2. `bundle` and restart the server
3. open the app again
4. delete the row created by install in the `shops` table
5. click on `Populate 5 products`
6. 👀 see how it correctly redirects to get a new access token ✨ 

### Things to focus on

I couldn't find a nicer way to test the path of `defined?(ClassName)`, I'd appreciate if anyone has better suggestions.

Anything else I'm missing?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
