### PR TITLE
Support Shopify storefront domain in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Unreleased
 ----------
+22.5.3 (March 24, 2025)
+----------
+- Fix bug app installation is not redirected to the right domain [#1960](https://github.com/Shopify/shopify_app/pull/1960)
 
 22.5.2 (March 14, 2025)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (22.5.2)
+    shopify_app (22.5.3)
       activeresource
       addressable (~> 2.7)
       jwt (>= 2.2.3)

--- a/lib/shopify_app/utils.rb
+++ b/lib/shopify_app/utils.rb
@@ -21,7 +21,11 @@ module ShopifyApp
 
           return myshopify_domain_from_unified_admin(uri) if unified_admin?(uri) && from_trusted_domain
           return nil if no_shop_name_in_subdomain || uri.host&.empty?
-          return uri.host if from_trusted_domain
+
+          next unless from_trusted_domain
+          return dev_api_domain(uri.host) if storefront_domain?(uri)
+
+          return uri.host
         end
         nil
       end
@@ -63,6 +67,14 @@ module ShopifyApp
         trusted_domains = TRUSTED_SHOPIFY_DOMAINS.dup
         trusted_domains.append(myshopify_domain).uniq! if myshopify_domain
         trusted_domains
+      end
+
+      def storefront_domain?(uri)
+        uri.host.include?(".my.shop.dev")
+      end
+
+      def dev_api_domain(host)
+        host.gsub(".my.shop.dev", ".dev-api.shop.dev")
       end
 
       def uri_from_shop_domain(shop_domain)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "22.5.2"
+  VERSION = "22.5.3"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "22.5.2",
+  "version": "22.5.3",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",

--- a/test/shopify_app/utils_test.rb
+++ b/test/shopify_app/utils_test.rb
@@ -34,6 +34,16 @@ class UtilsTest < ActiveSupport::TestCase
     end
   end
 
+  [
+    "https://my-shop.my.shop.dev",
+    "http://my-shop.my.shop.dev",
+    "my-shop.my.shop.dev",
+  ].each do |good_url|
+    test "sanitize_shop_domain replaces development storefront domain for (#{good_url}) with internal domain" do
+      assert_equal "my-shop.dev-api.shop.dev", ShopifyApp::Utils.sanitize_shop_domain(good_url)
+    end
+  end
+
   test "sanitize_shop_domain URL shopify spin.dev custom myshopify_domain" do
     myshop_domain = "http://shopify.foobar-part-onboard-0d6x.asdf-rygus.us.spin.dev"
     ShopifyApp.configuration.stubs(:myshopify_domain).returns(myshop_domain)


### PR DESCRIPTION
### What this PR does
Shopify recently changed their internal domains in development. In this PR, we update the URI sanitation to globally substitute storefront domains with internal domains and enable the installation of Shopify Apps.

We are okay to expose this logic publicly as per https://github.com/shop/world/pull/18779#discussion_r2003371745.

### Reviewer's guide to testing
Follow the instructions in https://shop.docs.shopify.io/docs/shop-server/architecture/components/merchant/local to install an app in development, using the code from https://github.com/Shopify/shop-server/pull/100230 and https://github.com/shop/world/pull/18779.

### Things to focus on
App installation setup should work in development.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
