### PR TITLE
Pass values to CSP frame_ancestors as individual arguments

### DIFF
--- a/lib/shopify_app/controller_concerns/frame_ancestors.rb
+++ b/lib/shopify_app/controller_concerns/frame_ancestors.rb
@@ -6,8 +6,13 @@ module ShopifyApp
 
     included do
       content_security_policy do |policy|
-        domain_host = current_shopify_domain || "*.#{::ShopifyApp.configuration.myshopify_domain}"
-        policy.frame_ancestors "#{ShopifyAPI::Context.host_scheme}://#{domain_host}", "https://admin.#{::ShopifyApp.configuration.unified_admin_domain}"
+        policy.frame_ancestors(-> do
+          domain_host = current_shopify_domain || "*.#{::ShopifyApp.configuration.myshopify_domain}"
+          [
+            "#{ShopifyAPI::Context.host_scheme}://#{domain_host}",
+            "https://admin.#{::ShopifyApp.configuration.unified_admin_domain}",
+          ]
+        end)
       end
     end
   end


### PR DESCRIPTION
### What this PR does

Rails core has patched a CVE preventing passing a string with whitespace as an argument.

https://github.com/rails/rails/commit/3da2479cfe1e00177114b17e496213c40d286b3a

This patch passes the arguments individually instead which achieves the same result whilst meeting the new requirements.

### Reviewer's guide to testing

There is no change in overall functionality.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
