### PR TITLE
Add license information to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - [Patch] Validate host param in generated HomeController template to prevent open redirect
 - [Patch] Fix sorbet errors in generated webhook handlers
+- [Patch] Include license information in the gemspec
 
 23.0.1 (December 22, 2025)
 - Fix engine initialization [#2040](https://github.com/Shopify/shopify_app/pull/2040)

--- a/shopify_app.gemspec
+++ b/shopify_app.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.author      = "Shopify"
   s.summary     = "This gem is used to get quickly started with the Shopify API"
+  s.license     = "MIT"
 
   s.required_ruby_version = ">= 3.2"
 


### PR DESCRIPTION
### What this PR does

This PR adds license metadata to the gemspec so the license metadata will populate properly in RubyGems and work with dependency auditing tools. I assume MIT is correct based on https://github.com/Shopify/shopify_app/blob/main/LICENSE.

### Reviewer's guide to testing

There are no functional changes in this PR.

### Things to focus on

Confirm that I entered the correct license.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [x] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
