### PR TITLE
Handle invalid record error for concurrent token exchange calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 - ⚠️ [Breaking] Bumps minimum supported Ruby version to 3.1 [#1959](https://github.com/Shopify/shopify_app/pull/1959)
 - Adds a `script_tag_manager` that will automatically create script tags when the app is installed. [1948](https://github.com/Shopify/shopify_app/pull/1948)
 - Handle invalid token when adding redirection headers [#1945](https://github.com/Shopify/shopify_app/pull/1945)
+- Handle invalid record error for concurrent token exchange calls [#1966](https://github.com/Shopify/shopify_app/pull/1966)
 
 22.5.2 (March 14, 2025)
 ----------

--- a/lib/shopify_app/auth/token_exchange.rb
+++ b/lib/shopify_app/auth/token_exchange.rb
@@ -60,6 +60,13 @@ module ShopifyApp
       rescue ActiveRecord::RecordNotUnique
         Logger.debug("Session not stored due to concurrent token exchange calls")
         session
+      rescue ActiveRecord::RecordInvalid => e
+        if e.message.include?("has already been taken")
+          Logger.debug("Session not stored due to concurrent token exchange calls")
+          session
+        else
+          raise
+        end
       rescue => error
         Logger.error("An error occurred during the token exchange: [#{error.class}] #{error.message}")
         raise


### PR DESCRIPTION
### What this PR does

This PR handles `ActiveRecord::RecordInvalid` error during token exchange calls, which might happen on concurrent requests (similar to existing `ActiveRecord::RecordNotUnique` handler).

### Reviewer's guide to testing

Added the test for new handler.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
