### PR TITLE
Fix declarative webhook generator route path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- [Patch] Fix declarative webhook generator routes to match the configured webhook path
 - [Patch] Validate host param in generated HomeController template to prevent open redirect
 - [Patch] Fix sorbet errors in generated webhook handlers
 

--- a/lib/generators/shopify_app/add_declarative_webhook/add_declarative_webhook_generator.rb
+++ b/lib/generators/shopify_app/add_declarative_webhook/add_declarative_webhook_generator.rb
@@ -31,14 +31,27 @@ module ShopifyApp
       end
 
       def add_webhook_route
-        route = "\t\t\tpost '#{file_name}', to: '#{file_name}#receive'\n"
-        inject_into_file("config/routes.rb", route, after: /namespace :webhooks do\n/)
+        webhook_route = "post \"#{route_path}\", to: \"webhooks/#{file_name}#receive\""
+        routes = File.read("config/routes.rb")
+        return if routes.include?(webhook_route)
+
+        mount_engine_route = /^\s*mount\s+ShopifyApp::Engine,\s+at:\s+["']\/["'].*\n/
+
+        if routes.match?(mount_engine_route)
+          inject_into_file("config/routes.rb", "  #{webhook_route}\n", before: mount_engine_route)
+        else
+          route(webhook_route)
+        end
       end
 
       private
 
       def file_name
         path.split("/").last
+      end
+
+      def route_path
+        "/#{path.delete_prefix("/")}"
       end
 
       def topic

--- a/test/generators/add_declarative_webhook_generator_test.rb
+++ b/test/generators/add_declarative_webhook_generator_test.rb
@@ -40,9 +40,9 @@ class AddDeclarativeWebhookGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "config/routes.rb" do |routes|
-      assert_match "namespace :webhooks do", routes
       assert_match exisiting_webhook, routes
       assert_match new_webhook, routes
+      assert_operator routes.index(new_webhook), :<, routes.index("mount ShopifyApp::Engine")
     end
   end
 
@@ -51,6 +51,6 @@ class AddDeclarativeWebhookGeneratorTest < Rails::Generators::TestCase
   end
 
   def new_webhook
-    "post 'product_update', to: 'product_update#receive'"
+    'post "/webhooks/product_update", to: "webhooks/product_update#receive"'
   end
 end


### PR DESCRIPTION
### What this PR does

Fixes #1977.

This updates the `shopify_app:add_declarative_webhook` generator so the generated Rails route matches the configured webhook `--path`.

Previously, running:

```bash
rails g shopify_app:add_declarative_webhook --topic products/update --path webhooks/product_update
```

could add only the basename route under an existing `namespace :webhooks`, which meant apps using the default `/api` route scope served `/api/webhooks/product_update` instead of `/webhooks/product_update`. Shopify then posted to the configured `/webhooks/product_update` path, which could fall through to `ShopifyApp::WebhooksController` and raise `ShopifyAPI::Errors::NoWebhookHandler`.

The generator now creates an explicit route for the configured path and inserts it before the root-mounted ShopifyApp engine.

### Reviewer's guide to testing

```bash
bundle exec rake test TEST=test/generators/add_declarative_webhook_generator_test.rb
```

### Things to focus on

1. The generated route uses the full configured webhook path.
2. The route is inserted before `mount ShopifyApp::Engine, at: "/"`.
3. The generator test covers the route path and ordering.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [ ] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
