### PR TITLE
Drop log_v23_deprecations console warning

### DIFF
--- a/lib/shopify_app/configuration.rb
+++ b/lib/shopify_app/configuration.rb
@@ -62,8 +62,6 @@ module ShopifyApp
       @webhooks_manager_queue_name = Rails.application.config.active_job.queue_name
       @disable_webpacker = ENV["SHOPIFY_APP_DISABLE_WEBPACKER"].present?
       @scope = []
-
-      log_v23_deprecations
     end
 
     def login_url
@@ -164,25 +162,6 @@ module ShopifyApp
 
         task_class
       end
-    end
-
-    private
-
-    def log_v23_deprecations
-      return unless Rails.env.development?
-
-      # TODO: Remove this before releasing v23.0.0
-      message = <<~EOS
-        ================================================
-        => Upcoming changes in v23.0:
-        * 'CallbackController::perform_after_authenticate_job' and related methods 'install_webhooks', 'perform_after_authenticate_job'
-        * are deprecated and  will be removed from CallbackController in the next major release. If you need to customize
-        * post authentication tasks, see https://github.com/Shopify/shopify_app/blob/main/docs/shopify_app/authentication.md#post-authenticate-tasks
-
-        * ShopifyApp::JWTMiddleware will be removed, use ShopifyApp::WithShopifyIdToken instead.
-        ================================================
-      EOS
-      puts message
     end
   end
 


### PR DESCRIPTION
### What this PR does

We've seen this console warning for 8 months with each app boot in dev, thinking we could remove the warning. 

Especially since if there's breaking changes they are could be raised in the changelog + via exceptions.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
