### PR TITLE
Add support for filters in webhook registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+
+- Add support for filters in webhook registration [1923](https://github.com/Shopify/shopify_app/pull/1923)
 -  Make `ShopifyApp.configuration.scope` default to empty list `[]` [1913](https://github.com/Shopify/shopify_app/pull/1913)
 
 22.4.0 (August 22, 2024)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       jwt (>= 2.2.3)
       rails (> 5.2.1)
       redirect_safely (~> 1.0)
-      shopify_api (>= 14.3.0, < 15.0)
+      shopify_api (>= 14.7.0, < 15.0)
       sprockets-rails (>= 2.0.0)
 
 GEM
@@ -219,7 +219,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.2.2)
-    shopify_api (14.3.0)
+    shopify_api (14.7.0)
       activesupport
       concurrent-ruby
       hash_diff

--- a/docs/shopify_app/webhooks.md
+++ b/docs/shopify_app/webhooks.md
@@ -62,8 +62,22 @@ ShopifyApp.configure do |config|
   config.webhooks = [
     {
       topic: 'orders/create',
-      path: 'api/webhooks/order_create',
+      path: 'api/webhooks/orders_create',
       metafield_namespaces: ['app-namespace'],
+    },
+  ]
+end
+```
+
+If you need to filter by webhook fields, you can register a webhook with a `filter` parameter. The documentation for Webhook filters can be found [here](https://shopify.dev/docs/apps/build/webhooks/customize/filters).
+
+```ruby
+ShopifyApp.configure do |config|
+  config.webhooks = [
+    {
+      topic: 'products/update',
+      path: 'api/webhooks/products_update',
+      filter: "variants.price:>=10.00",
     },
   ]
 end

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -52,6 +52,7 @@ module ShopifyApp
             path: webhook_path,
             handler: delivery_method == :http ? webhook_job_klass(webhook_path) : nil,
             fields: attributes[:fields],
+            filter: attributes[:filter],
             metafield_namespaces: attributes[:metafield_namespaces],
           )
         end

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("addressable", "~> 2.7")
   s.add_runtime_dependency("rails", "> 5.2.1")
   s.add_runtime_dependency("redirect_safely", "~> 1.0")
-  s.add_runtime_dependency("shopify_api", ">= 14.3.0", "< 15.0")
+  s.add_runtime_dependency("shopify_api", ">= 14.7.0", "< 15.0")
   s.add_runtime_dependency("sprockets-rails", ">= 2.0.0")
   # Deprecated: move to development dependencies when releasing v23
   s.add_runtime_dependency("jwt", ">= 2.2.3")

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -23,6 +23,7 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
       handler: OrdersUpdatedJob,
       fields: nil,
       metafield_namespaces: nil,
+      filter: nil,
     }
 
     ShopifyAPI::Webhooks::Registry.expects(:add_registration).with(**expected_hash).once
@@ -42,6 +43,7 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
       handler: OrdersUpdatedJob,
       fields: nil,
       metafield_namespaces: nil,
+      filter: nil,
     }
 
     ShopifyAPI::Webhooks::Registry.expects(:add_registration).with(**expected_hash).once
@@ -50,6 +52,31 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
         {
           topic: "orders/updated",
           address: "https://some.domain.over.the.rainbow.com/webhooks/orders_updated",
+        },
+      ]
+    end
+
+    ShopifyApp::WebhooksManager.add_registrations
+  end
+
+  test "#add_registrations includes filters" do
+    expected_hash = {
+      topic: "orders/updated",
+      delivery_method: :http,
+      path: "/webhooks/orders_updated",
+      handler: OrdersUpdatedJob,
+      fields: nil,
+      metafield_namespaces: nil,
+      filter: "id:*",
+    }
+
+    ShopifyAPI::Webhooks::Registry.expects(:add_registration).with(**expected_hash).once
+    ShopifyApp.configure do |config|
+      config.webhooks = [
+        {
+          topic: "orders/updated",
+          address: "https://some.domain.over.the.rainbow.com/webhooks/orders_updated",
+          filter: "id:*",
         },
       ]
     end


### PR DESCRIPTION
### What this PR does

To support passing a filter to webhook registrations, the filter parameter is needed.

Depends on https://github.com/Shopify/shopify-api-ruby/pull/1347


### Reviewer's guide to testing

```ruby
gem "shopify_api", github: 'nebulab/shopify-api-ruby', branch: 'kennyadsl/add-filter-support'
gem "shopify_app", github: 'nebulab/shopify_app', branch: 'kennyadsl/add-filter-support'
```

The following registration won't work without the changes in the two PRs above, because apparently, to register a metaobject-related webhook, at least one filter needs to be specified.

```ruby
ShopifyApp.configure do |config|
  config.webhooks = [
    {
      topic: "metaobjects/update",
      path: "api/webhooks/metaobjects_update",
      filter: "type:my_type OR type:my_other_type",
    },
  ]
end
```

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
