### PR TITLE
Handle invalid token when adding redirection headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 Unreleased
 ----------
-
 - ⚠️ [Breaking] Removed deprecated `CallbackController` methods. `perform_after_authenticate_job`, `install_webhooks`, and `perform_post_authenticate_jobs` have been removed. [#1961](https://github.com/Shopify/shopify_app/pull/1961)
 - ⚠️ [Breaking] Bumps minimum supported Ruby version to 3.1 [#1959](https://github.com/Shopify/shopify_app/pull/1959)
 - Adds a `script_tag_manager` that will automatically create script tags when the app is installed. [1948](https://github.com/Shopify/shopify_app/pull/1948)
+- Handle invalid token when adding redirection headers [#1945](https://github.com/Shopify/shopify_app/pull/1945)
 
 22.5.2 (March 14, 2025)
 ----------

--- a/test/shopify_app/controller_concerns/login_protection_test.rb
+++ b/test/shopify_app/controller_concerns/login_protection_test.rb
@@ -446,6 +446,16 @@ class LoginProtectionControllerTest < ActionController::TestCase
     end
   end
 
+  test "#activate_shopify_session when rescuing from invalid JWT token, breaks out of iframe in XHR requests" do
+    ShopifyAPI::Utils::SessionUtils.stubs(:current_session_id).returns(nil)
+    request.headers["HTTP_AUTHORIZATION"] = "Bearer token"
+    with_application_test_routes do
+      get :index, xhr: true
+
+      assert_equal "/login", response.headers["X-Shopify-API-Request-Failure-Reauthorize-Url"]
+    end
+  end
+
   test "#activate_shopify_session when rescuing from non 401 errors, does not close session" do
     with_application_test_routes do
       cookies.encrypted[ShopifyAPI::Auth::Oauth::SessionCookie::SESSION_COOKIE_NAME] = "cookie"


### PR DESCRIPTION
### What this PR does

Currently, while decoding a token while redirecting to login, it's possible for errors to occur. Example error: `Signature has expired`.

This PR rescues token decoding errors and handles them gracefully. The login url will not include the shop param in this scenario.

Exception:
```
gems/shopify_api-14.8.0/lib/shopify_api/auth/jwt_payload.rb:87:in `rescue in decode_token': Error decoding session token: Signature has expired (ShopifyAPI::Errors::InvalidJwtTokenError)
    from gems/shopify_api-14.8.0/lib/shopify_api/auth/jwt_payload.rb:84:in `decode_token'
    from gems/shopify_api-14.8.0/lib/shopify_api/auth/jwt_payload.rb:23:in `initialize'
    from gems/shopify_app-22.5.1/lib/shopify_app/controller_concerns/login_protection.rb:92:in `new'
    from gems/shopify_app-22.5.1/lib/shopify_app/controller_concerns/login_protection.rb:92:in `add_top_level_redirection_headers'
    from gems/shopify_app-22.5.1/lib/shopify_app/controller_concerns/login_protection.rb:112:in `redirect_to_login'
```

### Reviewer's guide to testing

The test covers this scenario by simulating an error decoding the session token, in this case the error is `Not enough or too many segments` but it covers any error while decoding tokens.

### Things to focus on

I'm unfamiliar with this repo so please ensure the way that the exception is handled won't cause issues in the redirect.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
