### PR TITLE
Preparing for release 23.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Unreleased
 ----------
-- [Patch] Validate host param in generated HomeController template to prevent open redirect
-- [Patch] Fix sorbet errors in generated webhook handlers
+
+23.0.2 (May 22, 2026)
+----------
+- Validate host param in generated HomeController template to prevent open redirect [#2059](https://github.com/Shopify/shopify_app/pull/2059)
+- Fix sorbet errors in generated webhook handlers [#2047](https://github.com/Shopify/shopify_app/pull/2047)
 
 23.0.1 (December 22, 2025)
 - Fix engine initialization [#2040](https://github.com/Shopify/shopify_app/pull/2040)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (23.0.1)
+    shopify_app (23.0.2)
       addressable (~> 2.7)
       rails (>= 7.1, < 9)
       redirect_safely (~> 1.0)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "23.0.1"
+  VERSION = "23.0.2"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "23.0.1",
+  "version": "23.0.2",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Packaging release **23.0.2** — a patch release containing two bug fixes that have been sitting in `Unreleased` on `main`.

### Changes

- Validate host param in generated HomeController template to prevent open redirect [#2059](https://github.com/Shopify/shopify_app/pull/2059) — addresses [bug bounty report 3551313](https://bugbounty.shopify.io/reports/3551313)
- Fix sorbet errors in generated webhook handlers [#2047](https://github.com/Shopify/shopify_app/pull/2047) — unblocks users hitting `TypeError` when registering webhook handlers due to Sorbet type checking introduced in `shopify_api` 16.0.0

### Files changed

- `lib/shopify_app/version.rb` — bumped to `23.0.2`
- `package.json` — bumped to `23.0.2`
- `Gemfile.lock` — bumped to `23.0.2`
- `CHANGELOG.md` — promoted `Unreleased` entries to `23.0.2 (May 22, 2026)` with PR links

## Test plan

- [ ] CI passes
- [ ] After merge: tag `v23.0.2`, ship via Shipit, verify on https://rubygems.org/gems/shopify_app

🤖 Generated with [Claude Code](https://claude.com/claude-code)