### PR TITLE
Simplify embedded check in HomeController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - [Patch] Validate host param in generated HomeController template to prevent open redirect
 - [Patch] Fix sorbet errors in generated webhook handlers
+- Remove unnecessary nil check in generated HomeController template
 
 23.0.1 (December 22, 2025)
 - Fix engine initialization [#2040](https://github.com/Shopify/shopify_app/pull/2040)

--- a/lib/generators/shopify_app/home_controller/templates/unauthenticated_home_controller.rb
+++ b/lib/generators/shopify_app/home_controller/templates/unauthenticated_home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   include ShopifyApp::ShopAccessScopesVerification
 
   def index
-    if ShopifyAPI::Context.embedded? && (!params[:embedded].present? || params[:embedded] != "1")
+    if ShopifyAPI::Context.embedded? && params[:embedded] != "1"
       redirect_url = ShopifyAPI::Auth.embedded_app_url(params[:host]) + request.path
       redirect_url = ShopifyApp.configuration.root_url if deduced_phishing_attack?(redirect_url)
       redirect_to(redirect_url, allow_other_host: true)


### PR DESCRIPTION
Anything that returns false for `.present?` (`nil`, empty strings, or other empty objects) will also return false for `!= "1"`. So there should be no need for the initial check.

### What this PR does

Simplifies the code in the templated HomeController by removing a redundant check.

Since the template code is added to apps built with `shopify_app`, it was being checked by our code quality checks (Reek), and raising a `reek:DuplicateMethodCall` warning for `params[:embedded]`. Our Reek is probably a bit overzealous, so that might not be a concern for you.

But in this case the extra call isn't doing anything and can safely be removed.

### Reviewer's guide to testing

The generated HomeController should work the same way it did before. No changes to functionality.

### Things to focus on

I'm not sure there's much to say.
The main things I'd want to confirm are:

1. Is this worth changing, or is it too minor for you to care about?
2. Confirm the tests still pass (though I expect they should).

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users.
        While this isn't a functionality change, it is user-visible due to affecting code generated in users' apps.
- [x] ~~Update `README.md`, if appropriate.~~ I don't believe this is necessary for such a minor change.
- [x] ~~Update any relevant pages in `/docs`, if necessary.~~ Ditto
- [x] ~~For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.~~ This is not a security fix.
