### PR TITLE
Validate host param in generated HomeController template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- [Patch] Validate host param in generated HomeController template to prevent open redirect
 - [Patch] Fix sorbet errors in generated webhook handlers
 
 23.0.1 (December 22, 2025)

--- a/lib/generators/shopify_app/home_controller/templates/unauthenticated_home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/unauthenticated_home_controller.rb
@@ -7,7 +7,9 @@ class HomeController < ApplicationController
 
   def index
     if ShopifyAPI::Context.embedded? && (!params[:embedded].present? || params[:embedded] != "1")
-      redirect_to(ShopifyAPI::Auth.embedded_app_url(params[:host]) + request.path, allow_other_host: true)
+      redirect_url = ShopifyAPI::Auth.embedded_app_url(params[:host]) + request.path
+      redirect_url = ShopifyApp.configuration.root_url if deduced_phishing_attack?(redirect_url)
+      redirect_to(redirect_url, allow_other_host: true)
     else
       @shop_origin = current_shopify_domain
       @host = params[:host]

--- a/test/generators/home_controller_generator_test.rb
+++ b/test/generators/home_controller_generator_test.rb
@@ -29,6 +29,7 @@ class HomeControllerGeneratorTest < Rails::Generators::TestCase
       assert_match "include ShopifyApp::ShopAccessScopesVerification", file
       assert_match "include ShopifyApp::EmbeddedApp", file
       assert_match "include ShopifyApp::EnsureInstalled", file
+      assert_match "deduced_phishing_attack?", file
     end
     assert_file "app/views/home/index.html.erb"
   end


### PR DESCRIPTION
## Summary
- Align generated home controller template with the existing validation in `redirect_to_embed_app_in_admin`

## Test plan
- [x] Existing tests pass
- [x] Generator test updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)