### PR TITLE
Allow custom handler to be passed when registering a webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 - Handle invalid token when adding redirection headers [#1945](https://github.com/Shopify/shopify_app/pull/1945)
 - Handle invalid record error for concurrent token exchange calls [#1966](https://github.com/Shopify/shopify_app/pull/1966)
 - Add App Bridge CDN URL to CSP script-src directive for embedded apps to ensure compatibility with strict CSP configurations
+- Closed bug in webhook registration which unnecessarily required Job class when using a custom WebhooksController. [2014](https://github.com/Shopify/shopify_app/pull/2014)
 
 22.5.2 (March 14, 2025)
 ----------

--- a/lib/shopify_app/managers/webhooks_manager.rb
+++ b/lib/shopify_app/managers/webhooks_manager.rb
@@ -45,12 +45,13 @@ module ShopifyApp
         ShopifyApp.configuration.webhooks.each do |attributes|
           webhook_path = path(attributes)
           delivery_method = attributes[:delivery_method] || :http
+          handler = attributes[:handler] || delivery_method == :http ? webhook_job_klass(webhook_path) : nil
 
           ShopifyAPI::Webhooks::Registry.add_registration(
             topic: attributes[:topic],
             delivery_method: delivery_method,
             path: webhook_path,
-            handler: delivery_method == :http ? webhook_job_klass(webhook_path) : nil,
+            handler:,
             fields: attributes[:fields],
             filter: attributes[:filter],
             metafield_namespaces: attributes[:metafield_namespaces],

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -84,6 +84,32 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
     ShopifyApp::WebhooksManager.add_registrations
   end
 
+  test "#add_registrations permits nil handler" do
+    expected_hash = {
+      topic: "orders/updated",
+      delivery_method: :http,
+      path: "/webhooks/orders_updated",
+      handler: nil,
+      fields: nil,
+      metafield_namespaces: nil,
+      filter: "id:*",
+    }
+
+    ShopifyAPI::Webhooks::Registry.expects(:add_registration).with(**expected_hash).once
+    ShopifyApp.configure do |config|
+      config.webhooks = [
+        {
+          topic: "orders/updated",
+          address: "https://some.domain.over.the.rainbow.com/webhooks/orders_updated",
+          handler: nil
+          filter: "id:*",
+        },
+      ]
+    end
+
+    ShopifyApp::WebhooksManager.add_registrations
+  end
+
   test "#add_registrations raises an error when missing path and address" do
     ShopifyApp.configure do |config|
       config.webhooks = [


### PR DESCRIPTION
### What this PR does

When an app uses a custom WebhooksController instead of using the Gem provided WebhooksController, the app assumes responsibility for receiving and processing web hook requests, and thus does not need to register ActiveJob `handlers` which match the name of the webhook's topic as required by WebhooksController.

There is a bug in `WebhookManager` which requires the app to [maintain an ActiveJob class matching the name of the topic](https://github.com/Shopify/shopify_app/blob/main/lib/shopify_app/managers/webhooks_manager.rb#L79) even if the app uses a custom WebhooksController.

In this Pull Request, I add an additional `WebhookManager` webhooks configuration property called `handler` which is the name of the ActiveJob class to enqueue if using the default WebhooksController or `nil` to unset the `handler`. The latter feature - the ability to set `handler: nil` will fix the bug.

### Reviewer's guide to testing

Because this introduces a new configuration property but maintains backward compatibility with current configuration (_not_ setting the `handler` property behaves exactly the same), I rely on unit tests to assert the change.

### Things to focus on

1. <!-- Focus on a particular file -->
2. <!-- Is the test case correct? -->
3. <!-- Etc. -->

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
