### PR TITLE
Document HOST env var as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This gem requires that you have the following credentials:
 - **Shopify API key:** The API key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations).
 - **Shopify API secret:** The API secret key app credential specified in your [Shopify Partners dashboard](https://partners.shopify.com/organizations).
 
+You'll also need to configure the following environment variables for your app to work:
+
+- **`HOST`:** The public URL of your app, including the scheme, e.g. `http://localhost:3000` or `https://my-app.example.com`. This is passed to `ShopifyAPI::Context.setup` and used to build OAuth redirect URLs, so a missing or malformed value (e.g. a bare hostname without `http://`/`https://`) causes authentication failures like `redirect_uri is not whitelisted`.
+
 ## Usage
 
 > [!NOTE]

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -2,6 +2,11 @@
 
 This guide assumes you have completed the steps to create a new Rails app using the Shopify App gem found in the [*Usage*](/README.md#usage) section of the project's [*README*](/README.md).
 
+> **Note:** The generated app reads configuration from environment variables. Make sure the following are set (e.g. in a `.env` file) before running your app:
+>
+> - `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET` — your app's credentials from the [Shopify Partners dashboard](https://partners.shopify.com/organizations).
+> - `HOST` — the public URL of your app *including the scheme*, e.g. `http://localhost:3000` for local development or `https://some-random-words.trycloudflare.com` when using a tunnel. A missing `HOST`, or a value without `http://`/`https://`, will break OAuth redirects.
+
 #### Table of contents
 
 [Optionally Setup SSH tunnel for development](#setup-ssh-tunnel-for-development)


### PR DESCRIPTION
### What this PR does

The gem reads the app's public URL from the `HOST` environment variable and passes it to `ShopifyAPI::Context.setup` in the generated initializer (`lib/generators/shopify_app/install/templates/shopify_app.rb.tt`). That value is used to build OAuth redirect URLs, so when `HOST` is missing or set without a scheme, apps fail with confusing errors such as `redirect_uri is not whitelisted` or `TypeError: Passed nil into T.must`. The requirement was not documented in the README's `# Requirements` section or in `docs/Quickstart.md`.

This PR adds `HOST` to the README `# Requirements` section and adds a "Required environment variables" note to `docs/Quickstart.md`, including the requirement that the value include the scheme (`http://` or `https://`).

### Reviewer's guide to testing

Docs-only change — nothing to run.

1. Open `README.md` and confirm the `# Requirements` section lists `HOST` after the API key/secret credentials.
2. Open `docs/Quickstart.md` and confirm the note block near the top lists `SHOPIFY_API_KEY`, `SHOPIFY_API_SECRET`, and `HOST`.

### Things to focus on

1. The `# Requirements` heading is linked from the generated initializer's error messages in `lib/generators/shopify_app/install/templates/shopify_app.rb.tt`, so the heading text was left unchanged.
2. Is the scheme-requirement caveat (`http(s)://`) worded clearly enough?

### Checklist

Before submitting the PR, please consider if any of the following are needed:

- [ ] Update `CHANGELOG.md` if the changes would impact users
- [x] Update `README.md`, if appropriate.
- [x] Update any relevant pages in `/docs`, if necessary
- [ ] For security fixes, the [Disclosure Policy](https://github.com/Shopify/shopify_app/blob/master/SECURITY.md#disclosure-policy) must be followed.