### PR TITLE
Fix webhook handler dispatch with shopify_api v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Fix webhook delivery with `shopify_api >= 16.0.0`: generated webhook jobs now implement the v16 `handle(data:)` contract, allowing the library to dispatch webhooks to the registered job. [#2045](https://github.com/Shopify/shopify_app/issues/2045)
 
 23.0.3 (June 24, 2026)
 ----------

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -232,14 +232,12 @@ Add a new `handle` method to existing webhook jobs to go through the updated `sh
 
 ```ruby
 class MyWebhookJob < ActiveJob::Base
-  extend ShopifyAPI::Webhooks::Handler
+  extend ShopifyAPI::Webhooks::WebhookHandler
 
-  class << self
-    # new handle function
-    def handle(topic:, shop:, body:)
-      # delegate to pre-existing perform_later function
-      perform_later(topic: topic, shop_domain: shop, webhook: body)
-    end
+  # new handle function
+  def self.handle(data:)
+    # delegate to pre-existing perform_later function
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   # original perform function

--- a/lib/generators/shopify_app/add_app_uninstalled_job/templates/app_uninstalled_job.rb.tt
+++ b/lib/generators/shopify_app/add_app_uninstalled_job/templates/app_uninstalled_job.rb.tt
@@ -1,8 +1,8 @@
 class AppUninstalledJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::WebhookHandler
 
-  def self.handle(topic:, shop:, body:, webhook_id:, api_version:)
-    perform_later(topic: topic, shop_domain: shop, webhook: body)
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform(topic:, shop_domain:, webhook:)

--- a/lib/generators/shopify_app/add_privacy_jobs/templates/customers_data_request_job.rb.tt
+++ b/lib/generators/shopify_app/add_privacy_jobs/templates/customers_data_request_job.rb.tt
@@ -1,8 +1,8 @@
 class CustomersDataRequestJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::WebhookHandler
 
-  def self.handle(topic:, shop:, body:, webhook_id:, api_version:)
-    perform_later(topic: topic, shop_domain: shop, webhook: body)
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform(topic:, shop_domain:, webhook:)

--- a/lib/generators/shopify_app/add_privacy_jobs/templates/customers_redact_job.rb.tt
+++ b/lib/generators/shopify_app/add_privacy_jobs/templates/customers_redact_job.rb.tt
@@ -1,8 +1,8 @@
 class CustomersRedactJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::WebhookHandler
 
-  def self.handle(topic:, shop:, body:, webhook_id:, api_version:)
-    perform_later(topic: topic, shop_domain: shop, webhook: body)
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform(topic:, shop_domain:, webhook:)

--- a/lib/generators/shopify_app/add_privacy_jobs/templates/shop_redact_job.rb.tt
+++ b/lib/generators/shopify_app/add_privacy_jobs/templates/shop_redact_job.rb.tt
@@ -1,8 +1,8 @@
 class ShopRedactJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::WebhookHandler
 
-  def self.handle(topic:, shop:, body:, webhook_id:, api_version:)
-    perform_later(topic: topic, shop_domain: shop, webhook: body)
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform(topic:, shop_domain:, webhook:)

--- a/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb.tt
+++ b/lib/generators/shopify_app/add_webhook/templates/webhook_job.rb.tt
@@ -1,8 +1,8 @@
 class <%= @job_class_name %> < ActiveJob::Base
   extend ShopifyAPI::Webhooks::WebhookHandler
 
-  def self.handle(topic:, shop:, body:, webhook_id:, api_version:)
-    perform_later(topic: topic, shop_domain: shop, webhook: body)
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform(topic:, shop_domain:, webhook:)

--- a/test/controllers/callback_controller_test.rb
+++ b/test/controllers/callback_controller_test.rb
@@ -16,12 +16,10 @@ module Shopify
 end
 
 class CartsUpdateJob < ActiveJob::Base
-  include ShopifyAPI::Webhooks::WebhookHandler
+  extend ShopifyAPI::Webhooks::WebhookHandler
 
-  class << self
-    def handle(topic:, shop:, body:, webhook_id:, api_version:)
-      perform_later(topic: topic, shop_domain: shop, webhook: body)
-    end
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform; end

--- a/test/generators/add_app_uninstalled_job_generator_test.rb
+++ b/test/generators/add_app_uninstalled_job_generator_test.rb
@@ -21,6 +21,10 @@ class AddAppUninstalledJobGeneratorTest < Rails::Generators::TestCase
   test "creates app uninstalled job file" do
     run_generator
 
-    assert_file "app/jobs/app_uninstalled_job.rb"
+    assert_file "app/jobs/app_uninstalled_job.rb" do |job|
+      assert_match "extend ShopifyAPI::Webhooks::WebhookHandler", job
+      assert_match "def self.handle(data:)", job
+      assert_match "perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)", job
+    end
   end
 end

--- a/test/generators/add_privacy_jobs_generator_job_test.rb
+++ b/test/generators/add_privacy_jobs_generator_job_test.rb
@@ -18,11 +18,15 @@ class AddPrivacyJobsGeneratorJobTest < Rails::Generators::TestCase
     provide_existing_application_controller
   end
 
-  test "creates app uninstalled job file" do
+  test "creates privacy job files" do
     run_generator
 
-    assert_file "app/jobs/customers_data_request_job.rb"
-    assert_file "app/jobs/shop_redact_job.rb"
-    assert_file "app/jobs/customers_redact_job.rb"
+    ["customers_data_request_job", "shop_redact_job", "customers_redact_job"].each do |job_name|
+      assert_file "app/jobs/#{job_name}.rb" do |job|
+        assert_match "extend ShopifyAPI::Webhooks::WebhookHandler", job
+        assert_match "def self.handle(data:)", job
+        assert_match "perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)", job
+      end
+    end
   end
 end

--- a/test/generators/add_webhook_generator_test.rb
+++ b/test/generators/add_webhook_generator_test.rb
@@ -43,6 +43,9 @@ class AddWebhookGeneratorTest < Rails::Generators::TestCase
     assert_directory "app/jobs"
     assert_file "app/jobs/product_update_job.rb" do |job|
       assert_match "class ProductUpdateJob < ActiveJob::Base", job
+      assert_match "extend ShopifyAPI::Webhooks::WebhookHandler", job
+      assert_match "def self.handle(data:)", job
+      assert_match "perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)", job
     end
   end
 

--- a/test/integration/webhooks_controller_test.rb
+++ b/test/integration/webhooks_controller_test.rb
@@ -3,12 +3,10 @@
 require_relative "../test_helper"
 
 class OrderUpdateJob < ActiveJob::Base
-  include ShopifyAPI::Webhooks::WebhookHandler
+  extend ShopifyAPI::Webhooks::WebhookHandler
 
-  class << self
-    def handle(topic:, shop:, body:, webhook_id:, api_version:)
-      perform_later(topic: topic, shop_domain: shop, webhook: body)
-    end
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform; end

--- a/test/shopify_app/auth/post_authenticate_tasks_test.rb
+++ b/test/shopify_app/auth/post_authenticate_tasks_test.rb
@@ -9,12 +9,10 @@ module Shopify
 end
 
 class CartsUpdateJob < ActiveJob::Base
-  include ShopifyAPI::Webhooks::WebhookHandler
+  extend ShopifyAPI::Webhooks::WebhookHandler
 
-  class << self
-    def handle(topic:, shop:, body:, webhook_id:, api_version:)
-      perform_later(topic: topic, shop_domain: shop, webhook: body)
-    end
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform; end

--- a/test/shopify_app/managers/webhooks_manager_test.rb
+++ b/test/shopify_app/managers/webhooks_manager_test.rb
@@ -3,18 +3,18 @@
 require_relative "../../test_helper"
 
 class OrdersUpdatedJob < ActiveJob::Base
-  include ShopifyAPI::Webhooks::WebhookHandler
+  extend ShopifyAPI::Webhooks::WebhookHandler
 
-  class << self
-    def handle(topic:, shop:, body:, webhook_id:, api_version:)
-      perform_later(topic: topic, shop_domain: shop, webhook: body)
-    end
+  def self.handle(data:)
+    perform_later(topic: data.topic, shop_domain: data.shop, webhook: data.body)
   end
 
   def perform; end
 end
 
 class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test "#add_registrations makes calls to library's add_registration" do
     expected_hash = {
       topic: "orders/updated",
@@ -136,5 +136,42 @@ class ShopifyApp::WebhooksManagerTest < ActiveSupport::TestCase
       config.webhooks = []
     end
     ShopifyApp::WebhooksManager.destroy_webhooks(session: ShopifyAPI::Auth::Session.new(shop: "shop.myshopify.com"))
+  end
+
+  test "#add_registrations registers a job that the shopify_api library can dispatch to" do
+    ShopifyAPI::Webhooks::Registry.clear
+
+    ShopifyApp.configure do |config|
+      config.webhooks = [
+        { topic: "orders/updated", path: "webhooks/orders_updated" },
+      ]
+    end
+
+    ShopifyApp::WebhooksManager.add_registrations
+
+    body = { "foo" => "bar" }.to_json
+
+    assert_enqueued_with(
+      job: OrdersUpdatedJob,
+      args: [{ topic: "orders/updated", shop_domain: "test.myshopify.com", webhook: { "foo" => "bar" } }],
+    ) do
+      ShopifyAPI::Webhooks::Registry.process(webhook_request(body))
+    end
+  end
+
+  private
+
+  def webhook_request(body)
+    hmac = OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), ShopifyApp.configuration.secret, body)
+    ShopifyAPI::Webhooks::Request.new(
+      raw_body: body,
+      headers: {
+        "x-shopify-topic" => "orders/updated",
+        "x-shopify-hmac-sha256" => Base64.encode64(hmac),
+        "x-shopify-shop-domain" => "test.myshopify.com",
+        "x-shopify-api-version" => TEST_API_VERSION,
+        "x-shopify-webhook-id" => "12345",
+      },
+    )
   end
 end


### PR DESCRIPTION
### What this PR does

Update generated webhook jobs to implement the shopify_api v16
`WebhookHandler` dispatch contract:

```ruby
def self.handle(data:)
  perform_later(
    topic: data.topic,
    shop_domain: data.shop,
    webhook: data.body,
  )
end
```

Generated jobs previously used the pre-v16
`handle(topic:, shop:, body:, webhook_id:, api_version:)` signature.
shopify_api v16 dispatches `WebhookMetadata` through `handle(data:)`, so
registered webhook handlers raised `ArgumentError` during delivery.

This also conforms the webhook fixtures used across the test suite and adds
regression coverage through the real `Registry` dispatch path.

Fixes #2045

### Reviewer's guide to testing

1. Run `bundle exec rake test`.
2. The regression test in `test/shopify_app/managers/webhooks_manager_test.rb`
   registers a job through `WebhooksManager.add_registrations`, then dispatches a
   real HMAC-signed webhook via `ShopifyAPI::Webhooks::Registry.process`, asserting
   the job is enqueued with the mapped `topic` / `shop_domain` / `webhook` arguments.
3. Generator tests for `add_webhook`, `add_app_uninstalled_job`, and `add_privacy_jobs`
   now assert that generated jobs implement the v16 `handle(data:)` contract.

### Things to focus on

1. The generated `handle(data:)` contract and the `data.topic` / `data.shop` / `data.body` mapping.
2. The regression test exercises the real `Registry` dispatch path rather than the mocked registration.
3. `CHANGELOG.md` and `docs/Upgrading.md` examples updated to the v16 contract.

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [x] Update `CHANGELOG.md` if the changes would impact users
- [ ] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.
