### PR TITLE
[Breaking] Drops support for Ruby version 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ruby ${{ matrix.version }}
     strategy:
       matrix:
-        version: ['3.0', '3.1', '3.2', '3.3']
+        version: ['3.1', '3.2', '3.3']
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+* ⚠️ [Breaking] Bumps minimum supported Ruby version to 3.1 [#1959](https://github.com/Shopify/shopify_app/pull/1959)
 
 22.5.2 (March 14, 2025)
 ----------

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -44,6 +44,9 @@ If you do run into issues, we recommend looking at our [debugging tips.](https:/
 
 ## Unreleased
 
+#### (v23.0.0) Drops support for Ruby 3.0
+The minimum ruby version is now 3.1
+
 #### (v23.0.0) - Deprecated methods in CallbackController
 The following methods from `ShopifyApp::CallbackController` have been deprecated in `v23.0.0`
 - `perform_after_authenticate_job`

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.author      = "Shopify"
   s.summary     = "This gem is used to get quickly started with the Shopify API"
 
-  s.required_ruby_version = ">= 3.0"
+  s.required_ruby_version = ">= 3.1"
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
### What this PR does
* Ruby 3.0 is EOL
* We need to drop support of ruby 3 to resolve dependencies
* See #1958 

### Reviewer's guide to testing

<!-- If this PR changes functionality, please list out steps to test your changes. This helps reviewers verify your changes are correct. -->

### Things to focus on

1. <!-- Focus on a particular file -->
2. <!-- Is the test case correct? -->
3. <!-- Etc. -->

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
