### PR TITLE
Deprecate ShopifyApp.add_csp_directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - [Patch] Fix sorbet errors in generated webhook handlers
+- Deprecate `ShopifyApp.add_csp_directives(policy)` - will be removed in v24.0.0
 
 23.0.1 (December 22, 2025)
 - Fix engine initialization [#2040](https://github.com/Shopify/shopify_app/pull/2040)

--- a/docs/shopify_app/content-security-policy.md
+++ b/docs/shopify_app/content-security-policy.md
@@ -11,6 +11,8 @@ For actions that include the `ShopifyApp::FrameAncestors` controller concern, th
 
 ## Strict Content Security Policy
 
+> **Deprecated:** The `ShopifyApp.add_csp_directives` helper is deprecated and will be removed in v24.0.0.
+
 If you enable a strict Content Security Policy in your application, you'll need to explicitly allow Shopify's App Bridge script. The gem provides a helper method to make this easy.
 
 ### Without Strict CSP (Default)

--- a/lib/shopify_app.rb
+++ b/lib/shopify_app.rb
@@ -27,6 +27,11 @@ module ShopifyApp
   end
 
   def self.add_csp_directives(policy)
+    ShopifyApp::Logger.deprecated(
+      "ShopifyApp.add_csp_directives is deprecated and will be removed in v24.0.0.",
+      "24.0.0",
+    )
+
     # Get current script-src directives
     current_script_src = policy.directives["script-src"] || []
 

--- a/test/shopify_app/csp_helper_test.rb
+++ b/test/shopify_app/csp_helper_test.rb
@@ -7,6 +7,15 @@ class CspHelperTest < ActiveSupport::TestCase
     @policy = ActionDispatch::ContentSecurityPolicy.new
   end
 
+  test "emits a deprecation warning" do
+    ShopifyApp::Logger.expects(:deprecated).with(
+      "ShopifyApp.add_csp_directives is deprecated and will be removed in v24.0.0.",
+      "24.0.0",
+    )
+
+    ShopifyApp.add_csp_directives(@policy)
+  end
+
   test "adds App Bridge script source to empty policy" do
     ShopifyApp.add_csp_directives(@policy)
 


### PR DESCRIPTION
## Summary
- Deprecates `ShopifyApp.add_csp_directives(policy)`, targeting removal in v24.0.0
- The method continues to function but now emits a deprecation warning via `ShopifyApp::Logger.deprecated`
- Updates documentation and changelog to reflect the deprecation

## Test plan
- [x] New test verifies deprecation warning is emitted with correct message and version
- [x] All 5 existing CSP helper tests continue to pass (method still works)
- [x] Full test suite passes (527 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)