### PR TITLE
Use ENV.fetch to get HOST instead of relying on useless Sorbet error

### DIFF
--- a/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
+++ b/lib/generators/shopify_app/install/templates/shopify_app.rb.tt
@@ -47,7 +47,7 @@ Rails.application.config.after_initialize do
       api_key: ShopifyApp.configuration.api_key,
       api_secret_key: ShopifyApp.configuration.secret,
       api_version: ShopifyApp.configuration.api_version,
-      host: ENV['HOST'],
+      host: ENV.fetch('HOST'),
       scope: ShopifyApp.configuration.scope,
       is_private: !ENV.fetch('SHOPIFY_APP_PRIVATE_SHOP', '').empty?,
       is_embedded: ShopifyApp.configuration.embedded_app,

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -33,7 +33,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
               api_key: ShopifyApp.configuration.api_key,
               api_secret_key: ShopifyApp.configuration.secret,
               api_version: ShopifyApp.configuration.api_version,
-              host: ENV['HOST'],
+              host: ENV.fetch('HOST'),
               scope: ShopifyApp.configuration.scope,
               is_private: !ENV.fetch('SHOPIFY_APP_PRIVATE_SHOP', '').empty?,
               is_embedded: ShopifyApp.configuration.embedded_app,


### PR DESCRIPTION
### What this PR does

The auto-generated initializer has various starting time checks to prevent app misconfiguration before running. This did not apply to ShopifyAPI::Context's host: keyword. If the HOST env var was not present, a unhelpful "TypeError (Passed `nil` into T.must)" error was raised by Sorbet. Now if there is no HOST env var present, the app will fail to run, like it does with other checks, and the user will receive a helpful message.

As mentioned in #1710 and #1526 

Sorbet 🤮

### Reviewer's guide to testing

### Things to focus on

In generated project: `config/inititalizers/shopify_app.rb`

### Checklist

Before submitting the PR, please consider if any of the following are needed:

> - [ ] Update `CHANGELOG.md` if the changes would impact users 

This should be done by the maintainer at release time, not by contributors. 
