### PR TITLE
[Minor] Add App Bridge script to allow for strict CSP policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Adds a `script_tag_manager` that will automatically create script tags when the app is installed. [1948](https://github.com/Shopify/shopify_app/pull/1948)
 - Handle invalid token when adding redirection headers [#1945](https://github.com/Shopify/shopify_app/pull/1945)
 - Handle invalid record error for concurrent token exchange calls [#1966](https://github.com/Shopify/shopify_app/pull/1966)
+- Add App Bridge CDN URL to CSP script-src directive for embedded apps to ensure compatibility with strict CSP configurations
 
 22.5.2 (March 14, 2025)
 ----------

--- a/docs/shopify_app/controller-concerns.md
+++ b/docs/shopify_app/controller-concerns.md
@@ -64,6 +64,26 @@ Implements Rails' [protect_from_forgery](https://api.rubyonrails.org/classes/Act
 #### EmbeddedApp
 If your ShopifyApp configuration has the `embedded_app` config set to true, [P3P header](https://www.w3.org/P3P/) and [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) are handled for you.
 
+##### Content Security Policy (CSP) Directives:
+
+The EmbeddedApp concern automatically configures the following CSP directives to ensure your embedded app works correctly within Shopify Admin:
+
+1. **frame-ancestors**: Allows the app to be embedded in iframes from:
+   - The current shop domain (e.g., `https://example.myshopify.com`)
+   - Shopify's unified admin domain (e.g., `https://admin.shopify.com`)
+
+2. **script-src**: Allows JavaScript execution from:
+   - `'self'` - Scripts from your app's own domain
+   - `https://cdn.shopify.com/shopifycloud/app-bridge.js` - Required for App Bridge functionality
+   - Any other script sources you explicitly add in your controller
+
+These CSP settings ensure that:
+- Your app can be properly embedded within Shopify Admin
+- App Bridge can load and function correctly
+- Your app maintains security while allowing necessary Shopify integrations
+
+##### Layout
+
 By default, the `EmbeddedApp` concern also sets the layout file to be `app/views/layouts/embedded_app.html.erb`.
 
 Sometimes one wants to run an embedded app in non-embedded mode. For example:

--- a/lib/shopify_app/controller_concerns/frame_ancestors.rb
+++ b/lib/shopify_app/controller_concerns/frame_ancestors.rb
@@ -13,6 +13,10 @@ module ShopifyApp
             "https://admin.#{::ShopifyApp.configuration.unified_admin_domain}",
           ]
         end)
+        # Allow app-bridge.js from Shopify CDN for embedded apps
+        # This ensures apps work correctly when developers enable strict CSP
+        current_script_src = policy.script_src || [:self]
+        policy.script_src(*current_script_src, "https://cdn.shopify.com/shopifycloud/app-bridge.js")
       end
     end
   end

--- a/test/controllers/concerns/embedded_app_test.rb
+++ b/test/controllers/concerns/embedded_app_test.rb
@@ -148,4 +148,24 @@ class EmbeddedAppTest < ActionDispatch::IntegrationTest
     get redirect_to_embed_path
     assert_includes response.headers["Content-Security-Policy"], ShopifyApp.configuration.unified_admin_domain
   end
+
+  test "content security policy includes App Bridge script-src" do
+    ShopifyApp.configuration.embedded_app = true
+
+    get redirect_to_embed_path
+    assert_includes response.headers["Content-Security-Policy"], "script-src"
+    assert_includes response.headers["Content-Security-Policy"], "https://cdn.shopify.com/shopifycloud/app-bridge.js"
+  end
+
+  test "content security policy preserves existing script-src directives when adding App Bridge" do
+    ShopifyApp.configuration.embedded_app = true
+
+    get redirect_to_embed_path
+    csp_header = response.headers["Content-Security-Policy"]
+
+    # Should include both self (default) and App Bridge URL
+    assert_includes csp_header, "script-src"
+    assert_includes csp_header, "'self'"
+    assert_includes csp_header, "https://cdn.shopify.com/shopifycloud/app-bridge.js"
+  end
 end


### PR DESCRIPTION
### What this PR does

This gem requires an asset that is hosted on cdn.shopify.com:
`https://cdn.shopify.com/shopifycloud/app-bridge.js`

For applications that enforce a strict ContentSecurityPolicy, the asset is unlikely to be listed as a permitted [script-src ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src).

This PR modifies the `FrameAncestors` concern to allow loading of the the App Bridge script. This concern is included in the `EmbeddedApp` concern. 
Any time the app attempts to load in an embedded context it will allow the loading of App Bridge

### Reviewer's guide to testing
To test:

1. Update a dev app to use strict CSP policy
e.g.
```
Rails.application.configure do
  config.content_security_policy do |policy|
    policy.default_src :self, :https
    policy.font_src    :self, :https, :data
    policy.img_src     :self, :https, :data
    policy.object_src  :none
    # For development: allow unsafe-inline for Vite's inline script and styles
    # In production, this should be removed or use SHA-256 hash
    if Rails.env.development?
      policy.script_src  :self, :unsafe_inline
      policy.style_src   :self, :https, :unsafe_inline
    else
      policy.script_src  :self
      policy.style_src   :self, :https
    end
    # Specify URI for violation reports
    # policy.report_uri "/csp-violation-report-endpoint"
  end
```
1. Using the current gem, attempt to install  the embedded app. 
1. See console error that app bridge script cannot be loaded
1. Use local version of this branch instead of published gem
1. See app is able to install correctly

### Things to focus on

1. Are there any scenarios where we would need to load App Bridge but it is not in an embedded context?


### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
