### PR TITLE
fix: replace CGI.parse with Rack::Utils.parse_query for Ruby 4.0 compatibility

### DIFF
--- a/lib/shopify_app/controller_concerns/login_protection.rb
+++ b/lib/shopify_app/controller_concerns/login_protection.rb
@@ -225,9 +225,8 @@ module ShopifyApp
 
     def return_address_with_params(params)
       uri = URI(base_return_address)
-      uri.query = CGI.parse(uri.query.to_s)
+      uri.query = Rack::Utils.parse_query(uri.query.to_s)
         .symbolize_keys
-        .transform_values { |v| v.one? ? v.first : v }
         .merge(params)
         .to_query
       uri.to_s


### PR DESCRIPTION
## Summary

Fixes #2057

`CGI.parse` was removed from Ruby's standard library in Ruby 4.0, causing a `NoMethodError` in `LoginProtection#return_address_with_params` on every OAuth callback. This breaks authentication entirely on Ruby 4.0 — the callback 500s before the session can be stored.

## Change

Replace `CGI.parse` with `Rack::Utils.parse_query`, which is already available as a transitive dependency of Rails (no new dependency introduced).

```ruby
# Before
uri.query = CGI.parse(uri.query.to_s)
  .symbolize_keys
  .transform_values { |v| v.one? ? v.first : v }
  .merge(params)
  .to_query

# After
uri.query = Rack::Utils.parse_query(uri.query.to_s)
  .symbolize_keys
  .merge(params)
  .to_query
```

`Rack::Utils.parse_query` returns a plain hash with string values directly, so the `.transform_values` unwrapping step (which existed to flatten `CGI.parse`'s array-of-strings format) is no longer needed — the result is also slightly simpler.

## Behaviour difference

For Shopify URL params, none. The only theoretical difference is duplicate keys: `CGI.parse` would collect them into an array, while `Rack::Utils.parse_query` keeps the last value. Shopify-generated query strings never have duplicate parameter names.

## Testing

Existing test coverage for `return_address_with_params` should confirm correctness. Manually verified on Ruby 4.0.1 + Rails 8.1.