### PR TITLE
Exchange id_token when it is present

### DIFF
--- a/lib/shopify_app/controller_concerns/token_exchange.rb
+++ b/lib/shopify_app/controller_concerns/token_exchange.rb
@@ -17,7 +17,7 @@ module ShopifyApp
     ].freeze
 
     def activate_shopify_session(&block)
-      retrieve_session_from_token_exchange if current_shopify_session.blank? || should_exchange_expired_token?
+      retrieve_session_from_token_exchange if should_exchange_token?
 
       ShopifyApp::Logger.debug("Activating Shopify session")
       ShopifyAPI::Context.activate_session(current_shopify_session)
@@ -27,6 +27,10 @@ module ShopifyApp
     ensure
       ShopifyApp::Logger.debug("Deactivating session")
       ShopifyAPI::Context.deactivate_session
+    end
+
+    def should_exchange_token?
+      current_shopify_session.blank? || should_exchange_expired_token? || params[:id_token].present?
     end
 
     def should_exchange_expired_token?


### PR DESCRIPTION
### What this PR does

Fixes #1886

### Reviewer's guide to testing

There are a couple of cases myself and others have ran into where the access token or scopes are not updated when using token exchange:
- When the user uninstalls and reinstalls the app (and you do not hard delete the shop for data retention reasons)
- When managed app install scopes are updated

In my testing when these cases occur we get an `id_token` back in the url params and this is a good indication that something has changed. Based on #1886 it seems like others have found this works for them as well. Triggering `retrieve_session_from_token_exchange` in this case causes all session storage and (I believe but didn't test) after authenticate triggers to run.

I haven't looked too much into the authentication header but it's possible that checking `shopify_id_token` is present would be a better approach to take into account that header having the id_token. I'm not sure what situations that header is present in through and my assumption is that most of those cases we don't necessarily need to update the scopes/access_token and the cases where we do want to update them it will be included in the url params.

### Things to focus on

1. Make sure my assumptions about when this should trigger are correct.
2. Check if it would make sense to trigger this when the authentication header is present as well.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
