### PR TITLE
Add support for trusted Shopify domain .shop.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
 
+22.5.2 (March 14, 2025)
+----------
+- Add support for a new trusted Shopify domain [#1949](https://github.com/Shopify/shopify_app/pull/1949)
+
 22.5.1 (December 11, 2024)
 ----------
 - Fix Rails [CVE-2024-54133](https://github.com/rails/rails/commit/3da2479cfe1e00177114b17e496213c40d286b3a) [1929](https://github.com/Shopify/shopify_app/pull/1929)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (22.5.1)
+    shopify_app (22.5.2)
       activeresource
       addressable (~> 2.7)
       jwt (>= 2.2.3)

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -8,6 +8,7 @@ module ShopifyApp
         "myshopify.io",
         "myshopify.com",
         "spin.dev",
+        "shop.dev",
       ].freeze
 
       def sanitize_shop_domain(shop_domain)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "22.5.1"
+  VERSION = "22.5.2"
 end

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -12,6 +12,9 @@ class UtilsTest < ActiveSupport::TestCase
     "my-shop.myshopify.com",
     "https://my-shop.myshopify.com",
     "http://my-shop.myshopify.com",
+    "my-shop.shop.dev",
+    "https://my-shop.shop.dev",
+    "http://my-shop.shop.dev",
   ].each do |good_url|
     test "sanitize_shop_domain for (#{good_url})" do
       assert ShopifyApp::Utils.sanitize_shop_domain(good_url)


### PR DESCRIPTION
### What this PR does
In this PR we add a new hostname `.shop.dev` to Shopify trusted domains to prevent internal flows from treating this hostname as a potential phishing attack.

### Reviewer's guide to testing
- Install a Shopify App, such as Shop channel locally. Requests referred from the Admin should not be treated as phishing and be nullified.

```
[ ShopifyApp | INFO | Shop Not Found ] host param from callback is not from a trusted domain
[ ShopifyApp | INFO | Shop Not Found ] redirecting to root as this is likely a phishing attack
```

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
