### PR TITLE
Add `audience` to `translation.yml`

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -3,6 +3,7 @@ target_languages: [cs, da, de, es, fi, fr, it, ja, ko, nb, nl, pl, pt-BR, pt-PT,
 async_pr_mode: per_pr
 components:
   - name: 'merchant'
+    audience: merchant
     paths:
       - config/locales/{{language}}.yml
       - config/locales/**/{{language}}.yml


### PR DESCRIPTION
Part of https://github.com/Shopify/translation-platform/issues/1638

Adding the `audience` config to any components where it's not set, so that Translation Platform can remove this repository from a list of internal hardcoded `audience` values.