### PR TITLE
Packaging for release 23.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Unreleased
 ----------
-- Token-exchange requests whose `shop` query parameter does not match the authenticated shop are now rejected with 401. `current_shopify_domain` no longer reflects the `shop` parameter; use `requested_shopify_domain` when you need the requested/bootstrap shop value.
-- Harden embedded app host validation to prevent parser-differential open redirects
+
+23.0.3 (June 24, 2026)
+----------
+- Token-exchange requests whose `shop` query parameter does not match the authenticated shop are now rejected with 401. `current_shopify_domain` no longer reflects the `shop` parameter; use `requested_shopify_domain` when you need the requested/bootstrap shop value. [#2081](https://github.com/Shopify/shopify_app/pull/2081)
+- Harden embedded app host validation to prevent parser-differential open redirects. [#2078](https://github.com/Shopify/shopify_app/pull/2078)
 
 23.0.2 (May 22, 2026)
 ----------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_app (23.0.2)
+    shopify_app (23.0.3)
       addressable (~> 2.7)
       rails (>= 7.1, < 9)
       redirect_safely (~> 1.0)

--- a/lib/shopify_app/version.rb
+++ b/lib/shopify_app/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShopifyApp
-  VERSION = "23.0.2"
+  VERSION = "23.0.3"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify_app",
-  "version": "23.0.2",
+  "version": "23.0.3",
   "repository": "git@github.com:Shopify/shopify_app.git",
   "author": "Shopify",
   "license": "MIT",


### PR DESCRIPTION
## Release notes

- Token-exchange requests whose `shop` query parameter does not match the authenticated shop are now rejected with 401. `current_shopify_domain` no longer reflects the `shop` parameter; use `requested_shopify_domain` when you need the requested/bootstrap shop value. [#2081](https://github.com/Shopify/shopify_app/pull/2081)
- Harden embedded app host validation to prevent parser-differential open redirects. [#2078](https://github.com/Shopify/shopify_app/pull/2078)

## Validation

- `bundle install`
- `bundle exec ruby -Itest test/controllers/sessions_controller_test.rb test/shopify_app/controller_concerns/token_exchange_test.rb`